### PR TITLE
feat: UI/governance polish (tooltips, search, DARs picker, mesh check, gov modal, member-party lookup)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -92,9 +92,7 @@ const App = () => {
   const [onboardingDialogOpen, setOnboardingDialogOpen] = useState(false);
   const [darsDialogOpen, setDarsDialogOpen] = useState(false);
   const [uploadDarsDialogOpen, setUploadDarsDialogOpen] = useState(false);
-  const [_pendingInvitations, setPendingInvitations] = useState<
-    PendingInvitation[]
-  >([]);
+  const [, setPendingInvitations] = useState<PendingInvitation[]>([]);
   const [currentInvitation, setCurrentInvitation] =
     useState<PendingInvitation | null>(null);
   const [loading, setLoading] = useState(true);
@@ -314,7 +312,6 @@ const App = () => {
     };
 
     fetchData();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Lazy-load parties when switching to parties tab (if not loaded on init)
@@ -389,7 +386,6 @@ const App = () => {
     const interval = window.setInterval(fetchInvitations, 2000);
 
     return () => clearInterval(interval);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handleInvitationAction = useCallback(() => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -101,6 +101,7 @@ const App = () => {
     INITIAL_ROUTE.partySlug ?? "",
   );
   const [refreshingParties, setRefreshingParties] = useState(false);
+  const [packagesRefreshNonce, setPackagesRefreshNonce] = useState(0);
   const [operatorParty, setOperatorParty] = useState("");
   const [selectedPartyId, setSelectedPartyId] = useState<string | null>(null);
   const [showSearchBar, setShowSearchBar] = useState(true);
@@ -186,33 +187,37 @@ const App = () => {
       .catch(() => {});
   }, [nodeConfig]);
 
-  const refreshParties = useCallback(async () => {
-    setRefreshingParties(true);
-    // Update hash to reflect the current filter
-    window.history.replaceState(
-      null,
-      "",
-      buildHash(0, partyFilter || null),
-    );
-    try {
-      const params = partyFilter
-        ? `?prefix=${encodeURIComponent(partyFilter)}`
-        : "";
-      const res = await authenticatedFetch(`${API_BASE}/decentralized-parties${params}`);
-      if (res.ok) {
-        const data: DecentralizedPartiesResponse = await res.json();
-        setParties(data.parties);
-      } else {
-        showSnackbar("Failed to refresh parties");
-      }
-    } catch (err) {
-      showSnackbar(
-        err instanceof Error ? err.message : "Failed to refresh parties",
+  const refreshParties = useCallback(
+    async (force = false) => {
+      setRefreshingParties(true);
+      // Update hash to reflect the current filter
+      window.history.replaceState(
+        null,
+        "",
+        buildHash(0, partyFilter || null),
       );
-    } finally {
-      setRefreshingParties(false);
-    }
-  }, [showSnackbar, partyFilter]);
+      try {
+        const qs = new URLSearchParams();
+        if (partyFilter) qs.set("prefix", partyFilter);
+        if (force) qs.set("refresh", "true");
+        const params = qs.toString() ? `?${qs.toString()}` : "";
+        const res = await authenticatedFetch(`${API_BASE}/decentralized-parties${params}`);
+        if (res.ok) {
+          const data: DecentralizedPartiesResponse = await res.json();
+          setParties(data.parties);
+        } else {
+          showSnackbar("Failed to refresh parties");
+        }
+      } catch (err) {
+        showSnackbar(
+          err instanceof Error ? err.message : "Failed to refresh parties",
+        );
+      } finally {
+        setRefreshingParties(false);
+      }
+    },
+    [showSnackbar, partyFilter],
+  );
 
   const savePeers = useCallback(
     async (peers: Peer[]) => {
@@ -487,7 +492,7 @@ const App = () => {
               }}
             />
             <IconButton
-              onClick={refreshParties}
+              onClick={() => refreshParties()}
               disabled={refreshingParties}
               color="primary"
               sx={{
@@ -593,21 +598,27 @@ const App = () => {
             <DarsDialog
               open={darsDialogOpen}
               onClose={() => setDarsDialogOpen(false)}
-              onComplete={refreshParties}
+              onComplete={() => {
+                refreshParties(true);
+                setPackagesRefreshNonce((n) => n + 1);
+              }}
               mode="distribute"
             />
 
             <DarsDialog
               open={uploadDarsDialogOpen}
               onClose={() => setUploadDarsDialogOpen(false)}
-              onComplete={refreshParties}
+              onComplete={() => {
+                refreshParties(true);
+                setPackagesRefreshNonce((n) => n + 1);
+              }}
               mode="upload"
             />
 
             <OnboardingDialog
               open={onboardingDialogOpen}
               onClose={() => setOnboardingDialogOpen(false)}
-              onComplete={refreshParties}
+              onComplete={() => refreshParties(true)}
             />
 
             <InvitationModal
@@ -630,7 +641,7 @@ const App = () => {
                 navigate(0, partyFilter || null);
                 window.scrollTo(0, savedScrollY.current);
               }}
-              onRefresh={refreshParties}
+              onRefresh={() => refreshParties(true)}
               selfParticipantId={nodeConfig?.node.participant_id}
               authStatus={authStatuses.find(
                 (a) => a.dec_party_id === selectedPartyId,
@@ -673,7 +684,7 @@ const App = () => {
                       sx={{ width: 300 }}
                     />
                     <IconButton
-                      onClick={refreshParties}
+                      onClick={() => refreshParties()}
                       disabled={refreshingParties}
                       color="primary"
                       sx={{ mt: "1px" }}
@@ -732,6 +743,7 @@ const App = () => {
           <PackagesPanel
             onUploadDars={() => setUploadDarsDialogOpen(true)}
             onDistributeDars={() => setDarsDialogOpen(true)}
+            refreshNonce={packagesRefreshNonce}
           />
         </Box>
       )}

--- a/frontend/src/clipboard.ts
+++ b/frontend/src/clipboard.ts
@@ -1,0 +1,19 @@
+export const copyToClipboard = async (text: string): Promise<boolean> => {
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    // Fallback for non-HTTPS contexts
+    try {
+      const textArea = document.createElement("textarea");
+      textArea.value = text;
+      document.body.appendChild(textArea);
+      textArea.select();
+      document.execCommand("copy");
+      document.body.removeChild(textArea);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+};

--- a/frontend/src/components/AuthCheckAccordion.tsx
+++ b/frontend/src/components/AuthCheckAccordion.tsx
@@ -9,6 +9,7 @@ import {
   Chip,
   CircularProgress,
   Alert,
+  Tooltip,
 } from "@mui/material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import RefreshIcon from "@mui/icons-material/Refresh";
@@ -105,13 +106,29 @@ export const AuthCheckAccordion = () => {
   const getStatusIcon = (status: PartyAuthStatus["status"]) => {
     switch (status.status) {
       case "authenticated":
-        return <CheckCircleIcon color="success" fontSize="small" />;
+        return (
+          <Tooltip title="Authenticated">
+            <CheckCircleIcon color="success" fontSize="small" />
+          </Tooltip>
+        );
       case "mock":
-        return <ScienceIcon color="warning" fontSize="small" />;
+        return (
+          <Tooltip title="Test mode (mock authentication)">
+            <ScienceIcon color="warning" fontSize="small" />
+          </Tooltip>
+        );
       case "failed":
-        return <ErrorIcon color="error" fontSize="small" />;
+        return (
+          <Tooltip title="Authentication failed">
+            <ErrorIcon color="error" fontSize="small" />
+          </Tooltip>
+        );
       case "notconfigured":
-        return <HelpOutlineIcon color="disabled" fontSize="small" />;
+        return (
+          <Tooltip title="Not configured">
+            <HelpOutlineIcon color="disabled" fontSize="small" />
+          </Tooltip>
+        );
     }
   };
 
@@ -236,9 +253,13 @@ export const AuthCheckAccordion = () => {
                     <Typography variant="subtitle2" sx={{ mb: 1 }}>
                       User Rights
                       {isRightsValid(party.rights) ? (
-                        <CheckCircleIcon color="success" fontSize="small" sx={{ ml: 1, verticalAlign: "middle" }} />
+                        <Tooltip title="All required rights granted">
+                          <CheckCircleIcon color="success" fontSize="small" sx={{ ml: 1, verticalAlign: "middle" }} />
+                        </Tooltip>
                       ) : (
-                        <WarningIcon color="warning" fontSize="small" sx={{ ml: 1, verticalAlign: "middle" }} />
+                        <Tooltip title="Missing required rights">
+                          <WarningIcon color="warning" fontSize="small" sx={{ ml: 1, verticalAlign: "middle" }} />
+                        </Tooltip>
                       )}
                     </Typography>
                     <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>

--- a/frontend/src/components/AuthSection.tsx
+++ b/frontend/src/components/AuthSection.tsx
@@ -6,6 +6,7 @@ import {
   Button,
   CircularProgress,
   Alert,
+  Tooltip,
 } from "@mui/material";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import ErrorIcon from "@mui/icons-material/Error";
@@ -33,7 +34,7 @@ const isRightsValid = (rights: RightsStatus | undefined): boolean => {
   );
 };
 
-export const getAuthStatusIcon = (authStatus: PartyAuthStatus) => {
+const getAuthStatusIcon = (authStatus: PartyAuthStatus) => {
   switch (authStatus.status.status) {
     case "authenticated":
       return <CheckCircleIcon color="success" fontSize="small" />;
@@ -46,7 +47,7 @@ export const getAuthStatusIcon = (authStatus: PartyAuthStatus) => {
   }
 };
 
-export const getAuthStatusChip = (authStatus: PartyAuthStatus) => {
+const getAuthStatusChip = (authStatus: PartyAuthStatus) => {
   switch (authStatus.status.status) {
     case "authenticated":
       return <Chip label="Authenticated" color="success" size="small" />;
@@ -121,9 +122,13 @@ export const AuthSection = ({ partyId, authStatus, onRefresh }: AuthSectionProps
           <Typography variant="subtitle2" sx={{ mb: 1 }}>
             User Rights
             {isRightsValid(authStatus.rights) ? (
-              <CheckCircleIcon color="success" fontSize="small" sx={{ ml: 1, verticalAlign: "middle" }} />
+              <Tooltip title="All required rights granted">
+                <CheckCircleIcon color="success" fontSize="small" sx={{ ml: 1, verticalAlign: "middle" }} />
+              </Tooltip>
             ) : (
-              <WarningIcon color="warning" fontSize="small" sx={{ ml: 1, verticalAlign: "middle" }} />
+              <Tooltip title="Missing required rights">
+                <WarningIcon color="warning" fontSize="small" sx={{ ml: 1, verticalAlign: "middle" }} />
+              </Tooltip>
             )}
           </Typography>
           <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>

--- a/frontend/src/components/AuthSection.tsx
+++ b/frontend/src/components/AuthSection.tsx
@@ -13,7 +13,9 @@ import ErrorIcon from "@mui/icons-material/Error";
 import ScienceIcon from "@mui/icons-material/Science";
 import WarningIcon from "@mui/icons-material/Warning";
 import RefreshIcon from "@mui/icons-material/Refresh";
+import VpnKeyIcon from "@mui/icons-material/VpnKey";
 import { CopyableText } from "./CopyableText";
+import { GrantRightsDialog } from "./GrantRightsDialog";
 import { API_BASE } from "../constants";
 import { authenticatedFetch } from "../api";
 import type { PartyAuthStatus, RightsStatus, AuthTestResponse } from "../types";
@@ -63,10 +65,16 @@ const getAuthStatusChip = (authStatus: PartyAuthStatus) => {
 export const AuthSection = ({ partyId, authStatus, onRefresh }: AuthSectionProps) => {
   const [testing, setTesting] = useState(false);
   const [testError, setTestError] = useState<string | null>(null);
+  const [grantDialogOpen, setGrantDialogOpen] = useState(false);
 
   if (!authStatus) {
     return null;
   }
+
+  const canGrant =
+    authStatus.status.status === "authenticated" &&
+    authStatus.rights !== undefined &&
+    !isRightsValid(authStatus.rights);
 
   const handleTestAuth = async () => {
     try {
@@ -203,7 +211,7 @@ export const AuthSection = ({ partyId, authStatus, onRefresh }: AuthSectionProps
         </Alert>
       )}
 
-      <Box sx={{ mt: 2 }}>
+      <Box sx={{ mt: 2, display: "flex", gap: 1, flexWrap: "wrap" }}>
         <Button
           variant="outlined"
           size="small"
@@ -213,7 +221,25 @@ export const AuthSection = ({ partyId, authStatus, onRefresh }: AuthSectionProps
         >
           {testing ? "Testing..." : "Test Auth"}
         </Button>
+        {canGrant && (
+          <Button
+            variant="contained"
+            color="primary"
+            size="small"
+            startIcon={<VpnKeyIcon />}
+            onClick={() => setGrantDialogOpen(true)}
+          >
+            Grant Rights
+          </Button>
+        )}
       </Box>
+
+      <GrantRightsDialog
+        open={grantDialogOpen}
+        onClose={() => setGrantDialogOpen(false)}
+        onGranted={() => onRefresh?.()}
+        partyId={partyId}
+      />
     </Box>
   );
 };

--- a/frontend/src/components/ContractsDialog.tsx
+++ b/frontend/src/components/ContractsDialog.tsx
@@ -688,6 +688,7 @@ interface ContractEditorProps {
   participantCount: number;
   partyId: string;
   knownPackageIds: string[];
+  lockStructure?: boolean;
 }
 
 const ContractEditor = ({
@@ -698,6 +699,7 @@ const ContractEditor = ({
   participantCount,
   partyId,
   knownPackageIds,
+  lockStructure = false,
 }: ContractEditorProps) => {
   const handleFieldChange = (fieldIndex: number, newField: FieldDefinition) => {
     const newFields = [...contract.fields];
@@ -812,14 +814,16 @@ const ContractEditor = ({
               partyId={partyId}
             />
           ))}
-          <Button
-            startIcon={<AddIcon />}
-            onClick={handleAddField}
-            variant="outlined"
-            size="small"
-          >
-            Add Field
-          </Button>
+          {!lockStructure && (
+            <Button
+              startIcon={<AddIcon />}
+              onClick={handleAddField}
+              variant="outlined"
+              size="small"
+            >
+              Add Field
+            </Button>
+          )}
         </Box>
       </AccordionDetails>
     </Accordion>
@@ -1408,20 +1412,23 @@ export const ContractsDialog = ({
                 <Typography variant="subtitle1">
                   Contract Definitions
                 </Typography>
-                <Button
-                  startIcon={<AddIcon />}
-                  onClick={handleAddContract}
-                  variant="outlined"
-                  size="small"
-                >
-                  Add Contract
-                </Button>
+                {contractType !== "governance-core" && (
+                  <Button
+                    startIcon={<AddIcon />}
+                    onClick={handleAddContract}
+                    variant="outlined"
+                    size="small"
+                  >
+                    Add Contract
+                  </Button>
+                )}
               </Box>
 
               {contracts.length === 0 ? (
                 <Typography variant="body2" color="text.secondary">
-                  No contracts defined. Click "Add Contract" to define contracts
-                  to deploy, or leave empty to skip contract creation.
+                  {contractType === "governance-core"
+                    ? "No contracts to deploy."
+                    : 'No contracts defined. Click "Add Contract" to define contracts to deploy, or leave empty to skip contract creation.'}
                 </Typography>
               ) : (
                 contracts.map((contract, index) => (
@@ -1434,6 +1441,7 @@ export const ContractsDialog = ({
                     participantCount={participantIds.length}
                     partyId={partyId}
                     knownPackageIds={allPackageIds}
+                    lockStructure={contractType === "governance-core"}
                   />
                 ))
               )}

--- a/frontend/src/components/ContractsDialog.tsx
+++ b/frontend/src/components/ContractsDialog.tsx
@@ -1146,11 +1146,11 @@ export const ContractsDialog = ({
         );
         if (!res.ok || cancelled) return;
         const data: {
-          members: Array<{ participant_uid: string; member_party_id: string }>;
+          members: Array<{ participant_uid: string; member_party_id?: string }>;
         } = await res.json();
         const memberIds = data.members
           .map((m) => m.member_party_id)
-          .filter((id) => id.length > 0);
+          .filter((id): id is string => !!id && id.length > 0);
         if (cancelled || memberIds.length === 0) return;
         setContracts((prev) =>
           prev.map((c) => ({

--- a/frontend/src/components/ContractsDialog.tsx
+++ b/frontend/src/components/ContractsDialog.tsx
@@ -1102,7 +1102,7 @@ export const ContractsDialog = ({
       setParticipantParties([]);
       setPackages({});
     }
-  }, [open]);
+  }, [open, defaultOperatorParty]);
 
   // Initialize contracts when type is selected
   useEffect(() => {

--- a/frontend/src/components/ContractsDialog.tsx
+++ b/frontend/src/components/ContractsDialog.tsx
@@ -244,6 +244,7 @@ interface FieldEditorProps {
   onDelete: () => void;
   participantCount?: number;
   partyId?: string;
+  lockStructure?: boolean;
 }
 
 const FieldEditor = ({
@@ -252,6 +253,7 @@ const FieldEditor = ({
   onDelete,
   participantCount = 3,
   partyId,
+  lockStructure = false,
 }: FieldEditorProps) => {
   const defaultThreshold = Math.max(2, Math.ceil((participantCount * 2) / 3));
 
@@ -656,26 +658,37 @@ const FieldEditor = ({
         py: 1,
       }}
     >
-      <FormControl size="small" fullWidth>
-        <Select
-          value={field.type}
-          onChange={(e) =>
-            onChange(createDefaultField(e.target.value, participantCount))
-          }
+      {lockStructure ? (
+        <Typography
+          variant="body2"
+          sx={{ fontWeight: 500, pl: 1.5, py: 1 }}
         >
-          {FIELD_TYPES.map((t) => (
-            <MenuItem key={t.value} value={t.value}>
-              {t.label}
-            </MenuItem>
-          ))}
-        </Select>
-      </FormControl>
+          {FIELD_TYPES.find((t) => t.value === field.type)?.label ?? field.type}
+        </Typography>
+      ) : (
+        <FormControl size="small" fullWidth>
+          <Select
+            value={field.type}
+            onChange={(e) =>
+              onChange(createDefaultField(e.target.value, participantCount))
+            }
+          >
+            {FIELD_TYPES.map((t) => (
+              <MenuItem key={t.value} value={t.value}>
+                {t.label}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      )}
       <Box sx={{ display: "flex", alignItems: "center", minWidth: 0 }}>
         {renderValueInput()}
       </Box>
-      <IconButton size="small" onClick={onDelete} color="error">
-        <DeleteIcon fontSize="small" />
-      </IconButton>
+      {!lockStructure && (
+        <IconButton size="small" onClick={onDelete} color="error">
+          <DeleteIcon fontSize="small" />
+        </IconButton>
+      )}
     </Box>
   );
 };
@@ -745,16 +758,18 @@ const ContractEditor = ({
           }}
         >
           <Typography>{contract.name || `Contract ${index + 1}`}</Typography>
-          <IconButton
-            size="small"
-            onClick={(e) => {
-              e.stopPropagation();
-              onDelete();
-            }}
-            color="error"
-          >
-            <DeleteIcon fontSize="small" />
-          </IconButton>
+          {!lockStructure && (
+            <IconButton
+              size="small"
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete();
+              }}
+              color="error"
+            >
+              <DeleteIcon fontSize="small" />
+            </IconButton>
+          )}
         </Box>
       </AccordionSummary>
       <AccordionDetails sx={{ p: 3 }}>
@@ -812,6 +827,7 @@ const ContractEditor = ({
               onDelete={() => handleDeleteField(fieldIndex)}
               participantCount={participantCount}
               partyId={partyId}
+              lockStructure={lockStructure}
             />
           ))}
           {!lockStructure && (
@@ -1117,6 +1133,43 @@ export const ContractsDialog = ({
     }
   }, [contractType, participantIds.length, packages]);
 
+  // Pre-fill the Member Set for gov-core from each peer's configured member_party_id.
+  useEffect(() => {
+    if (contractType !== "governance-core") return;
+    let cancelled = false;
+    const fetchKnownMembers = async () => {
+      try {
+        const res = await authenticatedFetch(
+          `${API_BASE}/governance/known-members?party_id=${encodeURIComponent(
+            partyId,
+          )}`,
+        );
+        if (!res.ok || cancelled) return;
+        const data: {
+          members: Array<{ participant_uid: string; member_party_id: string }>;
+        } = await res.json();
+        const memberIds = data.members
+          .map((m) => m.member_party_id)
+          .filter((id) => id.length > 0);
+        if (cancelled || memberIds.length === 0) return;
+        setContracts((prev) =>
+          prev.map((c) => ({
+            ...c,
+            fields: c.fields.map((f) =>
+              f.type === "party_set" ? { ...f, parties: memberIds } : f,
+            ),
+          })),
+        );
+      } catch {
+        // If discovery fails, the operator can still type values manually.
+      }
+    };
+    fetchKnownMembers();
+    return () => {
+      cancelled = true;
+    };
+  }, [contractType, partyId, packages]);
+
   const pollStatus = useCallback(async () => {
     try {
       const res = await authenticatedFetch(`${API_BASE}/contracts/status`);
@@ -1178,6 +1231,7 @@ export const ContractsDialog = ({
 
     if (
       contractType !== "vault" &&
+      contractType !== "governance-core" &&
       participantParties.length !== participantIds.length
     ) {
       setError(
@@ -1187,11 +1241,19 @@ export const ContractsDialog = ({
       return;
     }
 
+    // For gov core the user doesn't fill the top section; derive participant_parties from the contract's Member Set field.
+    const submittedParticipantParties =
+      contractType === "governance-core"
+        ? (contracts
+            .flatMap((c) => c.fields)
+            .find((f) => f.type === "party_set")?.parties ?? [])
+        : participantParties;
+
     try {
       const request: ContractsRequest = {
         decentralized_party_id: partyId,
         participant_ids: participantIds,
-        participant_parties: participantParties,
+        participant_parties: submittedParticipantParties,
         operator_party: operatorParty,
         contracts: contracts,
       };
@@ -1309,6 +1371,7 @@ export const ContractsDialog = ({
                 />
               )}
 
+              {contractType !== "governance-core" && (
               <>
                 <Typography variant="subtitle2" sx={{ mt: 1 }}>
                   Participant Party IDs ({participantParties.length}/
@@ -1400,6 +1463,7 @@ export const ContractsDialog = ({
                   )}
                 </Box>
               </>
+              )}
 
               <Divider />
               <Box

--- a/frontend/src/components/ContractsDialog.tsx
+++ b/frontend/src/components/ContractsDialog.tsx
@@ -63,10 +63,10 @@ const FIELD_TYPES = [
   { value: "decentralized_party", label: "Dec. Party" },
   { value: "operator_party", label: "Operator" },
   { value: "participant_party", label: "Party" },
-  { value: "party_set", label: "Party Set" },
+  { value: "party_set", label: "Member Set" },
   { value: "attestors_set", label: "Attestors Set" },
   { value: "governance_threshold", label: "Threshold" },
-  { value: "rel_time", label: "RelTime" },
+  { value: "rel_time", label: "Proposal Timeout" },
   { value: "optional", label: "Optional" },
   { value: "instrument", label: "Instrument" },
   { value: "text", label: "Text" },
@@ -773,7 +773,7 @@ const ContractEditor = ({
             renderInput={(params) => (
               <TextField
                 {...params}
-                label="Package ID"
+                label="Package Name / ID"
                 placeholder="Enter or select package ID"
               />
             )}

--- a/frontend/src/components/CopyableText.tsx
+++ b/frontend/src/components/CopyableText.tsx
@@ -1,26 +1,7 @@
 import { Box, IconButton, Tooltip, Typography, useMediaQuery, useTheme } from "@mui/material";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import { useSnackbar } from "../contexts";
-
-export const copyToClipboard = async (text: string): Promise<boolean> => {
-  try {
-    await navigator.clipboard.writeText(text);
-    return true;
-  } catch {
-    // Fallback for non-HTTPS contexts
-    try {
-      const textArea = document.createElement("textarea");
-      textArea.value = text;
-      document.body.appendChild(textArea);
-      textArea.select();
-      document.execCommand("copy");
-      document.body.removeChild(textArea);
-      return true;
-    } catch {
-      return false;
-    }
-  }
-};
+import { copyToClipboard } from "../clipboard";
 
 interface CopyableTextProps {
   text: string;

--- a/frontend/src/components/DarsDialog.tsx
+++ b/frontend/src/components/DarsDialog.tsx
@@ -10,6 +10,7 @@ import {
   Alert,
   Box,
   IconButton,
+  Tooltip,
 } from "@mui/material";
 import UploadFileIcon from "@mui/icons-material/UploadFile";
 import DeleteIcon from "@mui/icons-material/Delete";
@@ -247,12 +248,14 @@ export const DarsDialog = ({
                       }}
                     >
                       <Typography variant="body2">{file.filename}</Typography>
-                      <IconButton
-                        size="small"
-                        onClick={() => handleRemoveDarFile(index)}
-                      >
-                        <DeleteIcon fontSize="small" />
-                      </IconButton>
+                      <Tooltip title="Remove file">
+                        <IconButton
+                          size="small"
+                          onClick={() => handleRemoveDarFile(index)}
+                        >
+                          <DeleteIcon fontSize="small" />
+                        </IconButton>
+                      </Tooltip>
                     </Box>
                   ))}
                 </Box>

--- a/frontend/src/components/DarsDialog.tsx
+++ b/frontend/src/components/DarsDialog.tsx
@@ -11,12 +11,16 @@ import {
   Box,
   IconButton,
   Tooltip,
+  Divider,
+  FormGroup,
+  FormControlLabel,
+  Checkbox,
 } from "@mui/material";
 import UploadFileIcon from "@mui/icons-material/UploadFile";
 import DeleteIcon from "@mui/icons-material/Delete";
 import { API_BASE } from "../constants";
 import { authenticatedFetch } from "../api";
-import type { DarsStatusResponse, DarFile } from "../types";
+import type { DarsStatusResponse, DarFile, Peer, NodeConfig } from "../types";
 
 interface DarsDialogProps {
   open: boolean;
@@ -36,6 +40,43 @@ export const DarsDialog = ({
   const [error, setError] = useState<string | null>(null);
   const [status, setStatus] = useState<DarsStatusResponse | null>(null);
   const [darFiles, setDarFiles] = useState<DarFile[]>([]);
+  const [peers, setPeers] = useState<Peer[]>([]);
+  const [selfNodeId, setSelfNodeId] = useState<string | null>(null);
+  const [selectedPeerIds, setSelectedPeerIds] = useState<Set<string>>(new Set());
+  const [loadingPeers, setLoadingPeers] = useState(false);
+
+  // Fetch peers when dialog opens (distribute mode only)
+  useEffect(() => {
+    if (!open || mode !== "distribute") return;
+
+    const fetchPeers = async () => {
+      setLoadingPeers(true);
+      try {
+        const [networkRes, nodeRes] = await Promise.all([
+          authenticatedFetch(`${API_BASE}/network-config`),
+          authenticatedFetch(`${API_BASE}/node-config`),
+        ]);
+        if (networkRes.ok) {
+          const data = await networkRes.json();
+          setPeers(data.peers || []);
+          // Default to all peers selected
+          const allPeerIds = new Set<string>(
+            (data.peers || []).map((p: Peer) => p.participant_id),
+          );
+          setSelectedPeerIds(allPeerIds);
+        }
+        if (nodeRes.ok) {
+          const nodeData: NodeConfig = await nodeRes.json();
+          setSelfNodeId(nodeData.node.participant_id);
+        }
+      } catch {
+        // Ignore fetch errors
+      } finally {
+        setLoadingPeers(false);
+      }
+    };
+    fetchPeers();
+  }, [open, mode]);
 
   // Reset state when dialog opens/closes
   useEffect(() => {
@@ -44,8 +85,27 @@ export const DarsDialog = ({
       setStatus(null);
       setLoading(false);
       setDarFiles([]);
+      setPeers([]);
+      setSelectedPeerIds(new Set());
     }
   }, [open]);
+
+  const togglePeer = (peerId: string) => {
+    setSelectedPeerIds((prev) => {
+      const newSet = new Set(prev);
+      if (newSet.has(peerId)) {
+        newSet.delete(peerId);
+      } else {
+        newSet.add(peerId);
+      }
+      return newSet;
+    });
+  };
+
+  // Filter out self from peer list
+  const selectablePeers = peers.filter(
+    (p) => p.participant_id.split("::")[0] !== selfNodeId,
+  );
 
   const pollStatus = useCallback(async () => {
     try {
@@ -121,15 +181,25 @@ export const DarsDialog = ({
       return;
     }
 
+    if (mode === "distribute" && selectedPeerIds.size === 0) {
+      setError("At least one peer must be selected");
+      setLoading(false);
+      return;
+    }
+
     try {
       const endpoint =
         mode === "upload"
           ? `${API_BASE}/dars/upload`
           : `${API_BASE}/dars/distribute`;
+      const body =
+        mode === "upload"
+          ? { dar_files: darFiles }
+          : { dar_files: darFiles, peer_ids: Array.from(selectedPeerIds) };
       const res = await authenticatedFetch(endpoint, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ dar_files: darFiles }),
+        body: JSON.stringify(body),
       });
 
       if (!res.ok) {
@@ -174,7 +244,7 @@ export const DarsDialog = ({
             <Alert severity="info" icon={<CircularProgress size={20} />}>
               {mode === "upload"
                 ? "Uploading DARs to this node..."
-                : "Distributing DARs to all participants..."}
+                : "Distributing DARs to selected peers..."}
             </Alert>
           )}
 
@@ -182,7 +252,7 @@ export const DarsDialog = ({
             <Alert severity="success">
               {mode === "upload"
                 ? "DARs uploaded to this node successfully!"
-                : "DARs distributed to all participants successfully!"}
+                : "DARs distributed to selected peers successfully!"}
             </Alert>
           )}
 
@@ -198,7 +268,7 @@ export const DarsDialog = ({
               <Typography variant="body2" color="text.secondary">
                 {mode === "upload"
                   ? "Upload Daml Archive (DAR) files to this node only."
-                  : "Distribute Daml Archive (DAR) files to all participants. This will coordinate with other nodes via Noise protocol."}
+                  : "Distribute Daml Archive (DAR) files to selected peers. This will coordinate with the chosen nodes via Noise protocol."}
               </Typography>
 
               <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
@@ -260,6 +330,52 @@ export const DarsDialog = ({
                   ))}
                 </Box>
               )}
+
+              {mode === "distribute" && (
+                <>
+                  <Divider />
+                  <Box>
+                    <Typography variant="subtitle2" sx={{ mb: 1 }}>
+                      Select Peers to Distribute To
+                    </Typography>
+                    {loadingPeers ? (
+                      <Box sx={{ display: "flex", justifyContent: "center", py: 2 }}>
+                        <CircularProgress size={24} />
+                      </Box>
+                    ) : selectablePeers.length === 0 ? (
+                      <Typography variant="body2" color="text.secondary">
+                        No peers configured. Add peers in the Network
+                        Configuration first.
+                      </Typography>
+                    ) : (
+                      <FormGroup>
+                        {selectablePeers.map((peer) => (
+                          <FormControlLabel
+                            key={peer.participant_id}
+                            control={
+                              <Checkbox
+                                checked={selectedPeerIds.has(peer.participant_id)}
+                                onChange={() => togglePeer(peer.participant_id)}
+                                disabled={loading}
+                              />
+                            }
+                            label={
+                              <Box>
+                                <Typography variant="body2">
+                                  {peer.name || peer.participant_id}
+                                </Typography>
+                                <Typography variant="caption" color="text.secondary">
+                                  {peer.address}:{peer.port}
+                                </Typography>
+                              </Box>
+                            }
+                          />
+                        ))}
+                      </FormGroup>
+                    )}
+                  </Box>
+                </>
+              )}
             </>
           )}
         </Box>
@@ -273,7 +389,11 @@ export const DarsDialog = ({
             onClick={handleStart}
             variant="contained"
             color="primary"
-            disabled={loading || darFiles.length === 0}
+            disabled={
+              loading ||
+              darFiles.length === 0 ||
+              (mode === "distribute" && selectedPeerIds.size === 0)
+            }
           >
             {loading ? (
               <CircularProgress size={20} />

--- a/frontend/src/components/DarsDialog.tsx
+++ b/frontend/src/components/DarsDialog.tsx
@@ -56,18 +56,23 @@ export const DarsDialog = ({
           authenticatedFetch(`${API_BASE}/network-config`),
           authenticatedFetch(`${API_BASE}/node-config`),
         ]);
-        if (networkRes.ok) {
-          const data = await networkRes.json();
-          setPeers(data.peers || []);
-          // Default to all peers selected
-          const allPeerIds = new Set<string>(
-            (data.peers || []).map((p: Peer) => p.participant_id),
-          );
-          setSelectedPeerIds(allPeerIds);
-        }
+        let self: string | null = null;
         if (nodeRes.ok) {
           const nodeData: NodeConfig = await nodeRes.json();
-          setSelfNodeId(nodeData.node.participant_id);
+          self = nodeData.node.participant_id;
+          setSelfNodeId(self);
+        }
+        if (networkRes.ok) {
+          const data = await networkRes.json();
+          const allPeers: Peer[] = data.peers || [];
+          setPeers(allPeers);
+          // Default to all peers selected, excluding self
+          const allPeerIds = new Set<string>(
+            allPeers
+              .filter((p) => p.participant_id !== self)
+              .map((p) => p.participant_id),
+          );
+          setSelectedPeerIds(allPeerIds);
         }
       } catch {
         // Ignore fetch errors
@@ -102,9 +107,9 @@ export const DarsDialog = ({
     });
   };
 
-  // Filter out self from peer list
+  // Filter out self from peer list (compare full canton ids).
   const selectablePeers = peers.filter(
-    (p) => p.participant_id.split("::")[0] !== selfNodeId,
+    (p) => p.participant_id !== selfNodeId,
   );
 
   const pollStatus = useCallback(async () => {

--- a/frontend/src/components/ExecuteDialog.tsx
+++ b/frontend/src/components/ExecuteDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useMemo } from "react";
 import {
   Dialog,
   DialogTitle,
@@ -11,6 +11,7 @@ import {
   Alert,
   Box,
   IconButton,
+  Tooltip,
 } from "@mui/material";
 import DeleteIcon from "@mui/icons-material/Delete";
 import AddIcon from "@mui/icons-material/Add";
@@ -89,37 +90,33 @@ interface ExecuteDialogProps {
   blobMap?: Record<string, string>;
 }
 
-export const ExecuteDialog = ({
-  open,
-  onClose,
-  onExecute,
+interface ExecuteFormProps {
+  action: GovernanceAction;
+  fullBlobMap: Record<string, string>;
+  loading: boolean;
+  error: string | null;
+  onClose: () => void;
+  onExecute: (disclosedContracts: DisclosedContractInput[]) => void;
+}
+
+// Inner form. The parent re-keys it on action.action_hash so it remounts —
+// state is initialized lazily from the action prop instead of via an effect.
+const ExecuteForm = ({
   action,
+  fullBlobMap,
   loading,
   error,
-  blobMap = {},
-}: ExecuteDialogProps) => {
-  const fullBlobMap = useMemo(
-    () => ({ ...STATIC_BLOB_MAP, ...blobMap }),
-    [blobMap],
-  );
+  onClose,
+  onExecute,
+}: ExecuteFormProps) => {
   const [disclosedContracts, setDisclosedContracts] = useState<
     DisclosedContractInput[]
-  >([]);
-
-  // Populate disclosed contracts from blob map when dialog opens
-  useEffect(() => {
-    if (open && action) {
-      const contractIds = getRequiredContractIds(action.action);
-      setDisclosedContracts(
-        contractIds.map((cid) => ({
-          contract_id: cid,
-          blob: fullBlobMap[cid] || "",
-        })),
-      );
-    } else {
-      setDisclosedContracts([]);
-    }
-  }, [open, action, fullBlobMap]);
+  >(() =>
+    getRequiredContractIds(action.action).map((cid) => ({
+      contract_id: cid,
+      blob: fullBlobMap[cid] || "",
+    })),
+  );
 
   const handleAdd = () => {
     setDisclosedContracts((prev) => [
@@ -142,10 +139,8 @@ export const ExecuteDialog = ({
     );
   };
 
-  if (!action) return null;
-
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+    <>
       <DialogTitle>Execute Governance Action</DialogTitle>
       <DialogContent>
         <Box sx={{ display: "flex", flexDirection: "column", gap: 2, mt: 1 }}>
@@ -217,13 +212,17 @@ export const ExecuteDialog = ({
                       <Typography variant="caption" color="text.secondary">
                         Disclosed Contract #{index + 1}
                       </Typography>
-                      <IconButton
-                        size="small"
-                        onClick={() => handleRemove(index)}
-                        disabled={loading}
-                      >
-                        <DeleteIcon fontSize="small" />
-                      </IconButton>
+                      <Tooltip title="Remove disclosed contract">
+                        <span>
+                          <IconButton
+                            size="small"
+                            onClick={() => handleRemove(index)}
+                            disabled={loading}
+                          >
+                            <DeleteIcon fontSize="small" />
+                          </IconButton>
+                        </span>
+                      </Tooltip>
                     </Box>
                     <TextField
                       label="Contract ID"
@@ -271,6 +270,37 @@ export const ExecuteDialog = ({
           {loading ? <CircularProgress size={20} color="inherit" /> : "Execute"}
         </Button>
       </DialogActions>
+    </>
+  );
+};
+
+export const ExecuteDialog = ({
+  open,
+  onClose,
+  onExecute,
+  action,
+  loading,
+  error,
+  blobMap = {},
+}: ExecuteDialogProps) => {
+  const fullBlobMap = useMemo(
+    () => ({ ...STATIC_BLOB_MAP, ...blobMap }),
+    [blobMap],
+  );
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+      {action && (
+        <ExecuteForm
+          key={action.action_hash}
+          action={action}
+          fullBlobMap={fullBlobMap}
+          loading={loading}
+          error={error}
+          onClose={onClose}
+          onExecute={onExecute}
+        />
+      )}
     </Dialog>
   );
 };

--- a/frontend/src/components/GovernanceActionsDialog.tsx
+++ b/frontend/src/components/GovernanceActionsDialog.tsx
@@ -1,0 +1,57 @@
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Box,
+} from "@mui/material";
+import { GovernanceSection } from "./GovernanceSection";
+import type { Network } from "../types";
+
+interface GovernanceActionsDialogProps {
+  open: boolean;
+  onClose: () => void;
+  partyId: string;
+  rulesContractId: string;
+  memberPartyId: string;
+  defaultOperatorParty?: string;
+  network?: Network;
+  governanceType: "vault" | "core_self" | "core_domain";
+  onAfterAction?: () => void;
+}
+
+export const GovernanceActionsDialog = ({
+  open,
+  onClose,
+  partyId,
+  rulesContractId,
+  memberPartyId,
+  defaultOperatorParty,
+  network,
+  governanceType,
+  onAfterAction,
+}: GovernanceActionsDialogProps) => {
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="lg" fullWidth>
+      <DialogTitle>Governance Actions</DialogTitle>
+      <DialogContent>
+        <Box sx={{ pt: 1 }}>
+          <GovernanceSection
+            partyId={partyId}
+            rulesContractId={rulesContractId}
+            governanceContractIds={[rulesContractId]}
+            memberPartyId={memberPartyId}
+            defaultOperatorParty={defaultOperatorParty}
+            network={network}
+            governanceType={governanceType}
+            onAfterAction={onAfterAction}
+          />
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/frontend/src/components/GovernanceAuditTrail.tsx
+++ b/frontend/src/components/GovernanceAuditTrail.tsx
@@ -28,6 +28,9 @@ import type { ChainAuditEntry, ChainAuditResponse } from "../types";
 
 interface GovernanceAuditTrailProps {
   partyId: string;
+  /// Bumped by the parent after a sibling governance action mutates state, to
+  /// trigger a fresh fetch without the operator clicking Refresh.
+  refreshNonce?: number;
 }
 
 const CHAIN_LIMIT = 200;
@@ -114,7 +117,10 @@ const CopyButton = ({
   );
 };
 
-export const GovernanceAuditTrail = ({ partyId }: GovernanceAuditTrailProps) => {
+export const GovernanceAuditTrail = ({
+  partyId,
+  refreshNonce,
+}: GovernanceAuditTrailProps) => {
   const jsonTreeTheme = useJsonTreeTheme();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -190,6 +196,13 @@ export const GovernanceAuditTrail = ({ partyId }: GovernanceAuditTrailProps) => 
       fetchAudit(false);
     }
   }, [cacheLoaded, fetchAudit]);
+
+  // Re-fetch (force fresh) whenever the parent bumps the nonce after a
+  // sibling governance mutation.
+  useEffect(() => {
+    if (refreshNonce === undefined || refreshNonce === 0) return;
+    fetchAudit(true);
+  }, [refreshNonce, fetchAudit]);
 
   if (error) {
     return (

--- a/frontend/src/components/GovernanceAuditTrail.tsx
+++ b/frontend/src/components/GovernanceAuditTrail.tsx
@@ -119,6 +119,10 @@ export const GovernanceAuditTrail = ({ partyId }: GovernanceAuditTrailProps) => 
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [entries, setEntries] = useState<ChainAuditEntry[]>([]);
+  const sortedEntries = useMemo(
+    () => [...entries].sort((a, b) => b.timestamp - a.timestamp),
+    [entries],
+  );
   const [expandedRow, setExpandedRow] = useState<string | null>(null);
   const [cacheLoaded, setCacheLoaded] = useState(false);
   const [canScrollUp, setCanScrollUp] = useState(false);
@@ -278,7 +282,7 @@ export const GovernanceAuditTrail = ({ partyId }: GovernanceAuditTrailProps) => 
               </TableRow>
             </TableHead>
             <TableBody>
-              {entries.map((entry, idx) => {
+              {sortedEntries.map((entry, idx) => {
                 const rowKey = `${entry.offset}-${entry.contract_id}`;
                 const isExpanded = expandedRow === rowKey;
                 return (

--- a/frontend/src/components/GovernanceAuditTrail.tsx
+++ b/frontend/src/components/GovernanceAuditTrail.tsx
@@ -285,18 +285,20 @@ export const GovernanceAuditTrail = ({ partyId }: GovernanceAuditTrailProps) => 
                   <Fragment key={rowKey}>
                     <TableRow sx={zebraRow(idx)}>
                       <TableCell sx={{ py: 0.5 }}>
-                        <IconButton
-                          size="small"
-                          onClick={() =>
-                            setExpandedRow(isExpanded ? null : rowKey)
-                          }
-                        >
-                          {isExpanded ? (
-                            <ExpandLessIcon fontSize="small" />
-                          ) : (
-                            <ExpandMoreIcon fontSize="small" />
-                          )}
-                        </IconButton>
+                        <Tooltip title={isExpanded ? "Hide details" : "Show details"}>
+                          <IconButton
+                            size="small"
+                            onClick={() =>
+                              setExpandedRow(isExpanded ? null : rowKey)
+                            }
+                          >
+                            {isExpanded ? (
+                              <ExpandLessIcon fontSize="small" />
+                            ) : (
+                              <ExpandMoreIcon fontSize="small" />
+                            )}
+                          </IconButton>
+                        </Tooltip>
                       </TableCell>
                       <TableCell sx={{ py: 1, fontSize: "0.8rem" }}>
                         {entry.timestamp > 0

--- a/frontend/src/components/GovernanceSection.tsx
+++ b/frontend/src/components/GovernanceSection.tsx
@@ -179,6 +179,10 @@ interface GovernanceSectionProps {
   defaultOperatorParty?: string;
   network?: Network;
   governanceType?: "vault" | "core_self" | "core_domain";
+  /// Called after every successful mutating action (propose / confirm /
+  /// execute / revoke / expire / domain confirm / domain execute) so the
+  /// parent can refresh sibling views (e.g. the audit trail tab).
+  onAfterAction?: () => void;
 }
 
 // Default values for action form
@@ -208,6 +212,7 @@ export const GovernanceSection = ({
   defaultOperatorParty,
   network,
   governanceType = "vault",
+  onAfterAction,
 }: GovernanceSectionProps) => {
   const [expanded, setExpanded] = useState(true);
   const [loading, setLoading] = useState(true);
@@ -624,6 +629,7 @@ export const GovernanceSection = ({
 
       // Refresh data
       await fetchGovernance();
+      onAfterAction?.();
     } catch (e) {
       setError(
         e instanceof Error ? e.message : "Failed to submit confirmation",
@@ -669,6 +675,7 @@ export const GovernanceSection = ({
       // Close dialog and refresh data
       setExecuteDialogAction(null);
       await fetchGovernance();
+      onAfterAction?.();
     } catch (e) {
       setExecuteError(
         e instanceof Error ? e.message : "Failed to execute action",
@@ -705,6 +712,7 @@ export const GovernanceSection = ({
 
       // Refresh data
       await fetchGovernance();
+      onAfterAction?.();
     } catch (e) {
       setError(
         e instanceof Error ? e.message : "Failed to revoke confirmation",
@@ -746,6 +754,7 @@ export const GovernanceSection = ({
       }
 
       await fetchGovernance();
+      onAfterAction?.();
     } catch (e) {
       setError(
         e instanceof Error ? e.message : "Failed to expire confirmation",
@@ -975,6 +984,7 @@ export const GovernanceSection = ({
       // Reset form and refresh data
       setShowNewActionForm(false);
       await fetchGovernance();
+      onAfterAction?.();
     } catch (e) {
       setError(
         e instanceof Error ? e.message : "Failed to submit confirmation",
@@ -1140,6 +1150,7 @@ export const GovernanceSection = ({
 
       setShowProposalForm(false);
       await fetchGovernance();
+      onAfterAction?.();
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to create proposal");
     } finally {
@@ -1171,6 +1182,7 @@ export const GovernanceSection = ({
       }
 
       await fetchGovernance();
+      onAfterAction?.();
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to confirm proposal");
     } finally {
@@ -1204,6 +1216,7 @@ export const GovernanceSection = ({
       }
 
       await fetchGovernance();
+      onAfterAction?.();
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to execute proposal");
     } finally {

--- a/frontend/src/components/GovernanceSection.tsx
+++ b/frontend/src/components/GovernanceSection.tsx
@@ -15,6 +15,7 @@ import {
   Collapse,
   IconButton,
   TextField,
+  Tooltip,
   Select,
   MenuItem,
   FormControl,
@@ -1416,13 +1417,17 @@ export const GovernanceSection = ({
                   )}
                 </Select>
               </FormControl>
-              <IconButton
-                size="small"
-                onClick={fetchDeployContracts}
-                disabled={deployContractsLoading}
-              >
-                {deployContractsLoading ? <CircularProgress size={20} /> : <RefreshIcon />}
-              </IconButton>
+              <Tooltip title="Refresh">
+                <span>
+                  <IconButton
+                    size="small"
+                    onClick={fetchDeployContracts}
+                    disabled={deployContractsLoading}
+                  >
+                    {deployContractsLoading ? <CircularProgress size={20} /> : <RefreshIcon />}
+                  </IconButton>
+                </span>
+              </Tooltip>
             </Box>
             <TextField
               label="Vault Name"
@@ -1552,13 +1557,17 @@ export const GovernanceSection = ({
                   )}
                 </Select>
               </FormControl>
-              <IconButton
-                size="small"
-                onClick={fetchDeployContracts}
-                disabled={deployContractsLoading}
-              >
-                {deployContractsLoading ? <CircularProgress size={20} /> : <RefreshIcon />}
-              </IconButton>
+              <Tooltip title="Refresh">
+                <span>
+                  <IconButton
+                    size="small"
+                    onClick={fetchDeployContracts}
+                    disabled={deployContractsLoading}
+                  >
+                    {deployContractsLoading ? <CircularProgress size={20} /> : <RefreshIcon />}
+                  </IconButton>
+                </span>
+              </Tooltip>
             </Box>
             <Box sx={{ mb: 2 }}>
               <Typography variant="caption" display="block" color="text.secondary" sx={{ mb: 1 }}>
@@ -1663,13 +1672,17 @@ export const GovernanceSection = ({
                   )}
                 </Select>
               </FormControl>
-              <IconButton
-                size="small"
-                onClick={fetchDeployContracts}
-                disabled={deployContractsLoading}
-              >
-                {deployContractsLoading ? <CircularProgress size={20} /> : <RefreshIcon />}
-              </IconButton>
+              <Tooltip title="Refresh">
+                <span>
+                  <IconButton
+                    size="small"
+                    onClick={fetchDeployContracts}
+                    disabled={deployContractsLoading}
+                  >
+                    {deployContractsLoading ? <CircularProgress size={20} /> : <RefreshIcon />}
+                  </IconButton>
+                </span>
+              </Tooltip>
             </Box>
             <Box sx={{ display: "flex", gap: 1, alignItems: "center" }}>
               <FormControl fullWidth size="small" required>
@@ -1693,13 +1706,17 @@ export const GovernanceSection = ({
                   )}
                 </Select>
               </FormControl>
-              <IconButton
-                size="small"
-                onClick={fetchDeployContracts}
-                disabled={deployContractsLoading}
-              >
-                {deployContractsLoading ? <CircularProgress size={20} /> : <RefreshIcon />}
-              </IconButton>
+              <Tooltip title="Refresh">
+                <span>
+                  <IconButton
+                    size="small"
+                    onClick={fetchDeployContracts}
+                    disabled={deployContractsLoading}
+                  >
+                    {deployContractsLoading ? <CircularProgress size={20} /> : <RefreshIcon />}
+                  </IconButton>
+                </span>
+              </Tooltip>
             </Box>
           </>
         );
@@ -1728,13 +1745,17 @@ export const GovernanceSection = ({
                   )}
                 </Select>
               </FormControl>
-              <IconButton
-                size="small"
-                onClick={fetchDeployContracts}
-                disabled={deployContractsLoading}
-              >
-                {deployContractsLoading ? <CircularProgress size={20} /> : <RefreshIcon />}
-              </IconButton>
+              <Tooltip title="Refresh">
+                <span>
+                  <IconButton
+                    size="small"
+                    onClick={fetchDeployContracts}
+                    disabled={deployContractsLoading}
+                  >
+                    {deployContractsLoading ? <CircularProgress size={20} /> : <RefreshIcon />}
+                  </IconButton>
+                </span>
+              </Tooltip>
             </Box>
             <FormControl fullWidth size="small" sx={{ mb: 2 }}>
               <InputLabel>Vault</InputLabel>
@@ -1932,13 +1953,17 @@ export const GovernanceSection = ({
                       : undefined
                 }
               />
-              <IconButton
-                size="small"
-                onClick={fetchBurnMintFactory}
-                disabled={burnMintFactoryLoading}
-              >
-                {burnMintFactoryLoading ? <CircularProgress size={20} /> : <RefreshIcon />}
-              </IconButton>
+              <Tooltip title="Refresh">
+                <span>
+                  <IconButton
+                    size="small"
+                    onClick={fetchBurnMintFactory}
+                    disabled={burnMintFactoryLoading}
+                  >
+                    {burnMintFactoryLoading ? <CircularProgress size={20} /> : <RefreshIcon />}
+                  </IconButton>
+                </span>
+              </Tooltip>
             </Box>
             <Typography variant="caption" display="block" color="text.secondary">
               FAR Config (Optional)
@@ -1970,13 +1995,17 @@ export const GovernanceSection = ({
                   )}
                 </Select>
               </FormControl>
-              <IconButton
-                size="small"
-                onClick={fetchDeployContracts}
-                disabled={deployContractsLoading}
-              >
-                {deployContractsLoading ? <CircularProgress size={20} /> : <RefreshIcon />}
-              </IconButton>
+              <Tooltip title="Refresh">
+                <span>
+                  <IconButton
+                    size="small"
+                    onClick={fetchDeployContracts}
+                    disabled={deployContractsLoading}
+                  >
+                    {deployContractsLoading ? <CircularProgress size={20} /> : <RefreshIcon />}
+                  </IconButton>
+                </span>
+              </Tooltip>
             </Box>
             <Box sx={{ mb: 2 }}>
               <Typography variant="caption" display="block" color="text.secondary" sx={{ mb: 1 }}>
@@ -2175,13 +2204,17 @@ export const GovernanceSection = ({
                   )}
                 </Select>
               </FormControl>
-              <IconButton
-                size="small"
-                onClick={fetchServices}
-                disabled={servicesLoading}
-              >
-                {servicesLoading ? <CircularProgress size={20} /> : <RefreshIcon />}
-              </IconButton>
+              <Tooltip title="Refresh">
+                <span>
+                  <IconButton
+                    size="small"
+                    onClick={fetchServices}
+                    disabled={servicesLoading}
+                  >
+                    {servicesLoading ? <CircularProgress size={20} /> : <RefreshIcon />}
+                  </IconButton>
+                </span>
+              </Tooltip>
             </Box>
             <Box sx={{ display: "flex", gap: 1, alignItems: "center" }}>
               <FormControl fullWidth size="small">
@@ -2205,13 +2238,17 @@ export const GovernanceSection = ({
                   )}
                 </Select>
               </FormControl>
-              <IconButton
-                size="small"
-                onClick={fetchServices}
-                disabled={servicesLoading}
-              >
-                {servicesLoading ? <CircularProgress size={20} /> : <RefreshIcon />}
-              </IconButton>
+              <Tooltip title="Refresh">
+                <span>
+                  <IconButton
+                    size="small"
+                    onClick={fetchServices}
+                    disabled={servicesLoading}
+                  >
+                    {servicesLoading ? <CircularProgress size={20} /> : <RefreshIcon />}
+                  </IconButton>
+                </span>
+              </Tooltip>
             </Box>
           </>
         );
@@ -2248,13 +2285,17 @@ export const GovernanceSection = ({
                   )}
                 </Select>
               </FormControl>
-              <IconButton
-                size="small"
-                onClick={fetchServices}
-                disabled={servicesLoading}
-              >
-                {servicesLoading ? <CircularProgress size={20} /> : <RefreshIcon />}
-              </IconButton>
+              <Tooltip title="Refresh">
+                <span>
+                  <IconButton
+                    size="small"
+                    onClick={fetchServices}
+                    disabled={servicesLoading}
+                  >
+                    {servicesLoading ? <CircularProgress size={20} /> : <RefreshIcon />}
+                  </IconButton>
+                </span>
+              </Tooltip>
             </Box>
             <TextField
               label="Holder Service Request Contract ID"
@@ -2306,13 +2347,17 @@ export const GovernanceSection = ({
                   )}
                 </Select>
               </FormControl>
-              <IconButton
-                size="small"
-                onClick={fetchServices}
-                disabled={servicesLoading}
-              >
-                {servicesLoading ? <CircularProgress size={20} /> : <RefreshIcon />}
-              </IconButton>
+              <Tooltip title="Refresh">
+                <span>
+                  <IconButton
+                    size="small"
+                    onClick={fetchServices}
+                    disabled={servicesLoading}
+                  >
+                    {servicesLoading ? <CircularProgress size={20} /> : <RefreshIcon />}
+                  </IconButton>
+                </span>
+              </Tooltip>
             </Box>
             <TextField
               label="Holder Party"
@@ -2428,13 +2473,17 @@ export const GovernanceSection = ({
                   )}
                 </Select>
               </FormControl>
-              <IconButton
-                size="small"
-                onClick={fetchServices}
-                disabled={servicesLoading}
-              >
-                {servicesLoading ? <CircularProgress size={20} /> : <RefreshIcon />}
-              </IconButton>
+              <Tooltip title="Refresh">
+                <span>
+                  <IconButton
+                    size="small"
+                    onClick={fetchServices}
+                    disabled={servicesLoading}
+                  >
+                    {servicesLoading ? <CircularProgress size={20} /> : <RefreshIcon />}
+                  </IconButton>
+                </span>
+              </Tooltip>
             </Box>
             <TextField
               label="Credential Offer Contract ID"
@@ -2456,13 +2505,17 @@ export const GovernanceSection = ({
               size="small"
               required
             />
-            <IconButton
-              size="small"
-              onClick={fetchNetworkInfo}
-              disabled={amuletRulesLoading}
-            >
-              {amuletRulesLoading ? <CircularProgress size={20} /> : <RefreshIcon />}
-            </IconButton>
+            <Tooltip title="Refresh">
+              <span>
+                <IconButton
+                  size="small"
+                  onClick={fetchNetworkInfo}
+                  disabled={amuletRulesLoading}
+                >
+                  {amuletRulesLoading ? <CircularProgress size={20} /> : <RefreshIcon />}
+                </IconButton>
+              </span>
+            </Tooltip>
           </Box>
         );
       default:
@@ -2670,15 +2723,18 @@ export const GovernanceSection = ({
                               {isOwn ? " (you)" : ""}
                             </Typography>
                             {!isOwn && ADMIN_ACCESS && rulesContractId && (
-                              <IconButton
-                                size="small"
-                                title="Expire confirmation"
-                                onClick={() => handleExpire(action, conf.contract_id)}
-                                disabled={actionLoading === action.action_hash}
-                                sx={{ p: 0.25 }}
-                              >
-                                <TimerOffIcon sx={{ fontSize: 14 }} />
-                              </IconButton>
+                              <Tooltip title="Expire confirmation">
+                                <span>
+                                  <IconButton
+                                    size="small"
+                                    onClick={() => handleExpire(action, conf.contract_id)}
+                                    disabled={actionLoading === action.action_hash}
+                                    sx={{ p: 0.25 }}
+                                  >
+                                    <TimerOffIcon sx={{ fontSize: 14 }} />
+                                  </IconButton>
+                                </span>
+                              </Tooltip>
                             )}
                           </Box>
                         );

--- a/frontend/src/components/GovernanceSection.tsx
+++ b/frontend/src/components/GovernanceSection.tsx
@@ -2833,12 +2833,12 @@ export const GovernanceSection = ({
         )}
       </Collapse>
 
-      {/* Domain Proposals — only for governance-core */}
+      {/* Proposals — only for governance-core */}
       {governanceType === "core_self" && data && (
         <Box sx={{ mt: 2, mx: -2 }}>
           <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mb: 1, px: 2 }}>
             <Typography variant="subtitle2">
-              Domain Proposals
+              Proposals
               {(data.domain_actions?.length ?? 0) > 0 && (
                 <Chip label={data.domain_actions!.length} size="small" sx={{ ml: 1 }} color="secondary" />
               )}

--- a/frontend/src/components/GrantRightsDialog.tsx
+++ b/frontend/src/components/GrantRightsDialog.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useState } from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  TextField,
+  Typography,
+  CircularProgress,
+  Alert,
+  Box,
+} from "@mui/material";
+import { API_BASE } from "../constants";
+import { authenticatedFetch } from "../api";
+
+interface GrantRightsDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onGranted: () => void;
+  partyId: string;
+}
+
+export const GrantRightsDialog = ({
+  open,
+  onClose,
+  onGranted,
+  partyId,
+}: GrantRightsDialogProps) => {
+  const [clientId, setClientId] = useState("");
+  const [clientSecret, setClientSecret] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Always wipe the secret when the dialog opens (or closes) so it never
+  // carries across opens. Client_id is preserved so the operator doesn't
+  // have to retype it on a wrong-secret retry.
+  useEffect(() => {
+    setClientSecret("");
+    setError(null);
+    setLoading(false);
+    if (!open) {
+      setClientId("");
+    }
+  }, [open]);
+
+  const canSubmit =
+    !loading && clientId.trim().length > 0 && clientSecret.length > 0;
+
+  const handleSubmit = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await authenticatedFetch(`${API_BASE}/auth/grant-rights`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          dec_party_id: partyId,
+          admin_client_id: clientId.trim(),
+          admin_client_secret: clientSecret,
+        }),
+      });
+      if (res.ok) {
+        setClientSecret("");
+        onGranted();
+        onClose();
+      } else {
+        const data = await res.json().catch(() => ({}));
+        setClientSecret("");
+        setError(data.error || "Failed to grant rights");
+      }
+    } catch (err) {
+      setClientSecret("");
+      setError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleClose = () => {
+    if (!loading) onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={handleClose} maxWidth="xs" fullWidth>
+      <DialogTitle>Grant Rights — Admin Credentials</DialogTitle>
+      <DialogContent>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2, mt: 1 }}>
+          <Typography variant="body2" color="text.secondary">
+            Used once to grant <code>actAs</code> + <code>readAs</code> on the
+            member and dec parties. Credentials are not stored — paste the
+            Keycloak client whose service account has{" "}
+            <code>ParticipantAdmin</code> on this participant (the same one
+            your team uses in Yaak).
+          </Typography>
+
+          <TextField
+            label="Client ID"
+            value={clientId}
+            onChange={(e) => setClientId(e.target.value)}
+            size="small"
+            fullWidth
+            autoFocus
+            disabled={loading}
+            autoComplete="off"
+          />
+
+          <TextField
+            label="Client Secret"
+            value={clientSecret}
+            onChange={(e) => setClientSecret(e.target.value)}
+            size="small"
+            type="password"
+            fullWidth
+            disabled={loading}
+            autoComplete="off"
+          />
+
+          {error && <Alert severity="error">{error}</Alert>}
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose} disabled={loading}>
+          Cancel
+        </Button>
+        <Button
+          onClick={handleSubmit}
+          variant="contained"
+          color="primary"
+          disabled={!canSubmit}
+        >
+          {loading ? <CircularProgress size={20} color="inherit" /> : "Grant"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/frontend/src/components/NetworkConfigAccordion.tsx
+++ b/frontend/src/components/NetworkConfigAccordion.tsx
@@ -26,7 +26,7 @@ import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import ContentPasteIcon from "@mui/icons-material/ContentPaste";
 import { useSnackbar } from "../contexts";
 import { zebraRow } from "../styles";
-import { copyToClipboard } from "./CopyableText";
+import { copyToClipboard } from "../clipboard";
 import type {
   NetworkConfig,
   Peer,
@@ -245,13 +245,15 @@ export const NetworkConfigAccordion = ({
                     updatePeer(index, "public_key", e.target.value)
                   }
                 />
-                <IconButton
-                  color="error"
-                  onClick={() => removePeer(index)}
-                  size="small"
-                >
-                  <DeleteIcon />
-                </IconButton>
+                <Tooltip title="Remove peer">
+                  <IconButton
+                    color="error"
+                    onClick={() => removePeer(index)}
+                    size="small"
+                  >
+                    <DeleteIcon />
+                  </IconButton>
+                </Tooltip>
               </Box>
             ))}
             <Box
@@ -322,9 +324,11 @@ export const NetworkConfigAccordion = ({
                 </Button>
               )}
               {onSave && (
-                <IconButton size="small" onClick={startEditing}>
-                  <EditIcon fontSize="small" />
-                </IconButton>
+                <Tooltip title="Edit peers">
+                  <IconButton size="small" onClick={startEditing}>
+                    <EditIcon fontSize="small" />
+                  </IconButton>
+                </Tooltip>
               )}
             </Box>
           </Box>
@@ -342,7 +346,9 @@ export const NetworkConfigAccordion = ({
               {selfEntry && (
                 <TableRow sx={{ bgcolor: "action.selected" }}>
                   <TableCell sx={{ py: 1 }}>
-                    <PersonIcon sx={{ fontSize: 14, color: "primary.main" }} />
+                    <Tooltip title="This is your node" arrow>
+                      <PersonIcon sx={{ fontSize: 14, color: "primary.main" }} />
+                    </Tooltip>
                   </TableCell>
                   <TableCell sx={{ py: 1, whiteSpace: "nowrap" }}>
                     <Typography variant="body2" color="text.secondary">

--- a/frontend/src/components/OnboardingDialog.tsx
+++ b/frontend/src/components/OnboardingDialog.tsx
@@ -33,7 +33,13 @@ export const OnboardingDialog = ({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [meshErrors, setMeshErrors] = useState<
-    Array<{ from: string; to: string }> | null
+    Array<{
+      from: string;
+      to: string;
+      // `kind` is optional for backwards compatibility with older backends
+      // that didn't tag the failure mode.
+      kind?: "unreachable_from_coordinator" | "mesh_hole";
+    }> | null
   >(null);
   const [status, setStatus] = useState<OnboardingStatusResponse | null>(null);
   const [partyIdPrefix, setPartyIdPrefix] = useState("");
@@ -198,12 +204,21 @@ export const OnboardingDialog = ({
   const peerName = (id: string) =>
     peers.find((p) => p.participant_id === id)?.name || id;
 
-  // Group missing directed edges by the node that needs to be edited.
-  // The user's task on `from` = add each `to` to its network config.
-  const groupedMissing = (() => {
+  // Split missing directed edges into the two distinct user-actions:
+  //
+  //  - `mesh_hole`  — peer `from` is reachable from the coordinator but does
+  //    not have peer `to` in its config. Hint: "On <from>, add <to>".
+  //  - `unreachable_from_coordinator` — coordinator can't query `to` at all
+  //    (unknown / no key / unreachable / unparsable response). Hint: fix the
+  //    coordinator's view of `to`, or `to` itself (it may be offline).
+  //
+  // Older backends won't set `kind`; treat that as `mesh_hole` so behavior
+  // is identical to the pre-fix UI.
+  const meshHoles = (() => {
     if (!meshErrors) return [] as Array<{ node: string; missing: string[] }>;
     const map = new Map<string, string[]>();
     for (const edge of meshErrors) {
+      if (edge.kind && edge.kind !== "mesh_hole") continue;
       const list = map.get(edge.from) ?? [];
       list.push(edge.to);
       map.set(edge.from, list);
@@ -212,6 +227,16 @@ export const OnboardingDialog = ({
       node,
       missing,
     }));
+  })();
+  const unreachablePeers = (() => {
+    if (!meshErrors) return [] as string[];
+    const set = new Set<string>();
+    for (const edge of meshErrors) {
+      if (edge.kind === "unreachable_from_coordinator") {
+        set.add(edge.to);
+      }
+    }
+    return Array.from(set);
   })();
 
   return (
@@ -282,30 +307,61 @@ export const OnboardingDialog = ({
 
           {meshErrors && (
             <Alert severity="error">
-              <Typography variant="body2" sx={{ fontWeight: 600, mb: 1 }}>
-                Update network configs:
-              </Typography>
-              <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
-                {groupedMissing.map(({ node, missing }, i) => (
-                  <Box key={i}>
-                    <Typography variant="body2">
-                      On <strong>{peerName(node)}</strong>, add:
-                    </Typography>
-                    <Box component="ul" sx={{ pl: 2.5, m: 0 }}>
-                      {missing.map((toId, j) => (
-                        <Typography
-                          component="li"
-                          variant="body2"
-                          key={j}
-                          color="text.secondary"
-                        >
-                          {peerName(toId)}
-                        </Typography>
-                      ))}
-                    </Box>
+              {unreachablePeers.length > 0 && (
+                <Box sx={{ mb: meshHoles.length > 0 ? 2 : 0 }}>
+                  <Typography variant="body2" sx={{ fontWeight: 600, mb: 1 }}>
+                    Coordinator can't reach these peers:
+                  </Typography>
+                  <Box component="ul" sx={{ pl: 2.5, m: 0 }}>
+                    {unreachablePeers.map((id) => (
+                      <Typography
+                        component="li"
+                        variant="body2"
+                        key={id}
+                        color="text.secondary"
+                      >
+                        {peerName(id)}
+                      </Typography>
+                    ))}
                   </Box>
-                ))}
-              </Box>
+                  <Typography
+                    variant="caption"
+                    color="text.secondary"
+                    sx={{ display: "block", mt: 0.5 }}
+                  >
+                    Fix the coordinator's network config for each, or check
+                    that the peer is online.
+                  </Typography>
+                </Box>
+              )}
+              {meshHoles.length > 0 && (
+                <>
+                  <Typography variant="body2" sx={{ fontWeight: 600, mb: 1 }}>
+                    Update network configs:
+                  </Typography>
+                  <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+                    {meshHoles.map(({ node, missing }, i) => (
+                      <Box key={i}>
+                        <Typography variant="body2">
+                          On <strong>{peerName(node)}</strong>, add:
+                        </Typography>
+                        <Box component="ul" sx={{ pl: 2.5, m: 0 }}>
+                          {missing.map((toId, j) => (
+                            <Typography
+                              component="li"
+                              variant="body2"
+                              key={j}
+                              color="text.secondary"
+                            >
+                              {peerName(toId)}
+                            </Typography>
+                          ))}
+                        </Box>
+                      </Box>
+                    ))}
+                  </Box>
+                </>
+              )}
               <Typography
                 variant="caption"
                 color="text.secondary"

--- a/frontend/src/components/OnboardingDialog.tsx
+++ b/frontend/src/components/OnboardingDialog.tsx
@@ -32,6 +32,9 @@ export const OnboardingDialog = ({
 }: OnboardingDialogProps) => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [meshErrors, setMeshErrors] = useState<
+    Array<{ from: string; to: string }> | null
+  >(null);
   const [status, setStatus] = useState<OnboardingStatusResponse | null>(null);
   const [partyIdPrefix, setPartyIdPrefix] = useState("");
   const [peers, setPeers] = useState<Peer[]>([]);
@@ -77,6 +80,7 @@ export const OnboardingDialog = ({
   useEffect(() => {
     if (!open) {
       setError(null);
+      setMeshErrors(null);
       setStatus(null);
       setLoading(false);
       setPartyIdPrefix("");
@@ -146,6 +150,7 @@ export const OnboardingDialog = ({
 
     setLoading(true);
     setError(null);
+    setMeshErrors(null);
 
     try {
       const res = await authenticatedFetch(`${API_BASE}/onboarding`, {
@@ -158,7 +163,17 @@ export const OnboardingDialog = ({
       });
 
       if (!res.ok) {
-        const data = await res.json();
+        const data = await res.json().catch(() => ({}));
+        if (
+          res.status === 422 &&
+          Array.isArray(data.missing_edges) &&
+          data.missing_edges.length > 0
+        ) {
+          setMeshErrors(data.missing_edges);
+          setError(data.error || "Selected peers are not mutually connected");
+          setLoading(false);
+          return;
+        }
         throw new Error(data.error || "Failed to start onboarding workflow");
       }
 
@@ -174,6 +189,25 @@ export const OnboardingDialog = ({
       onClose();
     }
   };
+
+  const peerName = (id: string) =>
+    peers.find((p) => p.participant_id === id)?.name || id;
+
+  // Group missing directed edges by the node that needs to be edited.
+  // The user's task on `from` = add each `to` to its network config.
+  const groupedMissing = (() => {
+    if (!meshErrors) return [] as Array<{ node: string; missing: string[] }>;
+    const map = new Map<string, string[]>();
+    for (const edge of meshErrors) {
+      const list = map.get(edge.from) ?? [];
+      list.push(edge.to);
+      map.set(edge.from, list);
+    }
+    return Array.from(map.entries()).map(([node, missing]) => ({
+      node,
+      missing,
+    }));
+  })();
 
   return (
     <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
@@ -239,7 +273,43 @@ export const OnboardingDialog = ({
             )}
           </Box>
 
-          {error && <Alert severity="error">{error}</Alert>}
+          {error && !meshErrors && <Alert severity="error">{error}</Alert>}
+
+          {meshErrors && (
+            <Alert severity="error">
+              <Typography variant="body2" sx={{ fontWeight: 600, mb: 1 }}>
+                Update network configs:
+              </Typography>
+              <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+                {groupedMissing.map(({ node, missing }, i) => (
+                  <Box key={i}>
+                    <Typography variant="body2">
+                      On <strong>{peerName(node)}</strong>, add:
+                    </Typography>
+                    <Box component="ul" sx={{ pl: 2.5, m: 0 }}>
+                      {missing.map((toId, j) => (
+                        <Typography
+                          component="li"
+                          variant="body2"
+                          key={j}
+                          color="text.secondary"
+                        >
+                          {peerName(toId)}
+                        </Typography>
+                      ))}
+                    </Box>
+                  </Box>
+                ))}
+              </Box>
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{ display: "block", mt: 1 }}
+              >
+                Then retry.
+              </Typography>
+            </Alert>
+          )}
 
           {status?.status === "inprogress" && (
             <Alert severity="info" icon={<CircularProgress size={20} />}>

--- a/frontend/src/components/OnboardingDialog.tsx
+++ b/frontend/src/components/OnboardingDialog.tsx
@@ -54,18 +54,23 @@ export const OnboardingDialog = ({
             authenticatedFetch(`${API_BASE}/network-config`),
             authenticatedFetch(`${API_BASE}/node-config`),
           ]);
-          if (networkRes.ok) {
-            const data = await networkRes.json();
-            setPeers(data.peers || []);
-            // Select all peers by default
-            const allPeerIds = new Set<string>(
-              (data.peers || []).map((p: Peer) => p.participant_id),
-            );
-            setSelectedPeerIds(allPeerIds);
-          }
+          let self: string | null = null;
           if (nodeRes.ok) {
             const nodeData: NodeConfig = await nodeRes.json();
-            setSelfNodeId(nodeData.node.participant_id);
+            self = nodeData.node.participant_id;
+            setSelfNodeId(self);
+          }
+          if (networkRes.ok) {
+            const data = await networkRes.json();
+            const allPeers: Peer[] = data.peers || [];
+            setPeers(allPeers);
+            // Select all peers by default, excluding self
+            const allPeerIds = new Set<string>(
+              allPeers
+                .filter((p) => p.participant_id !== self)
+                .map((p) => p.participant_id),
+            );
+            setSelectedPeerIds(allPeerIds);
           }
         } catch {
           // Ignore fetch errors
@@ -100,9 +105,9 @@ export const OnboardingDialog = ({
     });
   };
 
-  // Filter out self from peer list (compare prefix of participant_id with selfNodeId)
+  // Filter out self from peer list (compare full canton ids).
   const selectablePeers = peers.filter(
-    (p) => p.participant_id.split("::")[0] !== selfNodeId,
+    (p) => p.participant_id !== selfNodeId,
   );
 
   const pollStatus = useCallback(async () => {

--- a/frontend/src/components/PackagesPanel.tsx
+++ b/frontend/src/components/PackagesPanel.tsx
@@ -33,11 +33,15 @@ import type {
 interface PackagesPanelProps {
   onUploadDars?: () => void;
   onDistributeDars?: () => void;
+  /// Bumped by the parent after a DAR upload/distribute completes, to trigger
+  /// a fresh fetch of the vetted-packages list without a manual refresh.
+  refreshNonce?: number;
 }
 
 export const PackagesPanel = ({
   onUploadDars,
   onDistributeDars,
+  refreshNonce,
 }: PackagesPanelProps) => {
   const [packages, setPackages] = useState<VettedPackageInfo[]>([]);
   const [loadingPackages, setLoadingPackages] = useState(true);
@@ -49,7 +53,7 @@ export const PackagesPanel = ({
       .then((data: VettedPackageInfo[]) => setPackages(data))
       .catch(() => {})
       .finally(() => setLoadingPackages(false));
-  }, []);
+  }, [refreshNonce]);
   const [canScrollUp, setCanScrollUp] = useState(false);
   const [canScrollDown, setCanScrollDown] = useState(false);
   const [comparison, setComparison] = useState<PeerPackageComparison | null>(

--- a/frontend/src/components/PackagesPanel.tsx
+++ b/frontend/src/components/PackagesPanel.tsx
@@ -10,8 +10,11 @@ import {
   TableCell,
   Button,
   CircularProgress,
+  TextField,
   Tooltip,
+  InputAdornment,
 } from "@mui/material";
+import SearchIcon from "@mui/icons-material/Search";
 import CloudUploadIcon from "@mui/icons-material/CloudUpload";
 import CompareArrowsIcon from "@mui/icons-material/CompareArrows";
 import SignalWifiOffIcon from "@mui/icons-material/SignalWifiOff";
@@ -53,6 +56,7 @@ export const PackagesPanel = ({
     null,
   );
   const [comparing, setComparing] = useState(false);
+  const [search, setSearch] = useState("");
   const scrollRef = useRef<HTMLDivElement>(null);
 
   const sorted = useMemo(
@@ -68,6 +72,25 @@ export const PackagesPanel = ({
       }),
     [packages],
   );
+
+  const filteredSorted = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return sorted;
+    return sorted.filter(
+      (p) =>
+        (p.package_name || "").toLowerCase().includes(q) ||
+        (p.package_id || "").toLowerCase().includes(q),
+    );
+  }, [sorted, search]);
+
+  const filteredComparison = useMemo(() => {
+    if (!comparison) return null;
+    const q = search.trim().toLowerCase();
+    if (!q) return comparison.local_packages;
+    return comparison.local_packages.filter((p) =>
+      (p.name || "").toLowerCase().includes(q),
+    );
+  }, [comparison, search]);
 
   const updateScrollShadows = useCallback(() => {
     const el = scrollRef.current;
@@ -142,10 +165,28 @@ export const PackagesPanel = ({
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", flex: 1, minHeight: 0 }}>
-      <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mb: 2, flexShrink: 0, px: 3, pt: 2 }}>
-        <Box>
-          <Typography variant="body2" color="text.secondary">
-            {`${packages.length} packages vetted on this participant`}
+      <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 2, mb: 2, flexShrink: 0, px: 3, pt: 2 }}>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 2, flex: 1, minWidth: 0 }}>
+          <TextField
+            size="small"
+            placeholder="Search packages"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            slotProps={{
+              input: {
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <SearchIcon fontSize="small" />
+                  </InputAdornment>
+                ),
+              },
+            }}
+            sx={{ width: 280 }}
+          />
+          <Typography variant="body2" color="text.secondary" noWrap>
+            {search.trim()
+              ? `${comparison ? (filteredComparison?.length ?? 0) : filteredSorted.length} of ${comparison ? comparison.local_packages.length : packages.length} packages`
+              : `${packages.length} packages vetted on this participant`}
           </Typography>
         </Box>
         <Box sx={{ display: "flex", gap: 1 }}>
@@ -276,7 +317,7 @@ export const PackagesPanel = ({
                   </TableRow>
                 </TableHead>
                 <TableBody>
-                  {comparison.local_packages
+                  {(filteredComparison ?? [])
                     .slice()
                     .sort((a, b) => a.name.localeCompare(b.name))
                     .map((pkg, idx) => (
@@ -343,7 +384,7 @@ export const PackagesPanel = ({
                   </TableRow>
                 </TableHead>
                 <TableBody>
-                  {sorted.map((p, idx) => (
+                  {filteredSorted.map((p, idx) => (
                     <TableRow key={p.package_id} sx={zebraRow(idx)}>
                       <TableCell sx={{ py: 1 }}>
                         {p.package_name || "-"}

--- a/frontend/src/components/PackagesPanel.tsx
+++ b/frontend/src/components/PackagesPanel.tsx
@@ -304,9 +304,11 @@ export const PackagesPanel = ({
                               }}
                             >
                               {status === "match" && (
-                                <CheckCircleIcon
-                                  sx={{ fontSize: 16, color: "success.main" }}
-                                />
+                                <Tooltip title="Matches local package" arrow>
+                                  <CheckCircleIcon
+                                    sx={{ fontSize: 16, color: "success.main" }}
+                                  />
+                                </Tooltip>
                               )}
                               {status === "mismatch" && (
                                 <Tooltip title="Missing or version mismatch" arrow>

--- a/frontend/src/components/PartyConfigDialog.tsx
+++ b/frontend/src/components/PartyConfigDialog.tsx
@@ -40,6 +40,8 @@ export const PartyConfigDialog = ({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
+  const [discovering, setDiscovering] = useState(false);
+  const [discoverInfo, setDiscoverInfo] = useState<string | null>(null);
 
   const [memberPartyId, setMemberPartyId] = useState("");
   const [userId, setUserId] = useState("");
@@ -87,6 +89,7 @@ export const PartyConfigDialog = ({
     if (open) {
       setError(null);
       setSuccess(false);
+      setDiscoverInfo(null);
       fetchConfig();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -101,7 +104,7 @@ export const PartyConfigDialog = ({
       if (res.ok) {
         const data: PartyConfigResponse = await res.json();
         setMemberPartyId(data.member_party_id ?? "");
-        setUserId(data.user_id);
+        setUserId(data.user_id ?? "");
         setKeycloakUrl(data.keycloak_url);
         setKeycloakRealm(data.keycloak_realm);
         setKeycloakClientId(data.keycloak_client_id);
@@ -118,6 +121,74 @@ export const PartyConfigDialog = ({
       // Config not found, fields stay empty
     } finally {
       setLoading(false);
+    }
+  };
+
+  const canDiscover = (() => {
+    if (
+      !keycloakUrl.trim() ||
+      !keycloakRealm.trim() ||
+      !keycloakClientId.trim()
+    ) {
+      return false;
+    }
+    if (authMethod === "client_credentials") {
+      return keycloakClientSecret.length > 0;
+    }
+    return keycloakUsername.length > 0 && keycloakPassword.length > 0;
+  })();
+
+  const handleDiscover = async () => {
+    setDiscovering(true);
+    setError(null);
+    setDiscoverInfo(null);
+    try {
+      const body: Record<string, string> = {
+        keycloak_url: keycloakUrl.trim(),
+        keycloak_realm: keycloakRealm.trim(),
+        keycloak_client_id: keycloakClientId.trim(),
+      };
+      if (authMethod === "client_credentials") {
+        body.keycloak_client_secret = keycloakClientSecret;
+      } else {
+        body.keycloak_username = keycloakUsername;
+        body.keycloak_password = keycloakPassword;
+      }
+      const res = await authenticatedFetch(
+        `${API_BASE}/party-config/discover-member-party`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        },
+      );
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        setError(data.error || "Discovery failed");
+        return;
+      }
+      const data: {
+        user_id: string;
+        primary_party?: string;
+        description?: string;
+      } = await res.json();
+      if (data.user_id) setUserId(data.user_id);
+      if (data.primary_party) {
+        setMemberPartyId(data.primary_party);
+        setDiscoverInfo(
+          data.description
+            ? `Found ${data.description}`
+            : "Member party discovered.",
+        );
+      } else {
+        setDiscoverInfo(
+          "Authenticated, but Canton has no primary party for this user. Enter the member party manually.",
+        );
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Discovery failed");
+    } finally {
+      setDiscovering(false);
     }
   };
 
@@ -319,6 +390,21 @@ export const PartyConfigDialog = ({
                   />
                 </>
               )}
+
+              <Box>
+                <Button
+                  size="small"
+                  variant="outlined"
+                  onClick={handleDiscover}
+                  disabled={!canDiscover || discovering || saving}
+                  startIcon={
+                    discovering ? <CircularProgress size={16} /> : undefined
+                  }
+                >
+                  {discovering ? "Discovering…" : "Discover Member Party"}
+                </Button>
+              </Box>
+              {discoverInfo && <Alert severity="success">{discoverInfo}</Alert>}
 
               {error && <Alert severity="error">{error}</Alert>}
               {success && (

--- a/frontend/src/components/PartyConfigDialog.tsx
+++ b/frontend/src/components/PartyConfigDialog.tsx
@@ -100,7 +100,7 @@ export const PartyConfigDialog = ({
       );
       if (res.ok) {
         const data: PartyConfigResponse = await res.json();
-        setMemberPartyId(data.member_party_id);
+        setMemberPartyId(data.member_party_id ?? "");
         setUserId(data.user_id);
         setKeycloakUrl(data.keycloak_url);
         setKeycloakRealm(data.keycloak_realm);

--- a/frontend/src/components/PartyDetail.tsx
+++ b/frontend/src/components/PartyDetail.tsx
@@ -106,6 +106,7 @@ export const PartyDetail = ({
   const [authExpanded, setAuthExpanded] = useState(true);
   const [governanceExpanded, setGovernanceExpanded] = useState(true);
   const [governanceTab, setGovernanceTab] = useState(0);
+  const [governanceRefreshNonce, setGovernanceRefreshNonce] = useState(0);
   const [canScrollUp, setCanScrollUp] = useState(false);
   const [canScrollDown, setCanScrollDown] = useState(false);
   const contractsScrollRef = useRef<HTMLDivElement>(null);
@@ -426,12 +427,18 @@ export const PartyDetail = ({
                 defaultOperatorParty={operatorParty}
                 network={network}
                 governanceType={governanceType}
+                onAfterAction={() =>
+                  setGovernanceRefreshNonce((n) => n + 1)
+                }
               />
             </Box>
           )}
           {governanceTab === 1 && (
             <Box sx={{ pl: 3 }}>
-              <GovernanceAuditTrail partyId={party.party_id} />
+              <GovernanceAuditTrail
+                partyId={party.party_id}
+                refreshNonce={governanceRefreshNonce}
+              />
             </Box>
           )}
         </CollapsibleSection>

--- a/frontend/src/components/PartyDetail.tsx
+++ b/frontend/src/components/PartyDetail.tsx
@@ -159,9 +159,11 @@ export const PartyDetail = ({
           px: 3,
         }}
       >
-        <IconButton onClick={onBack}>
-          <ArrowBackIcon />
-        </IconButton>
+        <Tooltip title="Back to parties">
+          <IconButton onClick={onBack}>
+            <ArrowBackIcon />
+          </IconButton>
+        </Tooltip>
         <CopyableText
           text={party.party_id}
           truncate={{ start: party.party_id.indexOf("::") + 18, end: 16 }}

--- a/frontend/src/components/PartyDetail.tsx
+++ b/frontend/src/components/PartyDetail.tsx
@@ -11,12 +11,11 @@ import {
   TableCell,
   TableHead,
   TableRow,
-  Tabs,
-  Tab,
   Tooltip,
   Typography,
 } from "@mui/material";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import EditIcon from "@mui/icons-material/Edit";
 import PersonRemoveIcon from "@mui/icons-material/PersonRemove";
 import UploadFileIcon from "@mui/icons-material/UploadFile";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
@@ -25,7 +24,7 @@ import { CopyableText } from "./CopyableText";
 import { KickDialog } from "./KickDialog";
 import { ContractsDialog } from "./ContractsDialog";
 import { PartyConfigDialog } from "./PartyConfigDialog";
-import { GovernanceSection } from "./GovernanceSection";
+import { GovernanceActionsDialog } from "./GovernanceActionsDialog";
 import { GovernanceAuditTrail } from "./GovernanceAuditTrail";
 import { AuthSection } from "./AuthSection";
 import { zebraRow } from "../styles";
@@ -105,24 +104,34 @@ export const PartyDetail = ({
   const [contractsExpanded, setContractsExpanded] = useState(true);
   const [authExpanded, setAuthExpanded] = useState(true);
   const [governanceExpanded, setGovernanceExpanded] = useState(true);
-  const [governanceTab, setGovernanceTab] = useState(0);
+  const [editGovContractId, setEditGovContractId] = useState<string | null>(
+    null,
+  );
   const [governanceRefreshNonce, setGovernanceRefreshNonce] = useState(0);
   const [canScrollUp, setCanScrollUp] = useState(false);
   const [canScrollDown, setCanScrollDown] = useState(false);
   const contractsScrollRef = useRef<HTMLDivElement>(null);
 
+  const isGovRulesContract = (template_id: string) =>
+    template_id.includes("VaultGovernanceRules") ||
+    template_id.includes("VaultGovernance") ||
+    template_id === "Governance.Rules:GovernanceRules";
+
   const governanceContracts =
-    party.contracts?.filter(
-      (c) =>
-        c.template_id.includes("VaultGovernanceRules") ||
-        c.template_id.includes("VaultGovernance") ||
-        c.template_id === "Governance.Rules:GovernanceRules",
-    ) ?? [];
+    party.contracts?.filter((c) => isGovRulesContract(c.template_id)) ?? [];
   const rulesContract = governanceContracts[0];
-  const governanceType =
-    rulesContract?.template_id === "Governance.Rules:GovernanceRules"
+  const governanceTypeFor = (template_id: string) =>
+    template_id === "Governance.Rules:GovernanceRules"
       ? ("core_self" as const)
       : ("vault" as const);
+  const governanceType = rulesContract
+    ? governanceTypeFor(rulesContract.template_id)
+    : ("vault" as const);
+
+  const editingContract =
+    editGovContractId != null
+      ? party.contracts?.find((c) => c.contract_id === editGovContractId)
+      : undefined;
 
   const isOwner = Boolean(party.my_owner_key);
 
@@ -342,6 +351,7 @@ export const PartyDetail = ({
                   <TableRow>
                     <TableCell sx={{ py: 1 }}>Template</TableCell>
                     <TableCell sx={{ py: 1 }}>Contract ID</TableCell>
+                    <TableCell sx={{ py: 1, width: 40 }} />
                   </TableRow>
                 </TableHead>
                 <TableBody>
@@ -356,6 +366,19 @@ export const PartyDetail = ({
                           truncate={{ start: 16, end: 16 }}
                           variant="caption"
                         />
+                      </TableCell>
+                      <TableCell sx={{ py: 1 }} align="right">
+                        {isGovRulesContract(c.template_id) && (
+                          <Tooltip title="Edit governance actions">
+                            <IconButton
+                              size="small"
+                              onClick={() => setEditGovContractId(c.contract_id)}
+                              disabled={!authStatus?.rights?.dec_party_act_as}
+                            >
+                              <EditIcon fontSize="small" />
+                            </IconButton>
+                          </Tooltip>
+                        )}
                       </TableCell>
                     </TableRow>
                   ))}
@@ -398,49 +421,19 @@ export const PartyDetail = ({
         </CollapsibleSection>
       )}
 
-      {/* Governance */}
+      {/* Audit Trail */}
       {authStatus?.rights?.dec_party_act_as && (
         <CollapsibleSection
-          title="Governance"
+          title="Audit Trail"
           expanded={governanceExpanded}
           onToggle={() => setGovernanceExpanded(!governanceExpanded)}
         >
-          <Box sx={{ px: 3 }}>
-            <Tabs
-              value={governanceTab}
-              onChange={(_e, v) => setGovernanceTab(v)}
-              sx={{ borderBottom: 1, borderColor: "divider" }}
-            >
-              <Tab label="Governance" />
-              <Tab label="Audit Trail" />
-            </Tabs>
+          <Box sx={{ pl: 3 }}>
+            <GovernanceAuditTrail
+              partyId={party.party_id}
+              refreshNonce={governanceRefreshNonce}
+            />
           </Box>
-          {governanceTab === 0 && (
-            <Box sx={{ pl: 3 }}>
-              <GovernanceSection
-                partyId={party.party_id}
-                rulesContractId={rulesContract?.contract_id}
-                governanceContractIds={governanceContracts.map(
-                  (c) => c.contract_id,
-                )}
-                memberPartyId={authStatus!.member_party_id}
-                defaultOperatorParty={operatorParty}
-                network={network}
-                governanceType={governanceType}
-                onAfterAction={() =>
-                  setGovernanceRefreshNonce((n) => n + 1)
-                }
-              />
-            </Box>
-          )}
-          {governanceTab === 1 && (
-            <Box sx={{ pl: 3 }}>
-              <GovernanceAuditTrail
-                partyId={party.party_id}
-                refreshNonce={governanceRefreshNonce}
-              />
-            </Box>
-          )}
         </CollapsibleSection>
       )}
 
@@ -482,6 +475,20 @@ export const PartyDetail = ({
         }}
         partyId={party.party_id}
       />
+
+      {editingContract && authStatus && (
+        <GovernanceActionsDialog
+          open={editGovContractId != null}
+          onClose={() => setEditGovContractId(null)}
+          partyId={party.party_id}
+          rulesContractId={editingContract.contract_id}
+          memberPartyId={authStatus.member_party_id}
+          defaultOperatorParty={operatorParty}
+          network={network}
+          governanceType={governanceTypeFor(editingContract.template_id)}
+          onAfterAction={() => setGovernanceRefreshNonce((n) => n + 1)}
+        />
+      )}
     </Box>
   );
 };

--- a/frontend/src/components/PartyList.tsx
+++ b/frontend/src/components/PartyList.tsx
@@ -6,6 +6,7 @@ import {
   TableCell,
   TableHead,
   TableRow,
+  Tooltip,
   Typography,
 } from "@mui/material";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
@@ -25,11 +26,23 @@ const AuthStatusIcon = ({ status }: { status?: PartyAuthStatus }) => {
   if (!status) return null;
   switch (status.status.status) {
     case "authenticated":
-      return <CheckCircleIcon color="success" sx={{ fontSize: 18 }} />;
+      return (
+        <Tooltip title="Authenticated">
+          <CheckCircleIcon color="success" sx={{ fontSize: 18 }} />
+        </Tooltip>
+      );
     case "mock":
-      return <ScienceIcon color="warning" sx={{ fontSize: 18 }} />;
+      return (
+        <Tooltip title="Test mode (mock authentication)">
+          <ScienceIcon color="warning" sx={{ fontSize: 18 }} />
+        </Tooltip>
+      );
     case "failed":
-      return <ErrorIcon color="error" sx={{ fontSize: 18 }} />;
+      return (
+        <Tooltip title="Authentication failed">
+          <ErrorIcon color="error" sx={{ fontSize: 18 }} />
+        </Tooltip>
+      );
     default:
       return null;
   }

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,6 +1,4 @@
 import {
-  createContext,
-  useContext,
   useEffect,
   useRef,
   useState,
@@ -19,19 +17,7 @@ import {
 } from "../auth";
 import { LoginPage } from "../components/LoginPage";
 import type { AuthConfig } from "../types";
-
-interface AuthContextValue {
-  token: string | null;
-  logout: () => void;
-}
-
-const AuthContext = createContext<AuthContextValue | null>(null);
-
-export function useAuth(): AuthContextValue {
-  const ctx = useContext(AuthContext);
-  if (!ctx) throw new Error("useAuth must be used within AuthProvider");
-  return ctx;
-}
+import { AuthContext } from "./AuthContextValue";
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [token, setTokenState] = useState<string | null>(getToken());

--- a/frontend/src/contexts/AuthContextValue.ts
+++ b/frontend/src/contexts/AuthContextValue.ts
@@ -1,0 +1,14 @@
+import { createContext, useContext } from "react";
+
+export interface AuthContextValue {
+  token: string | null;
+  logout: () => void;
+}
+
+export const AuthContext = createContext<AuthContextValue | null>(null);
+
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error("useAuth must be used within AuthProvider");
+  return ctx;
+}

--- a/frontend/src/contexts/SnackbarContext.tsx
+++ b/frontend/src/contexts/SnackbarContext.tsx
@@ -1,19 +1,6 @@
-import { createContext, useContext, useState, useCallback, type ReactNode } from "react";
+import { useState, useCallback, type ReactNode } from "react";
 import { Snackbar } from "@mui/material";
-
-interface SnackbarContextType {
-  showSnackbar: (message: string) => void;
-}
-
-const SnackbarContext = createContext<SnackbarContextType | undefined>(undefined);
-
-export const useSnackbar = () => {
-  const context = useContext(SnackbarContext);
-  if (!context) {
-    throw new Error("useSnackbar must be used within SnackbarProvider");
-  }
-  return context;
-};
+import { SnackbarContext } from "./SnackbarContextValue";
 
 interface SnackbarProviderProps {
   children: ReactNode;

--- a/frontend/src/contexts/SnackbarContextValue.ts
+++ b/frontend/src/contexts/SnackbarContextValue.ts
@@ -1,0 +1,17 @@
+import { createContext, useContext } from "react";
+
+export interface SnackbarContextType {
+  showSnackbar: (message: string) => void;
+}
+
+export const SnackbarContext = createContext<SnackbarContextType | undefined>(
+  undefined,
+);
+
+export const useSnackbar = () => {
+  const context = useContext(SnackbarContext);
+  if (!context) {
+    throw new Error("useSnackbar must be used within SnackbarProvider");
+  }
+  return context;
+};

--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -1,24 +1,7 @@
-import { createContext, useContext, useState, useEffect, useMemo, type ReactNode } from "react";
+import { useState, useEffect, useMemo, type ReactNode } from "react";
 import { ThemeProvider as MuiThemeProvider, createTheme } from "@mui/material/styles";
 import { CssBaseline } from "@mui/material";
-
-type ThemeMode = "light" | "dark" | "auto";
-
-interface ThemeContextType {
-  mode: ThemeMode;
-  setMode: (mode: ThemeMode) => void;
-  resolvedMode: "light" | "dark";
-}
-
-const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
-
-export const useThemeMode = () => {
-  const context = useContext(ThemeContext);
-  if (!context) {
-    throw new Error("useThemeMode must be used within ThemeProvider");
-  }
-  return context;
-};
+import { ThemeContext, type ThemeMode } from "./ThemeContextValue";
 
 // BitSafe Brand Colors
 // Primary: Orange #ff6633

--- a/frontend/src/contexts/ThemeContextValue.ts
+++ b/frontend/src/contexts/ThemeContextValue.ts
@@ -1,0 +1,21 @@
+import { createContext, useContext } from "react";
+
+export type ThemeMode = "light" | "dark" | "auto";
+
+export interface ThemeContextType {
+  mode: ThemeMode;
+  setMode: (mode: ThemeMode) => void;
+  resolvedMode: "light" | "dark";
+}
+
+export const ThemeContext = createContext<ThemeContextType | undefined>(
+  undefined,
+);
+
+export const useThemeMode = () => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error("useThemeMode must be used within ThemeProvider");
+  }
+  return context;
+};

--- a/frontend/src/contexts/index.ts
+++ b/frontend/src/contexts/index.ts
@@ -1,3 +1,6 @@
-export { AuthProvider, useAuth } from "./AuthContext";
-export { ThemeProvider, useThemeMode } from "./ThemeContext";
-export { SnackbarProvider, useSnackbar } from "./SnackbarContext";
+export { AuthProvider } from "./AuthContext";
+export { useAuth } from "./AuthContextValue";
+export { ThemeProvider } from "./ThemeContext";
+export { useThemeMode } from "./ThemeContextValue";
+export { SnackbarProvider } from "./SnackbarContext";
+export { useSnackbar } from "./SnackbarContextValue";

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -40,7 +40,8 @@ export interface PartyConfigRequest {
 
 export interface PartyConfigResponse {
   dec_party_id: string;
-  member_party_id: string;
+  /** Optional: backend returns null when no config has been saved yet. */
+  member_party_id?: string;
   user_id: string;
   keycloak_url: string;
   keycloak_realm: string;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -42,7 +42,8 @@ export interface PartyConfigResponse {
   dec_party_id: string;
   /** Optional: backend returns null when no config has been saved yet. */
   member_party_id?: string;
-  user_id: string;
+  /** Optional: backend returns null when no config has been saved yet. */
+  user_id?: string;
   keycloak_url: string;
   keycloak_realm: string;
   keycloak_client_id: string;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -264,6 +264,10 @@ export interface AuthTestResponse {
   results: AuthTestResult[];
 }
 
+export interface GrantRightsResponse {
+  rights: RightsStatus;
+}
+
 // Governance types
 export interface GovernanceConfirmation {
   contract_id: string;

--- a/integration-tests/env.sh
+++ b/integration-tests/env.sh
@@ -50,7 +50,6 @@ MOCK_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOiJodHRwczovL2NhbnRvbi5
 
 # Process tracking
 PIDS=()
-TEMP_FILES=()
 
 # ============================================================================
 # Logging
@@ -157,11 +156,6 @@ cleanup() {
 
     # Stop localnet
     stop_localnet
-
-    # Remove temp files
-    for f in "${TEMP_FILES[@]}"; do
-        rm -f "$f" 2>/dev/null || true
-    done
 
     # Remove temp directory
     if [ -n "$DEV_DIR" ] && [ -d "$DEV_DIR" ]; then

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -89,10 +89,12 @@ pub enum Commands {
         #[arg(long, env = "DECPM_KEYCLOAK_CLIENT_ID")]
         keycloak_client_id: Option<String>,
 
-        /// Role name that grants admin access to sensitive endpoints
-        /// (PUT /party-config, POST /kick). Defaults to "dpm-admin".
-        #[arg(long, env = "DECPM_ADMIN_ROLE", default_value = "dpm-admin")]
-        admin_role: String,
+        /// Role name that gates sensitive endpoints (PUT /party-config,
+        /// POST /kick, etc.). Unset (default) skips the role check —
+        /// every authenticated caller is treated as admin. Set this to
+        /// require a specific role for shared/multi-user nodes.
+        #[arg(long, env = "DECPM_ADMIN_ROLE")]
+        admin_role: Option<String>,
 
         /// Origin permitted by CORS (e.g. `https://dpm.example.com`).
         /// Defaults to same-origin only — set this when the SPA is served

--- a/src/noise/mod.rs
+++ b/src/noise/mod.rs
@@ -34,6 +34,7 @@ pub enum MessageType {
     Ping = 0x000A,
     ListPackages = 0x000B,
     RequestOwnerKeys = 0x000C,
+    ListPeers = 0x000D,
 
     // Invites (0x0010 - 0x001F)
     InviteOnboarding = 0x0010,
@@ -49,6 +50,7 @@ pub enum MessageType {
     Wait = 0x0105,
     Pong = 0x0106,
     OwnerKeys = 0x0107,
+    PeerList = 0x0108,
 
     // Data Transfers (0x0200 - 0x02FF)
     KeysUpload = 0x0201,
@@ -89,6 +91,7 @@ impl TryFrom<u16> for MessageType {
             0x000A => Ok(Self::Ping),
             0x000B => Ok(Self::ListPackages),
             0x000C => Ok(Self::RequestOwnerKeys),
+            0x000D => Ok(Self::ListPeers),
             0x0010 => Ok(Self::InviteOnboarding),
             0x0011 => Ok(Self::InviteKick),
             0x0012 => Ok(Self::InviteContracts),
@@ -100,6 +103,7 @@ impl TryFrom<u16> for MessageType {
             0x0105 => Ok(Self::Wait),
             0x0106 => Ok(Self::Pong),
             0x0107 => Ok(Self::OwnerKeys),
+            0x0108 => Ok(Self::PeerList),
             0x0201 => Ok(Self::KeysUpload),
             0x0202 => Ok(Self::DnsSignature),
             0x0203 => Ok(Self::P2pSignatures),

--- a/src/noise/mod.rs
+++ b/src/noise/mod.rs
@@ -35,6 +35,7 @@ pub enum MessageType {
     ListPackages = 0x000B,
     RequestOwnerKeys = 0x000C,
     ListPeers = 0x000D,
+    RequestMemberParty = 0x000E,
 
     // Invites (0x0010 - 0x001F)
     InviteOnboarding = 0x0010,
@@ -51,6 +52,7 @@ pub enum MessageType {
     Pong = 0x0106,
     OwnerKeys = 0x0107,
     PeerList = 0x0108,
+    MemberPartyResponse = 0x0109,
 
     // Data Transfers (0x0200 - 0x02FF)
     KeysUpload = 0x0201,
@@ -92,6 +94,7 @@ impl TryFrom<u16> for MessageType {
             0x000B => Ok(Self::ListPackages),
             0x000C => Ok(Self::RequestOwnerKeys),
             0x000D => Ok(Self::ListPeers),
+            0x000E => Ok(Self::RequestMemberParty),
             0x0010 => Ok(Self::InviteOnboarding),
             0x0011 => Ok(Self::InviteKick),
             0x0012 => Ok(Self::InviteContracts),
@@ -104,6 +107,7 @@ impl TryFrom<u16> for MessageType {
             0x0106 => Ok(Self::Pong),
             0x0107 => Ok(Self::OwnerKeys),
             0x0108 => Ok(Self::PeerList),
+            0x0109 => Ok(Self::MemberPartyResponse),
             0x0201 => Ok(Self::KeysUpload),
             0x0202 => Ok(Self::DnsSignature),
             0x0203 => Ok(Self::P2pSignatures),

--- a/src/server/handlers/auth.rs
+++ b/src/server/handlers/auth.rs
@@ -354,9 +354,12 @@ pub async fn grant_rights(
     {
         Ok(resp) => resp.access_token,
         Err(e) => {
-            tracing::warn!("Failed to mint admin token for grant-rights: {e}");
+            // Full chain to logs (the keycloak crate's Display can include
+            // request URL / response body — keep it server-side); generic
+            // message in the response so we don't surface reflected secrets.
+            tracing::warn!("Failed to mint admin token for grant-rights: {e:#}");
             return HttpResponse::Unauthorized().json(ErrorResponse {
-                error: format!("Admin Keycloak auth failed: {e}"),
+                error: "Admin Keycloak auth failed".into(),
             });
         }
     };
@@ -375,7 +378,7 @@ pub async fn grant_rights(
         Err(e) => {
             tracing::error!("Failed to grant rights: {e:#}");
             HttpResponse::InternalServerError().json(ErrorResponse {
-                error: format!("Failed to grant rights: {e}"),
+                error: "Failed to grant rights".into(),
             })
         }
     }
@@ -474,5 +477,140 @@ async fn test_keycloak_auth(
         .await
         .map(|_| ())
         .map_err(|e| e.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::{HashMap, HashSet},
+        sync::Arc,
+    };
+
+    use actix_web::{
+        App,
+        http::{StatusCode, header::AUTHORIZATION},
+        test::{self, TestRequest},
+        web::Data,
+    };
+    use serde_json::{Value, json};
+    use sqlx::SqlitePool;
+    use tokio::sync::{Mutex, Notify, RwLock};
+
+    use super::grant_rights;
+    use crate::{
+        auth::{MockAuthRegistry, MockValidator, TokenValidator, WorkflowAuth},
+        config::NodeConfig,
+        server::{AppState, ListenerControl, middleware::AuthMiddleware},
+    };
+
+    /// Build an `AppState` configured for handler-level tests:
+    /// - in-memory sqlite (no migrations needed for grant_rights paths)
+    /// - `MockValidator` accepts any token, mints an "admin"-roled principal
+    /// - `WorkflowAuth::Mock` so `grant_rights` hits its test-mode short-circuit
+    /// - `admin_role` is configurable so the require-admin gate can be exercised
+    async fn build_state(admin_role: Option<&str>) -> Data<AppState> {
+        let db = SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite");
+        let party_credentials = Arc::new(RwLock::new(Vec::new()));
+        Data::new(AppState {
+            db,
+            config: NodeConfig::default(),
+            peer_status: Arc::new(RwLock::new(HashMap::new())),
+            noise_listener_control: Arc::new(RwLock::new(ListenerControl {
+                should_pause: false,
+            })),
+            noise_listener_notify: Arc::new(Notify::new()),
+            onboarding_trigger: Arc::new(Notify::new()),
+            kick_trigger: Arc::new(Notify::new()),
+            contracts_trigger: Arc::new(Notify::new()),
+            dars_trigger: Arc::new(Notify::new()),
+            coordinator_pubkey: Arc::new(RwLock::new(None)),
+            pending_invitations: Arc::new(RwLock::new(Vec::new())),
+            auth: Arc::new(RwLock::new(Some(WorkflowAuth::Mock(Arc::new(
+                MockAuthRegistry::new(party_credentials.clone()),
+            ))))),
+            token_validator: TokenValidator::Mock(Arc::new(MockValidator::new(
+                "decman-admin".to_string(),
+            ))),
+            admin_role: admin_role.map(str::to_string),
+            party_credentials,
+            bootstrap_mu: Arc::new(Mutex::new(())),
+            test_mode: true,
+            refreshing_prefixes: Arc::new(RwLock::new(HashSet::new())),
+        })
+    }
+
+    /// `dec_party_id` deserializes via `CantonId::parse`, which requires a
+    /// `prefix::<68-hex-char namespace>` shape (34 bytes). Pin a fixed valid
+    /// value so the JSON extractor doesn't 400 before the handler runs.
+    const VALID_CANTON_ID: &str =
+        "test-network::12200000000000000000000000000000000000000000000000000000000000000000";
+
+    /// In mock mode, `grant_rights` short-circuits and returns canned
+    /// `RightsStatus` with all four rights `true`. This proves the handler
+    /// is reachable and the security-sensitive Keycloak path is bypassed
+    /// when we tell it to be — operators running with `--features test-mode`
+    /// rely on this for swagger and CI smoke tests.
+    #[actix_web::test]
+    async fn grant_rights_mock_mode_returns_canned_rights() {
+        let state = build_state(None).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(state)
+                .wrap(AuthMiddleware)
+                .service(grant_rights),
+        )
+        .await;
+        let req = TestRequest::post()
+            .uri("/auth/grant-rights")
+            .insert_header((AUTHORIZATION, "Bearer any-token"))
+            .set_json(json!({
+                "dec_party_id": VALID_CANTON_ID,
+                "admin_client_id": "validator-admin",
+                "admin_client_secret": "secret",
+            }))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: Value = test::read_body_json(resp).await;
+        let rights = body
+            .get("rights")
+            .expect("response carries `rights` object");
+        for field in [
+            "member_party_act_as",
+            "member_party_read_as",
+            "dec_party_act_as",
+            "dec_party_read_as",
+        ] {
+            assert_eq!(
+                rights.get(field),
+                Some(&Value::Bool(true)),
+                "expected canned `{field}: true` in mock-mode RightsStatus, got {body}"
+            );
+        }
+    }
+
+    /// `require_admin` rejects requests that arrive without a `Principal`
+    /// attached. We skip the `AuthMiddleware` wrap here so no principal is
+    /// injected — that's the production path when a request slips past auth
+    /// (e.g. middleware misconfigured) and the handler is the last line of
+    /// defense. With `admin_role = Some(...)`, the response is 401 from
+    /// `require_admin`'s own guard, before any body validation runs.
+    #[actix_web::test]
+    async fn grant_rights_rejects_request_without_principal() {
+        let state = build_state(Some("decman-admin")).await;
+        let app = test::init_service(App::new().app_data(state).service(grant_rights)).await;
+        let req = TestRequest::post()
+            .uri("/auth/grant-rights")
+            .set_json(json!({
+                "dec_party_id": VALID_CANTON_ID,
+                "admin_client_id": "validator-admin",
+                "admin_client_secret": "secret",
+            }))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
     }
 }

--- a/src/server/handlers/auth.rs
+++ b/src/server/handlers/auth.rs
@@ -1,9 +1,10 @@
-use actix_web::{HttpResponse, Responder, get, post, web};
+use actix_web::{HttpRequest, HttpResponse, Responder, get, post, web};
 use base64::Engine;
 use canton_proto_rs::com::daml::ledger::api::v2::admin::{
-    ListUserRightsRequest,
+    GrantUserRightsRequest, ListUserRightsRequest, Right,
     right::{CanActAs, CanReadAs, Kind},
 };
+use keycloak::login::{ClientCredentialsParams, client_credentials, password_url};
 
 use crate::{
     auth::WorkflowAuth,
@@ -11,9 +12,10 @@ use crate::{
     error::Result,
     server::{
         AppState,
+        middleware::require_admin,
         types::{
             AuthConfigResponse, AuthStatus, AuthStatusResponse, AuthTestResponse, AuthTestResult,
-            PartyAuthStatus, RightsStatus,
+            ErrorResponse, GrantRightsRequest, GrantRightsResponse, PartyAuthStatus, RightsStatus,
         },
     },
     utils,
@@ -255,6 +257,187 @@ pub async fn test_auth(data: web::Data<AppState>) -> impl Responder {
     }
 
     HttpResponse::Ok().json(AuthTestResponse { results })
+}
+
+/// Grant actAs + readAs rights on the member party and the dec party to the
+/// configured coordinator user, using the participant admin API
+#[utoipa::path(
+    tag = "Authentication",
+    request_body = GrantRightsRequest,
+    responses(
+        (status = 200, description = "Rights granted; current rights returned", body = GrantRightsResponse),
+        (status = 400, description = "Bad request", body = ErrorResponse),
+        (status = 404, description = "Party not configured", body = ErrorResponse),
+        (status = 500, description = "Grant failed", body = ErrorResponse)
+    )
+)]
+#[post("/auth/grant-rights")]
+pub async fn grant_rights(
+    http_req: HttpRequest,
+    data: web::Data<AppState>,
+    body: web::Json<GrantRightsRequest>,
+) -> impl Responder {
+    if let Err(resp) = require_admin(&http_req, data.admin_role.as_deref()) {
+        return resp;
+    }
+
+    let admin_client_id = body.admin_client_id.trim().to_string();
+    let admin_client_secret = body.admin_client_secret.trim().to_string();
+    if admin_client_id.is_empty() || admin_client_secret.is_empty() {
+        return HttpResponse::BadRequest().json(ErrorResponse {
+            error: "admin_client_id and admin_client_secret are required".to_string(),
+        });
+    }
+
+    let auth = data.auth.read().await;
+    if matches!(*auth, Some(WorkflowAuth::Mock(_))) {
+        return HttpResponse::Ok().json(GrantRightsResponse {
+            rights: RightsStatus {
+                member_party_act_as: true,
+                member_party_read_as: true,
+                dec_party_act_as: true,
+                dec_party_read_as: true,
+            },
+        });
+    }
+
+    let party_creds_list = data.party_credentials.read().await;
+    let Some(party_creds) = party_creds_list
+        .iter()
+        .find(|c| c.dec_party_id == body.dec_party_id)
+    else {
+        return HttpResponse::NotFound().json(ErrorResponse {
+            error: format!(
+                "Party {dec_party_id} is not configured",
+                dec_party_id = body.dec_party_id
+            ),
+        });
+    };
+
+    let party_token = match &*auth {
+        Some(WorkflowAuth::Keycloak(registry)) => match registry.get(&party_creds.dec_party_id) {
+            Some(tm) => match tm.get_token().await {
+                Ok(t) => t,
+                Err(e) => {
+                    return HttpResponse::InternalServerError().json(ErrorResponse {
+                        error: format!("Failed to get auth token: {e}"),
+                    });
+                }
+            },
+            None => {
+                return HttpResponse::InternalServerError().json(ErrorResponse {
+                    error: "No token manager configured for this party".to_string(),
+                });
+            }
+        },
+        _ => {
+            return HttpResponse::InternalServerError().json(ErrorResponse {
+                error: "Auth not configured".to_string(),
+            });
+        }
+    };
+
+    let member_party_id = party_creds.member_party_id.to_string();
+    let dec_party_id = party_creds.dec_party_id.to_string();
+    let user_id = party_creds.user_id.clone();
+    let token_url = password_url(&party_creds.keycloak.url, &party_creds.keycloak.realm);
+
+    drop(party_creds_list);
+    drop(auth);
+
+    let admin_token = match client_credentials(ClientCredentialsParams {
+        url: token_url,
+        client_id: admin_client_id,
+        client_secret: admin_client_secret,
+    })
+    .await
+    {
+        Ok(resp) => resp.access_token,
+        Err(e) => {
+            tracing::warn!("Failed to mint admin token for grant-rights: {e}");
+            return HttpResponse::Unauthorized().json(ErrorResponse {
+                error: format!("Admin Keycloak auth failed: {e}"),
+            });
+        }
+    };
+
+    match grant_user_rights(
+        &data.config,
+        &admin_token,
+        &party_token,
+        &user_id,
+        &member_party_id,
+        &dec_party_id,
+    )
+    .await
+    {
+        Ok(rights) => HttpResponse::Ok().json(GrantRightsResponse { rights }),
+        Err(e) => {
+            tracing::error!("Failed to grant rights: {e:#}");
+            HttpResponse::InternalServerError().json(ErrorResponse {
+                error: format!("Failed to grant rights: {e}"),
+            })
+        }
+    }
+}
+
+/// Grant actAs+readAs for both parties to the user using the admin token,
+/// then re-check rights using the per-party token (read-only).
+async fn grant_user_rights(
+    config: &NodeConfig,
+    admin_token: &str,
+    party_token: &str,
+    user_id: &str,
+    member_party_id: &str,
+    dec_party_id: &str,
+) -> Result<RightsStatus> {
+    let mut client = utils::create_user_client(config, Some(admin_token.to_string())).await?;
+
+    let effective_user_id =
+        extract_user_id_from_jwt(party_token).unwrap_or_else(|| user_id.to_string());
+
+    tracing::info!(
+        "Granting rights for user_id={effective_user_id}, member_party={member_party_id}, dec_party={dec_party_id}"
+    );
+
+    let rights = vec![
+        right_act_as(member_party_id),
+        right_read_as(member_party_id),
+        right_act_as(dec_party_id),
+        right_read_as(dec_party_id),
+    ];
+
+    let response = client
+        .grant_user_rights(tonic::Request::new(GrantUserRightsRequest {
+            user_id: effective_user_id.clone(),
+            rights,
+            identity_provider_id: String::new(),
+        }))
+        .await?
+        .into_inner();
+
+    tracing::info!(
+        "GrantUserRights newly granted {count} right(s)",
+        count = response.newly_granted_rights.len()
+    );
+
+    check_user_rights(config, party_token, user_id, member_party_id, dec_party_id).await
+}
+
+fn right_act_as(party: &str) -> Right {
+    Right {
+        kind: Some(Kind::CanActAs(CanActAs {
+            party: party.to_string(),
+        })),
+    }
+}
+
+fn right_read_as(party: &str) -> Right {
+    Right {
+        kind: Some(Kind::CanReadAs(CanReadAs {
+            party: party.to_string(),
+        })),
+    }
 }
 
 async fn test_keycloak_auth(

--- a/src/server/handlers/governance.rs
+++ b/src/server/handlers/governance.rs
@@ -17,9 +17,10 @@ use serde::Deserialize;
 
 use crate::{
     auth::WorkflowAuth,
-    config::{NodeConfig, PackageConfig, default_package_config},
+    config::{NetworkConfig, NodeConfig, PackageConfig, default_package_config},
     db::schema::SchemaRead,
     error::Result,
+    noise::{Message, MessageType, NoiseKeypair, parse_public_key, send_noise_message},
     participant_id::CantonId,
     server::{
         AppState, action_serializer,
@@ -34,9 +35,10 @@ use crate::{
             AuditLogEntry, AuditLogQuery, AuditLogResponse, CancelConfirmationRequest,
             ChainAuditEntry, ChainAuditQuery, ChainAuditResponse, ConfirmActionRequest,
             ContractQueryResponse, ErrorResponse, ExecuteActionRequest, ExpireConfirmationRequest,
-            GovernanceResponse, GovernanceStateResponse, GovernanceType, MessageResponse,
-            NetworkInfo, ProposeActionRequest, ProviderServicesResponse, RegistrarServicesResponse,
-            UserServicesResponse, VaultsResponse,
+            GovernanceResponse, GovernanceStateResponse, GovernanceType, KnownMember,
+            KnownMembersResponse, MessageResponse, NetworkInfo, ProposeActionRequest,
+            ProviderServicesResponse, RegistrarServicesResponse, UserServicesResponse,
+            VaultsResponse,
         },
     },
     utils,
@@ -148,6 +150,124 @@ pub async fn get_governance_state(
             })
         }
     }
+}
+
+#[utoipa::path(
+    tag = "Governance",
+    params(GovernanceQuery),
+    responses(
+        (status = 200, description = "Member parties known to each participant", body = KnownMembersResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    )
+)]
+#[get("/governance/known-members")]
+pub async fn get_known_members(
+    data: web::Data<AppState>,
+    query: web::Query<GovernanceQuery>,
+) -> impl Responder {
+    match collect_known_members(&data, &query.party_id).await {
+        Ok(members) => HttpResponse::Ok().json(KnownMembersResponse { members }),
+        Err(e) => {
+            tracing::error!("Failed to collect known members: {e:#}");
+            HttpResponse::InternalServerError().json(ErrorResponse {
+                error: format!("Failed to collect known members: {e}"),
+            })
+        }
+    }
+}
+
+async fn collect_known_members(
+    data: &web::Data<AppState>,
+    dec_party_id: &CantonId,
+) -> Result<Vec<KnownMember>> {
+    let dec_party_str = dec_party_id.to_string();
+    let network_config = NetworkConfig::from_peers(data.db.get_all_peers().await?);
+    let keypair = NoiseKeypair::from_file(&data.config.key_file_path()).await?;
+    let identity = data.config.participant_id().to_string();
+    let request = Message::new(
+        MessageType::RequestMemberParty,
+        dec_party_str.as_bytes().to_vec(),
+    );
+
+    let mut out = Vec::new();
+
+    {
+        let creds = data.party_credentials.read().await;
+        let self_member = creds
+            .iter()
+            .find(|c| c.dec_party_id == *dec_party_id)
+            .map(|c| c.member_party_id.to_string())
+            .unwrap_or_default();
+        out.push(KnownMember {
+            participant_uid: identity.clone(),
+            member_party_id: self_member,
+        });
+    }
+
+    let self_id = data.config.participant_id();
+    for peer in &network_config.peers {
+        if peer.participant_id == *self_id {
+            continue;
+        }
+        if peer.public_key.is_empty() {
+            out.push(KnownMember {
+                participant_uid: peer.participant_id.to_string(),
+                member_party_id: String::new(),
+            });
+            continue;
+        }
+        let peer_pub_key = match parse_public_key(&peer.public_key) {
+            Ok(pk) => pk,
+            Err(e) => {
+                tracing::warn!(
+                    "Skipping member-party query to {pid}: invalid public key: {e}",
+                    pid = peer.participant_id,
+                );
+                out.push(KnownMember {
+                    participant_uid: peer.participant_id.to_string(),
+                    member_party_id: String::new(),
+                });
+                continue;
+            }
+        };
+
+        let psk = keypair.derive_psk(&peer_pub_key);
+        let response = match send_noise_message(
+            &peer.address,
+            peer.port,
+            &psk,
+            identity.as_bytes(),
+            &request,
+        )
+        .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!(
+                    "Failed to query member party from {pid}: {e}",
+                    pid = peer.participant_id,
+                );
+                out.push(KnownMember {
+                    participant_uid: peer.participant_id.to_string(),
+                    member_party_id: String::new(),
+                });
+                continue;
+            }
+        };
+
+        let member_party = match Message::from_bytes(&response) {
+            Ok(msg) if msg.msg_type == MessageType::MemberPartyResponse => {
+                String::from_utf8(msg.payload).unwrap_or_default()
+            }
+            _ => String::new(),
+        };
+        out.push(KnownMember {
+            participant_uid: peer.participant_id.to_string(),
+            member_party_id: member_party,
+        });
+    }
+
+    Ok(out)
 }
 
 /// Get deployed Vault contracts

--- a/src/server/handlers/governance.rs
+++ b/src/server/handlers/governance.rs
@@ -196,8 +196,7 @@ async fn collect_known_members(
         let self_member = creds
             .iter()
             .find(|c| c.dec_party_id == *dec_party_id)
-            .map(|c| c.member_party_id.to_string())
-            .unwrap_or_default();
+            .map(|c| c.member_party_id.clone());
         out.push(KnownMember {
             participant_uid: identity.clone(),
             member_party_id: self_member,
@@ -212,7 +211,7 @@ async fn collect_known_members(
         if peer.public_key.is_empty() {
             out.push(KnownMember {
                 participant_uid: peer.participant_id.to_string(),
-                member_party_id: String::new(),
+                member_party_id: None,
             });
             continue;
         }
@@ -225,7 +224,7 @@ async fn collect_known_members(
                 );
                 out.push(KnownMember {
                     participant_uid: peer.participant_id.to_string(),
-                    member_party_id: String::new(),
+                    member_party_id: None,
                 });
                 continue;
             }
@@ -249,7 +248,7 @@ async fn collect_known_members(
                 );
                 out.push(KnownMember {
                     participant_uid: peer.participant_id.to_string(),
-                    member_party_id: String::new(),
+                    member_party_id: None,
                 });
                 continue;
             }
@@ -257,9 +256,12 @@ async fn collect_known_members(
 
         let member_party = match Message::from_bytes(&response) {
             Ok(msg) if msg.msg_type == MessageType::MemberPartyResponse => {
-                String::from_utf8(msg.payload).unwrap_or_default()
+                String::from_utf8(msg.payload)
+                    .ok()
+                    .filter(|s| !s.is_empty())
+                    .and_then(|s| CantonId::parse(&s).ok())
             }
-            _ => String::new(),
+            _ => None,
         };
         out.push(KnownMember {
             participant_uid: peer.participant_id.to_string(),

--- a/src/server/handlers/mod.rs
+++ b/src/server/handlers/mod.rs
@@ -7,7 +7,7 @@ mod parties;
 mod party_config;
 mod workflows;
 
-pub use auth::{get_auth_config, get_auth_status, test_auth};
+pub use auth::{get_auth_config, get_auth_status, grant_rights, test_auth};
 pub use config::{get_network_config, get_node_config, save_network_config};
 pub use governance::{
     cancel_confirmation, confirm_action, execute_action, expire_confirmation, get_governance,

--- a/src/server/handlers/mod.rs
+++ b/src/server/handlers/mod.rs
@@ -23,7 +23,7 @@ pub use parties::{
     get_participants_status, get_vetted_packages, resolve_owner_keys_from_peers,
     store_parties_to_db,
 };
-pub use party_config::{get_party_config, save_party_config};
+pub use party_config::{discover_member_party, get_party_config, save_party_config};
 pub use workflows::{
     ContractsWorkflowState, DarsWorkflowState, KickWorkflowState, OnboardingWorkflowState,
     get_contracts_status, get_dars_status, get_kick_status, get_onboarding_status, start_contracts,

--- a/src/server/handlers/mod.rs
+++ b/src/server/handlers/mod.rs
@@ -11,8 +11,8 @@ pub use auth::{get_auth_config, get_auth_status, grant_rights, test_auth};
 pub use config::{get_network_config, get_node_config, save_network_config};
 pub use governance::{
     cancel_confirmation, confirm_action, execute_action, expire_confirmation, get_governance,
-    get_governance_audit, get_governance_chain_audit, get_governance_state, get_network_info,
-    get_packages, get_provider_services_handler, get_registrar_services_handler,
+    get_governance_audit, get_governance_chain_audit, get_governance_state, get_known_members,
+    get_network_info, get_packages, get_provider_services_handler, get_registrar_services_handler,
     get_token_standard_contracts, get_user_services_handler, get_vaults_handler, propose_action,
     query_contracts_handler,
 };

--- a/src/server/handlers/parties.rs
+++ b/src/server/handlers/parties.rs
@@ -48,6 +48,11 @@ pub struct PartiesQuery {
     /// Filter parties by prefix (e.g., "cbtc-network")
     #[serde(default)]
     pub prefix: Option<String>,
+    /// Force a synchronous Canton fetch, bypassing the cache. Used right after
+    /// mutating workflows (kick / contracts / dars) so the UI sees fresh data
+    /// instead of the up-to-60s-stale cached snapshot.
+    #[serde(default)]
+    pub refresh: Option<bool>,
 }
 
 /// Get decentralized parties the current participant is a member of
@@ -65,9 +70,14 @@ pub async fn get_decentralized_parties(
     query: web::Query<PartiesQuery>,
 ) -> impl Responder {
     let prefix = query.prefix.clone().unwrap_or_default();
+    let force_refresh = query.refresh.unwrap_or(false);
 
-    // Try to load from DB cache first
-    let cached = load_cached_parties(&data.db, &prefix).await;
+    // Try to load from DB cache first (unless caller explicitly demanded fresh)
+    let cached = if force_refresh {
+        Ok(None)
+    } else {
+        load_cached_parties(&data.db, &prefix).await
+    };
     if let Ok(Some((mut response, updated_at))) = cached {
         response.source = ResponseSource::Cache;
 

--- a/src/server/handlers/party_config.rs
+++ b/src/server/handlers/party_config.rs
@@ -107,7 +107,7 @@ pub async fn save_party_config(
     // through unauthenticated. Once any party credential exists, require the
     // caller to carry the admin role.
     let is_fresh = data.party_credentials.read().await.is_empty();
-    if !is_fresh && let Err(resp) = require_admin(&http_req, &data.admin_role) {
+    if !is_fresh && let Err(resp) = require_admin(&http_req, data.admin_role.as_deref()) {
         return resp;
     }
 

--- a/src/server/handlers/party_config.rs
+++ b/src/server/handlers/party_config.rs
@@ -47,7 +47,7 @@ pub async fn get_party_config(
     match creds {
         Some(c) => HttpResponse::Ok().json(PartyConfigResponse {
             dec_party_id: c.dec_party_id.clone(),
-            member_party_id: c.member_party_id.clone(),
+            member_party_id: Some(c.member_party_id.clone()),
             user_id: c.user_id.clone(),
             keycloak_url: c.keycloak.url.clone(),
             keycloak_realm: c.keycloak.realm.clone(),
@@ -61,8 +61,8 @@ pub async fn get_party_config(
             let kc_defaults = data.config.canton.network.keycloak_defaults();
             let packages = default_package_config();
             HttpResponse::Ok().json(PartyConfigResponse {
-                dec_party_id: dec_party_id.clone(),
-                member_party_id: dec_party_id,
+                dec_party_id,
+                member_party_id: None,
                 user_id: "CoordinatorUser".to_string(),
                 keycloak_url: kc_defaults.url,
                 keycloak_realm: kc_defaults.realm,

--- a/src/server/handlers/party_config.rs
+++ b/src/server/handlers/party_config.rs
@@ -277,8 +277,12 @@ pub async fn discover_member_party(
     let token = match token_result {
         Ok(resp) => resp.access_token,
         Err(e) => {
+            // Full chain to logs (keycloak Display can echo request URL or
+            // response body); generic message to clients so we don't surface
+            // reflected creds.
+            tracing::warn!("Keycloak auth failed during member-party discovery: {e:#}");
             return HttpResponse::Unauthorized().json(ErrorResponse {
-                error: format!("Keycloak auth failed: {e}"),
+                error: "Keycloak auth failed".into(),
             });
         }
     };
@@ -286,8 +290,9 @@ pub async fn discover_member_party(
     let mut client = match utils::create_user_client(&data.config, Some(token)).await {
         Ok(c) => c,
         Err(e) => {
+            tracing::error!("Failed to create user client: {e:#}");
             return HttpResponse::InternalServerError().json(ErrorResponse {
-                error: format!("Failed to create user client: {e}"),
+                error: "Failed to create user client".into(),
             });
         }
     };
@@ -301,8 +306,9 @@ pub async fn discover_member_party(
     {
         Ok(r) => r.into_inner(),
         Err(e) => {
+            tracing::error!("Canton GetUser failed: {e:#}");
             return HttpResponse::InternalServerError().json(ErrorResponse {
-                error: format!("Canton GetUser failed: {e}"),
+                error: "Canton GetUser failed".into(),
             });
         }
     };
@@ -330,4 +336,82 @@ pub async fn discover_member_party(
         primary_party,
         description,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::{HashMap, HashSet},
+        sync::Arc,
+    };
+
+    use actix_web::{
+        App,
+        http::StatusCode,
+        test::{self, TestRequest},
+        web::Data,
+    };
+    use serde_json::json;
+    use sqlx::SqlitePool;
+    use tokio::sync::{Mutex, Notify, RwLock};
+
+    use super::discover_member_party;
+    use crate::{
+        auth::{MockAuthRegistry, MockValidator, TokenValidator, WorkflowAuth},
+        config::NodeConfig,
+        server::{AppState, ListenerControl},
+    };
+
+    /// `discover_member_party` is admin-gated. Drive the handler without the
+    /// `AuthMiddleware` wrap so no `Principal` is attached to the request,
+    /// then assert `require_admin`'s 401 fires before any Keycloak/Canton
+    /// call is attempted. This is the production handler-as-last-line-of-
+    /// defense path: even if a request slips through (or middleware is
+    /// misconfigured), the credential-handling code stays gated.
+    #[actix_web::test]
+    async fn discover_member_party_rejects_request_without_principal() {
+        let db = SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite");
+        let party_credentials = Arc::new(RwLock::new(Vec::new()));
+        let state = Data::new(AppState {
+            db,
+            config: NodeConfig::default(),
+            peer_status: Arc::new(RwLock::new(HashMap::new())),
+            noise_listener_control: Arc::new(RwLock::new(ListenerControl {
+                should_pause: false,
+            })),
+            noise_listener_notify: Arc::new(Notify::new()),
+            onboarding_trigger: Arc::new(Notify::new()),
+            kick_trigger: Arc::new(Notify::new()),
+            contracts_trigger: Arc::new(Notify::new()),
+            dars_trigger: Arc::new(Notify::new()),
+            coordinator_pubkey: Arc::new(RwLock::new(None)),
+            pending_invitations: Arc::new(RwLock::new(Vec::new())),
+            auth: Arc::new(RwLock::new(Some(WorkflowAuth::Mock(Arc::new(
+                MockAuthRegistry::new(party_credentials.clone()),
+            ))))),
+            token_validator: TokenValidator::Mock(Arc::new(MockValidator::new(
+                "decman-admin".to_string(),
+            ))),
+            admin_role: Some("decman-admin".to_string()),
+            party_credentials,
+            bootstrap_mu: Arc::new(Mutex::new(())),
+            test_mode: true,
+            refreshing_prefixes: Arc::new(RwLock::new(HashSet::new())),
+        });
+        let app =
+            test::init_service(App::new().app_data(state).service(discover_member_party)).await;
+        let req = TestRequest::post()
+            .uri("/party-config/discover-member-party")
+            .set_json(json!({
+                "keycloak_url": "https://example.invalid",
+                "keycloak_realm": "test",
+                "keycloak_client_id": "validator-admin",
+                "keycloak_client_secret": "secret",
+            }))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
 }

--- a/src/server/handlers/party_config.rs
+++ b/src/server/handlers/party_config.rs
@@ -1,6 +1,10 @@
 use std::sync::Arc;
 
-use actix_web::{HttpRequest, HttpResponse, Responder, get, put, web};
+use actix_web::{HttpRequest, HttpResponse, Responder, get, post, put, web};
+use canton_proto_rs::com::daml::ledger::api::v2::admin::GetUserRequest;
+use keycloak::login::{
+    ClientCredentialsParams, PasswordParams, client_credentials, password, password_url,
+};
 use tokio::sync::RwLock;
 
 use crate::{
@@ -12,8 +16,12 @@ use crate::{
     server::{
         AppState,
         middleware::require_admin,
-        types::{ErrorResponse, PartyConfigRequest, PartyConfigResponse, SuccessResponse},
+        types::{
+            DiscoverMemberPartyRequest, DiscoverMemberPartyResponse, ErrorResponse,
+            PartyConfigRequest, PartyConfigResponse, SuccessResponse,
+        },
     },
+    utils,
 };
 
 /// Get party configuration (secrets masked)
@@ -48,7 +56,7 @@ pub async fn get_party_config(
         Some(c) => HttpResponse::Ok().json(PartyConfigResponse {
             dec_party_id: c.dec_party_id.clone(),
             member_party_id: Some(c.member_party_id.clone()),
-            user_id: c.user_id.clone(),
+            user_id: Some(c.user_id.clone()),
             keycloak_url: c.keycloak.url.clone(),
             keycloak_realm: c.keycloak.realm.clone(),
             keycloak_client_id: c.keycloak.client_id.clone(),
@@ -63,7 +71,7 @@ pub async fn get_party_config(
             HttpResponse::Ok().json(PartyConfigResponse {
                 dec_party_id,
                 member_party_id: None,
-                user_id: "CoordinatorUser".to_string(),
+                user_id: None,
                 keycloak_url: kc_defaults.url,
                 keycloak_realm: kc_defaults.realm,
                 keycloak_client_id: String::new(),
@@ -209,4 +217,117 @@ pub async fn reload_auth(
         );
     }
     Ok(())
+}
+
+/// Discover the member party of the user the given Keycloak credentials
+/// authenticate as, by minting a token + calling Canton's
+/// `UserManagementService.GetUser`. Used to pre-fill the Member Party ID
+/// field in the Party Configuration dialog.
+#[utoipa::path(
+    tag = "Configuration",
+    request_body = DiscoverMemberPartyRequest,
+    responses(
+        (status = 200, description = "Discovered user record", body = DiscoverMemberPartyResponse),
+        (status = 400, description = "Bad request", body = ErrorResponse),
+        (status = 401, description = "Keycloak auth failed", body = ErrorResponse),
+        (status = 500, description = "Canton call failed", body = ErrorResponse)
+    )
+)]
+#[post("/party-config/discover-member-party")]
+pub async fn discover_member_party(
+    http_req: HttpRequest,
+    data: web::Data<AppState>,
+    body: web::Json<DiscoverMemberPartyRequest>,
+) -> impl Responder {
+    if let Err(resp) = require_admin(&http_req, data.admin_role.as_deref()) {
+        return resp;
+    }
+
+    let token_url = password_url(&body.keycloak_url, &body.keycloak_realm);
+
+    let token_result = if let Some(secret) = body
+        .keycloak_client_secret
+        .as_ref()
+        .filter(|s| !s.is_empty())
+    {
+        client_credentials(ClientCredentialsParams {
+            url: token_url,
+            client_id: body.keycloak_client_id.clone(),
+            client_secret: secret.clone(),
+        })
+        .await
+    } else if let (Some(username), Some(pw)) = (
+        body.keycloak_username.as_ref().filter(|s| !s.is_empty()),
+        body.keycloak_password.as_ref().filter(|s| !s.is_empty()),
+    ) {
+        password(PasswordParams {
+            url: token_url,
+            client_id: body.keycloak_client_id.clone(),
+            username: username.clone(),
+            password: pw.clone(),
+        })
+        .await
+    } else {
+        return HttpResponse::BadRequest().json(ErrorResponse {
+            error: "Provide either keycloak_client_secret or keycloak_username + keycloak_password"
+                .to_string(),
+        });
+    };
+
+    let token = match token_result {
+        Ok(resp) => resp.access_token,
+        Err(e) => {
+            return HttpResponse::Unauthorized().json(ErrorResponse {
+                error: format!("Keycloak auth failed: {e}"),
+            });
+        }
+    };
+
+    let mut client = match utils::create_user_client(&data.config, Some(token)).await {
+        Ok(c) => c,
+        Err(e) => {
+            return HttpResponse::InternalServerError().json(ErrorResponse {
+                error: format!("Failed to create user client: {e}"),
+            });
+        }
+    };
+
+    let response = match client
+        .get_user(tonic::Request::new(GetUserRequest {
+            user_id: String::new(),
+            identity_provider_id: String::new(),
+        }))
+        .await
+    {
+        Ok(r) => r.into_inner(),
+        Err(e) => {
+            return HttpResponse::InternalServerError().json(ErrorResponse {
+                error: format!("Canton GetUser failed: {e}"),
+            });
+        }
+    };
+
+    let Some(user) = response.user else {
+        return HttpResponse::InternalServerError().json(ErrorResponse {
+            error: "Canton returned no user".to_string(),
+        });
+    };
+
+    let primary_party = if user.primary_party.is_empty() {
+        None
+    } else {
+        CantonId::parse(&user.primary_party).ok()
+    };
+
+    let description = user
+        .metadata
+        .as_ref()
+        .and_then(|m| m.annotations.get("description").cloned())
+        .filter(|s| !s.is_empty());
+
+    HttpResponse::Ok().json(DiscoverMemberPartyResponse {
+        user_id: user.id,
+        primary_party,
+        description,
+    })
 }

--- a/src/server/handlers/workflows.rs
+++ b/src/server/handlers/workflows.rs
@@ -394,7 +394,10 @@ pub async fn start_onboarding(
             );
             return HttpResponse::UnprocessableEntity().json(OnboardingMeshErrorResponse {
                 error: format!(
-                    "Selected peers are not mutually connected. Missing peer-to-peer config: {edge_summary}"
+                    "Could not verify a full peer mesh. \
+                     Each edge below points to a peer that is unreachable from the listed source \
+                     (missing from network config, missing/invalid public key, unreachable, or \
+                     responded with an unparsable peer list). Edges: {edge_summary}"
                 ),
                 missing_edges: missing,
             });
@@ -716,6 +719,10 @@ async fn verify_peer_mesh(
             Ok(m) => m,
             Err(e) => {
                 tracing::warn!("Malformed response from {peer_id}: {e}");
+                missing_edges.push(MissingPeerEdge {
+                    from: identity.clone(),
+                    to: peer_id.clone(),
+                });
                 continue;
             }
         };
@@ -725,6 +732,10 @@ async fn verify_peer_mesh(
                 "Peer {peer_id} responded with {msg_type:?} instead of PeerList",
                 msg_type = msg.msg_type
             );
+            missing_edges.push(MissingPeerEdge {
+                from: identity.clone(),
+                to: peer_id.clone(),
+            });
             continue;
         }
 
@@ -732,6 +743,10 @@ async fn verify_peer_mesh(
             Ok(v) => v,
             Err(e) => {
                 tracing::warn!("Could not parse peer list from {peer_id}: {e}");
+                missing_edges.push(MissingPeerEdge {
+                    from: identity.clone(),
+                    to: peer_id.clone(),
+                });
                 continue;
             }
         };
@@ -972,6 +987,7 @@ pub async fn upload_dars_local(
     request_body = DarsRequest,
     responses(
         (status = 202, description = "DARs distribution workflow started", body = WorkflowResponse),
+        (status = 400, description = "Bad request (e.g. empty peer_ids)", body = ErrorResponse),
         (status = 409, description = "Workflow already in progress", body = ErrorResponse)
     )
 )]

--- a/src/server/handlers/workflows.rs
+++ b/src/server/handlers/workflows.rs
@@ -5,7 +5,6 @@ use std::{
 };
 
 use actix_web::{HttpRequest, HttpResponse, Responder, get, post, web};
-use tokio::sync::RwLock;
 
 use sqlx::SqlitePool;
 
@@ -13,9 +12,8 @@ use super::parties::{
     fetch_decentralized_parties, resolve_owner_keys_from_peers, store_parties_to_db,
 };
 use crate::{
-    auth::{AuthRegistry, WorkflowAuth},
-    config::{KeycloakConfig, NetworkConfig, NodeConfig, PartyCredentials, default_package_config},
-    db::schema::{Commitable, SchemaRead, SchemaWrite},
+    config::{NetworkConfig, NodeConfig},
+    db::schema::SchemaRead,
     error::Result,
     noise::{Message, MessageType, NoiseKeypair, parse_public_key, send_noise_message},
     participant_id::CantonId,
@@ -428,7 +426,6 @@ pub async fn start_onboarding(
     let peer_ids = body.peer_ids.clone();
     let party_credentials = data.party_credentials.clone();
     let auth_lock = data.auth.clone();
-    let is_test_mode = data.test_mode;
 
     tokio::spawn(async move {
         let guard = ListenerPauseGuard::pause(listener_control, listener_notify).await;
@@ -470,23 +467,10 @@ pub async fn start_onboarding(
         let mut error = onboarding_state_clone.error.write().await;
 
         match result {
-            Ok(coordinator_result) => {
+            Ok(_) => {
                 *status = OnboardingStatus::Completed;
                 tracing::info!("Onboarding workflow completed successfully");
-
-                if !is_test_mode
-                    && let Some(dec_party_id) = coordinator_result.created_party_id
-                    && let Err(e) = save_default_party_config(
-                        &config,
-                        &db,
-                        &dec_party_id,
-                        &party_credentials,
-                        &auth_lock,
-                    )
-                    .await
-                {
-                    tracing::warn!("Failed to auto-save party config: {e}");
-                }
+                // Operator configures party credentials via the Party Configuration dialog; auto-saving placeholders pollutes the auth registry.
 
                 // Refresh dec_party cache in background
                 let bg_config = config.clone();
@@ -1182,66 +1166,6 @@ async fn send_dars_invites(config: &NodeConfig, db: &SqlitePool, peer_ids: &[Can
         }
     }
 
-    Ok(())
-}
-
-/// Auto-save default party config after successful onboarding
-async fn save_default_party_config(
-    config: &NodeConfig,
-    db: &SqlitePool,
-    dec_party_id: &CantonId,
-    party_credentials: &Arc<RwLock<Vec<PartyCredentials>>>,
-    auth_lock: &Arc<RwLock<Option<WorkflowAuth>>>,
-) -> Result {
-    tracing::info!("Saving default config for new dec party: {dec_party_id}");
-
-    let kc_defaults = config.canton.network.keycloak_defaults();
-    let creds = PartyCredentials {
-        dec_party_id: dec_party_id.clone(),
-        // Placeholder — user must set the real member party ID via the config dialog
-        member_party_id: dec_party_id.clone(),
-        user_id: "CoordinatorUser".to_string(),
-        keycloak: KeycloakConfig {
-            url: kc_defaults.url,
-            realm: kc_defaults.realm,
-            client_id: String::new(),
-            client_secret: None,
-            username: None,
-            password: None,
-        },
-        packages: default_package_config(),
-    };
-
-    // Primary write: save to database
-    let mut tx = db.begin_transaction().await?;
-    tx.upsert_party_credentials(&creds).await?;
-    Commitable::commit(tx).await?;
-
-    // Update in-memory state
-    {
-        let mut pc = party_credentials.write().await;
-        if let Some(existing) = pc.iter_mut().find(|p| p.dec_party_id == *dec_party_id) {
-            *existing = creds;
-        } else {
-            pc.push(creds);
-        }
-    }
-
-    let creds_snapshot = party_credentials.read().await.clone();
-    if !creds_snapshot.is_empty() {
-        match AuthRegistry::new(&creds_snapshot).await {
-            Ok(registry) => {
-                let mut auth = auth_lock.write().await;
-                *auth = Some(WorkflowAuth::Keycloak(Arc::new(registry)));
-                tracing::info!("Auth registry reinitialized after onboarding");
-            }
-            Err(e) => {
-                tracing::warn!("Failed to reinitialize auth registry: {e}");
-            }
-        }
-    }
-
-    tracing::info!("Default party config saved for {dec_party_id}");
     Ok(())
 }
 

--- a/src/server/handlers/workflows.rs
+++ b/src/server/handlers/workflows.rs
@@ -832,6 +832,12 @@ pub async fn start_dars(
     dars_state: web::Data<Arc<DarsWorkflowState>>,
     body: web::Json<DarsRequest>,
 ) -> impl Responder {
+    if body.peer_ids.is_empty() {
+        return HttpResponse::BadRequest().json(ErrorResponse {
+            error: "peer_ids must contain at least one peer".to_string(),
+        });
+    }
+
     // Check if a DARs workflow is already in progress
     {
         let status = dars_state.status.read().await;
@@ -859,6 +865,7 @@ pub async fn start_dars(
     let dars_config = workflow::DarsConfig {
         dar_files: body.dar_files.clone(),
         instance_name,
+        peer_ids: body.peer_ids.clone(),
     };
 
     // Spawn the DARs workflow in the background
@@ -867,12 +874,13 @@ pub async fn start_dars(
     let dars_state_clone = dars_state.get_ref().clone();
     let listener_control = data.noise_listener_control.clone();
     let listener_notify = data.noise_listener_notify.clone();
+    let peer_ids = body.peer_ids.clone();
 
     tokio::spawn(async move {
         let guard = ListenerPauseGuard::pause(listener_control, listener_notify).await;
 
-        // Send invites to all peers before starting coordinator workflow
-        let invite_result = send_dars_invites(&config, &db).await;
+        // Send invites to selected peers before starting coordinator workflow
+        let invite_result = send_dars_invites(&config, &db, &peer_ids).await;
         if let Err(e) = invite_result {
             tracing::error!("Failed to send DARs invites: {e}");
             guard.resume().await;
@@ -940,34 +948,35 @@ pub async fn get_dars_status(dars_state: web::Data<Arc<DarsWorkflowState>>) -> i
     })
 }
 
-/// Send DARs invites to all peers using Noise protocol
-async fn send_dars_invites(config: &NodeConfig, db: &SqlitePool) -> Result {
+/// Send DARs invites to selected peers using Noise protocol
+async fn send_dars_invites(config: &NodeConfig, db: &SqlitePool, peer_ids: &[CantonId]) -> Result {
     let network_config = NetworkConfig::from_peers(db.get_all_peers().await?);
     let keypair = NoiseKeypair::from_file(&config.key_file_path()).await?;
 
-    let current_participant_id = config.participant_id();
     let invite_message = Message::new_empty(MessageType::InviteDars);
 
-    for peer in &network_config.peers {
-        if peer.participant_id == *current_participant_id {
-            continue;
-        }
+    for peer_id in peer_ids {
+        let peer = match network_config
+            .peers
+            .iter()
+            .find(|p| &p.participant_id == peer_id)
+        {
+            Some(p) => p,
+            None => {
+                tracing::warn!("Skipping invite to {peer_id} - peer not found in network config");
+                continue;
+            }
+        };
 
         if peer.public_key.is_empty() {
-            tracing::warn!(
-                "Skipping invite to {} - no public key configured",
-                peer.participant_id
-            );
+            tracing::warn!("Skipping invite to {peer_id} - no public key configured");
             continue;
         }
 
         let peer_pub_key = match parse_public_key(&peer.public_key) {
             Ok(pk) => pk,
             Err(e) => {
-                tracing::warn!(
-                    "Skipping invite to {} - invalid public key: {e}",
-                    peer.participant_id
-                );
+                tracing::warn!("Skipping invite to {peer_id} - invalid public key: {e}");
                 continue;
             }
         };
@@ -976,10 +985,9 @@ async fn send_dars_invites(config: &NodeConfig, db: &SqlitePool) -> Result {
         let identity = config.participant_id().to_string();
 
         tracing::info!(
-            "Sending DARs invite to {} at {}:{}",
-            peer.participant_id,
-            peer.address,
-            peer.port
+            "Sending DARs invite to {peer_id} at {addr}:{port}",
+            addr = peer.address,
+            port = peer.port
         );
 
         match send_noise_message(
@@ -994,18 +1002,17 @@ async fn send_dars_invites(config: &NodeConfig, db: &SqlitePool) -> Result {
             Ok(response) => {
                 if let Ok(msg) = Message::from_bytes(&response) {
                     if msg.msg_type == MessageType::Ack {
-                        tracing::info!("Peer {} acknowledged DARs invite", peer.participant_id);
+                        tracing::info!("Peer {peer_id} acknowledged DARs invite");
                     } else {
                         tracing::warn!(
-                            "Peer {} responded with {msg_type:?} instead of Ack",
-                            peer.participant_id,
+                            "Peer {peer_id} responded with {msg_type:?} instead of Ack",
                             msg_type = msg.msg_type
                         );
                     }
                 }
             }
             Err(e) => {
-                tracing::error!("Failed to send DARs invite to {}: {e}", peer.participant_id);
+                tracing::error!("Failed to send DARs invite to {peer_id}: {e}");
             }
         }
     }

--- a/src/server/handlers/workflows.rs
+++ b/src/server/handlers/workflows.rs
@@ -22,7 +22,7 @@ use crate::{
         middleware::require_admin,
         types::{
             ContractsRequest, DarsRequest, ErrorResponse, HttpWorkflowState, KickRequest,
-            KickResponse, KickStatus, ListenerPauseGuard, MissingPeerEdge,
+            KickResponse, KickStatus, ListenerPauseGuard, MissingEdgeKind, MissingPeerEdge,
             OnboardingMeshErrorResponse, OnboardingRequest, OnboardingResponse, OnboardingStatus,
             SuccessResponse, WorkflowProgress, WorkflowResponse, WorkflowStatusResponse,
         },
@@ -383,9 +383,21 @@ pub async fn start_onboarding(
     // for attestor connections that can never be established.
     match verify_peer_mesh(&data.config, &data.db, &body.peer_ids).await {
         Ok(missing) if !missing.is_empty() => {
+            // Tag each edge with its failure mode in the human-readable
+            // summary; the structured `missing_edges` array carries the same
+            // info via `kind` for the frontend to render targeted hints.
             let edge_summary = missing
                 .iter()
-                .map(|e| format!("{from} → {to}", from = e.from, to = e.to))
+                .map(|e| match e.kind {
+                    MissingEdgeKind::UnreachableFromCoordinator => format!(
+                        "[unreachable from coordinator] {from} → {to}",
+                        from = e.from,
+                        to = e.to
+                    ),
+                    MissingEdgeKind::MeshHole => {
+                        format!("[mesh hole] {from} → {to}", from = e.from, to = e.to)
+                    }
+                })
                 .collect::<Vec<_>>()
                 .join("; ");
             tracing::warn!(
@@ -394,10 +406,13 @@ pub async fn start_onboarding(
             );
             return HttpResponse::UnprocessableEntity().json(OnboardingMeshErrorResponse {
                 error: format!(
-                    "Could not verify a full peer mesh. \
-                     Each edge below points to a peer that is unreachable from the listed source \
-                     (missing from network config, missing/invalid public key, unreachable, or \
-                     responded with an unparsable peer list). Edges: {edge_summary}"
+                    "Could not verify a full peer mesh. Two failure modes are folded together: \
+                     `unreachable from coordinator` (the coordinator cannot query that peer — \
+                     it's missing from network config, has no/invalid public key, didn't \
+                     answer, or replied with an unparsable peer list — fix the coordinator's \
+                     view of `to`, or `to` itself), and `mesh hole` (peer `from` is reachable \
+                     but does not have peer `to` in its peer list — add `to` to `from`'s \
+                     network config). Edges: {edge_summary}"
                 ),
                 missing_edges: missing,
             });
@@ -406,7 +421,7 @@ pub async fn start_onboarding(
         Err(e) => {
             tracing::error!("Failed to run mesh pre-flight: {e:#}");
             return HttpResponse::InternalServerError().json(ErrorResponse {
-                error: format!("Failed to verify peer mesh: {e}"),
+                error: "Failed to verify peer mesh".into(),
             });
         }
     }
@@ -667,6 +682,7 @@ async fn verify_peer_mesh(
                 missing_edges.push(MissingPeerEdge {
                     from: identity.clone(),
                     to: peer_id.clone(),
+                    kind: MissingEdgeKind::UnreachableFromCoordinator,
                 });
                 continue;
             }
@@ -677,6 +693,7 @@ async fn verify_peer_mesh(
             missing_edges.push(MissingPeerEdge {
                 from: identity.clone(),
                 to: peer_id.clone(),
+                kind: MissingEdgeKind::UnreachableFromCoordinator,
             });
             continue;
         }
@@ -688,6 +705,7 @@ async fn verify_peer_mesh(
                 missing_edges.push(MissingPeerEdge {
                     from: identity.clone(),
                     to: peer_id.clone(),
+                    kind: MissingEdgeKind::UnreachableFromCoordinator,
                 });
                 continue;
             }
@@ -710,6 +728,7 @@ async fn verify_peer_mesh(
                 missing_edges.push(MissingPeerEdge {
                     from: identity.clone(),
                     to: peer_id.clone(),
+                    kind: MissingEdgeKind::UnreachableFromCoordinator,
                 });
                 continue;
             }
@@ -722,6 +741,7 @@ async fn verify_peer_mesh(
                 missing_edges.push(MissingPeerEdge {
                     from: identity.clone(),
                     to: peer_id.clone(),
+                    kind: MissingEdgeKind::UnreachableFromCoordinator,
                 });
                 continue;
             }
@@ -735,6 +755,7 @@ async fn verify_peer_mesh(
             missing_edges.push(MissingPeerEdge {
                 from: identity.clone(),
                 to: peer_id.clone(),
+                kind: MissingEdgeKind::UnreachableFromCoordinator,
             });
             continue;
         }
@@ -746,6 +767,7 @@ async fn verify_peer_mesh(
                 missing_edges.push(MissingPeerEdge {
                     from: identity.clone(),
                     to: peer_id.clone(),
+                    kind: MissingEdgeKind::UnreachableFromCoordinator,
                 });
                 continue;
             }
@@ -768,6 +790,7 @@ async fn verify_peer_mesh(
                 missing_edges.push(MissingPeerEdge {
                     from: a.clone(),
                     to: b.clone(),
+                    kind: MissingEdgeKind::MeshHole,
                 });
             }
         }

--- a/src/server/handlers/workflows.rs
+++ b/src/server/handlers/workflows.rs
@@ -66,7 +66,7 @@ pub async fn start_kick(
     kick_state: web::Data<Arc<KickWorkflowState>>,
     body: web::Json<KickRequest>,
 ) -> impl Responder {
-    if let Err(resp) = require_admin(&http_req, &data.admin_role) {
+    if let Err(resp) = require_admin(&http_req, data.admin_role.as_deref()) {
         return resp;
     }
 

--- a/src/server/handlers/workflows.rs
+++ b/src/server/handlers/workflows.rs
@@ -1,4 +1,8 @@
-use std::{sync::Arc, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+    time::Duration,
+};
 
 use actix_web::{HttpRequest, HttpResponse, Responder, get, post, web};
 use tokio::sync::RwLock;
@@ -20,9 +24,9 @@ use crate::{
         middleware::require_admin,
         types::{
             ContractsRequest, DarsRequest, ErrorResponse, HttpWorkflowState, KickRequest,
-            KickResponse, KickStatus, ListenerPauseGuard, OnboardingRequest, OnboardingResponse,
-            OnboardingStatus, SuccessResponse, WorkflowProgress, WorkflowResponse,
-            WorkflowStatusResponse,
+            KickResponse, KickStatus, ListenerPauseGuard, MissingPeerEdge,
+            OnboardingMeshErrorResponse, OnboardingRequest, OnboardingResponse, OnboardingStatus,
+            SuccessResponse, WorkflowProgress, WorkflowResponse, WorkflowStatusResponse,
         },
     },
     workflow,
@@ -356,7 +360,8 @@ async fn send_kick_invites(
     request_body = OnboardingRequest,
     responses(
         (status = 202, description = "Onboarding workflow started", body = WorkflowResponse),
-        (status = 409, description = "Workflow already in progress", body = ErrorResponse)
+        (status = 409, description = "Workflow already in progress", body = ErrorResponse),
+        (status = 422, description = "Selected peers are not mutually meshed", body = OnboardingMeshErrorResponse)
     )
 )]
 #[post("/onboarding")]
@@ -371,6 +376,36 @@ pub async fn start_onboarding(
         if *status == OnboardingStatus::InProgress {
             return HttpResponse::Conflict().json(ErrorResponse {
                 error: "An onboarding workflow is already in progress".to_string(),
+            });
+        }
+    }
+
+    // Pre-flight: every selected peer must have every other selected peer in
+    // its network config, otherwise the coordinator workflow will hang waiting
+    // for attestor connections that can never be established.
+    match verify_peer_mesh(&data.config, &data.db, &body.peer_ids).await {
+        Ok(missing) if !missing.is_empty() => {
+            let edge_summary = missing
+                .iter()
+                .map(|e| format!("{from} → {to}", from = e.from, to = e.to))
+                .collect::<Vec<_>>()
+                .join("; ");
+            tracing::warn!(
+                "Onboarding rejected: {n} missing peer mesh edge(s): {edge_summary}",
+                n = missing.len()
+            );
+            return HttpResponse::UnprocessableEntity().json(OnboardingMeshErrorResponse {
+                error: format!(
+                    "Selected peers are not mutually connected. Missing peer-to-peer config: {edge_summary}"
+                ),
+                missing_edges: missing,
+            });
+        }
+        Ok(_) => {}
+        Err(e) => {
+            tracing::error!("Failed to run mesh pre-flight: {e:#}");
+            return HttpResponse::InternalServerError().json(ErrorResponse {
+                error: format!("Failed to verify peer mesh: {e}"),
             });
         }
     }
@@ -610,6 +645,136 @@ async fn send_onboarding_invites(
     }
 
     Ok(())
+}
+
+/// Pre-flight check: query each selected peer for its known peer list and
+/// verify every pair within `peer_ids` knows each other. Returns the list of
+/// missing directed edges (`from` does not have `to` configured). Empty Vec
+/// on success.
+///
+/// Coordinator → peer reachability is implicitly verified: if a peer can
+/// answer our Noise call, it already has us in its peer list. We only check
+/// peer ↔ peer mesh — that's the case the user can't see otherwise.
+async fn verify_peer_mesh(
+    config: &NodeConfig,
+    db: &SqlitePool,
+    peer_ids: &[String],
+) -> Result<Vec<MissingPeerEdge>> {
+    let network_config = NetworkConfig::from_peers(db.get_all_peers().await?);
+    let keypair = NoiseKeypair::from_file(&config.key_file_path()).await?;
+    let request = Message::new_empty(MessageType::ListPeers);
+    let identity = config.participant_id().to_string();
+
+    let mut missing_edges = Vec::new();
+    let mut peer_views: HashMap<String, HashSet<String>> = HashMap::new();
+
+    for peer_id in peer_ids {
+        let peer = match network_config
+            .peers
+            .iter()
+            .find(|p| p.participant_id.to_string() == *peer_id)
+        {
+            Some(p) => p,
+            None => {
+                // Coordinator doesn't know this peer — won't be able to invite them.
+                missing_edges.push(MissingPeerEdge {
+                    from: identity.clone(),
+                    to: peer_id.clone(),
+                });
+                continue;
+            }
+        };
+
+        if peer.public_key.is_empty() {
+            tracing::warn!("Peer {peer_id} has no public key configured — cannot mesh-check");
+            missing_edges.push(MissingPeerEdge {
+                from: identity.clone(),
+                to: peer_id.clone(),
+            });
+            continue;
+        }
+
+        let peer_pub_key = match parse_public_key(&peer.public_key) {
+            Ok(pk) => pk,
+            Err(e) => {
+                tracing::warn!("Peer {peer_id} has invalid public key: {e}");
+                missing_edges.push(MissingPeerEdge {
+                    from: identity.clone(),
+                    to: peer_id.clone(),
+                });
+                continue;
+            }
+        };
+
+        let psk = keypair.derive_psk(&peer_pub_key);
+
+        let response = match send_noise_message(
+            &peer.address,
+            peer.port,
+            &psk,
+            identity.as_bytes(),
+            &request,
+        )
+        .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!("Failed to query peers from {peer_id}: {e}");
+                missing_edges.push(MissingPeerEdge {
+                    from: identity.clone(),
+                    to: peer_id.clone(),
+                });
+                continue;
+            }
+        };
+
+        let msg = match Message::from_bytes(&response) {
+            Ok(m) => m,
+            Err(e) => {
+                tracing::warn!("Malformed response from {peer_id}: {e}");
+                continue;
+            }
+        };
+
+        if msg.msg_type != MessageType::PeerList {
+            tracing::warn!(
+                "Peer {peer_id} responded with {msg_type:?} instead of PeerList",
+                msg_type = msg.msg_type
+            );
+            continue;
+        }
+
+        let view: HashSet<String> = match serde_json::from_slice(&msg.payload) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!("Could not parse peer list from {peer_id}: {e}");
+                continue;
+            }
+        };
+        peer_views.insert(peer_id.clone(), view);
+    }
+
+    // For every directed pair within selected peers, check that A's peer view
+    // includes B. Missing means A and B aren't mutually connected.
+    for a in peer_ids {
+        let Some(a_view) = peer_views.get(a) else {
+            // Already recorded a coordinator→A reachability problem above.
+            continue;
+        };
+        for b in peer_ids {
+            if a == b {
+                continue;
+            }
+            if !a_view.contains(b) {
+                missing_edges.push(MissingPeerEdge {
+                    from: a.clone(),
+                    to: b.clone(),
+                });
+            }
+        }
+    }
+
+    Ok(missing_edges)
 }
 
 // ============================================================================

--- a/src/server/middleware/auth.rs
+++ b/src/server/middleware/auth.rs
@@ -135,13 +135,18 @@ where
 }
 
 /// Handler helper: pull the `Principal` the middleware attached, then
-/// check it carries the admin role.
+/// check it carries the admin role. `None` disables the role check —
+/// any authenticated caller passes.
 ///
 /// # Errors
 ///
 /// Returns an `HttpResponse` ready to return: 401 if no principal was
-/// attached to the request, 403 if the principal lacks `admin_role`.
-pub fn require_admin(req: &HttpRequest, admin_role: &str) -> Result<Principal, HttpResponse> {
+/// attached to the request, 403 if `admin_role` is `Some` and the
+/// principal does not carry it.
+pub fn require_admin(
+    req: &HttpRequest,
+    admin_role: Option<&str>,
+) -> Result<Principal, HttpResponse> {
     let principal = {
         let extensions = req.extensions();
         extensions.get::<Principal>().cloned()
@@ -149,9 +154,11 @@ pub fn require_admin(req: &HttpRequest, admin_role: &str) -> Result<Principal, H
     let Some(principal) = principal else {
         return Err(HttpResponse::Unauthorized().json(json!({"error": "authentication required"})));
     };
-    principal
-        .require_admin(admin_role)
-        .map_err(|e| HttpResponse::Forbidden().json(json!({"error": e.to_string()})))?;
+    if let Some(role) = admin_role {
+        principal
+            .require_admin(role)
+            .map_err(|e| HttpResponse::Forbidden().json(json!({"error": e.to_string()})))?;
+    }
     Ok(principal)
 }
 
@@ -330,7 +337,7 @@ mod tests {
             pending_invitations: Arc::new(RwLock::new(Vec::new())),
             auth: Arc::new(RwLock::new(None)),
             token_validator: validator,
-            admin_role: "dpm-admin".to_string(),
+            admin_role: Some("decman-admin".to_string()),
             party_credentials,
             bootstrap_mu: Arc::new(Mutex::new(())),
             test_mode: true,
@@ -341,7 +348,7 @@ mod tests {
     async fn build_app_state(parties: Vec<PartyCredentials>) -> Data<AppState> {
         build_app_state_with(
             parties,
-            TokenValidator::Mock(Arc::new(MockValidator::new("dpm-admin".to_string()))),
+            TokenValidator::Mock(Arc::new(MockValidator::new("decman-admin".to_string()))),
         )
         .await
     }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -97,6 +97,8 @@ struct WorkflowTriggers {
     admin_api_url: String,
     synchronizer: String,
     db: SqlitePool,
+    /// Read by the `RequestMemberParty` listener arm.
+    party_credentials: Arc<RwLock<Vec<PartyCredentials>>>,
 }
 
 /// Start the HTTP server and a heartbeat system for peer status tracking
@@ -211,7 +213,7 @@ pub async fn start_server(
         auth,
         token_validator,
         admin_role,
-        party_credentials,
+        party_credentials: party_credentials.clone(),
         bootstrap_mu: Arc::new(Mutex::new(())),
         test_mode,
         refreshing_prefixes: Arc::new(RwLock::new(HashSet::new())),
@@ -232,6 +234,7 @@ pub async fn start_server(
         admin_api_url: config.admin_api_url(),
         synchronizer: config.synchronizer().to_string(),
         db: db.clone(),
+        party_credentials: party_credentials.clone(),
     };
     tokio::spawn(async move {
         run_heartbeat(
@@ -431,6 +434,7 @@ pub async fn start_server(
             .service(handlers::grant_rights)
             .service(handlers::get_governance)
             .service(handlers::get_governance_state)
+            .service(handlers::get_known_members)
             .service(handlers::get_vaults_handler)
             .service(handlers::get_provider_services_handler)
             .service(handlers::get_user_services_handler)
@@ -697,6 +701,25 @@ async fn handle_incoming_connection(
                                 }
                             };
                             let response_msg = Message::new(MessageType::PeerList, payload);
+                            return Ok(Response::builder()
+                                .status(StatusCode::OK)
+                                .body(Body::from(response_msg.to_bytes()))
+                                .unwrap());
+                        }
+                        MessageType::RequestMemberParty => {
+                            let dec_party_id =
+                                std::str::from_utf8(&msg.payload).unwrap_or("").to_string();
+                            tracing::debug!("Received RequestMemberParty for {dec_party_id}",);
+                            let payload = {
+                                let creds = triggers.party_credentials.read().await;
+                                creds
+                                    .iter()
+                                    .find(|c| c.dec_party_id.to_string() == dec_party_id)
+                                    .map(|c| c.member_party_id.to_string().into_bytes())
+                                    .unwrap_or_default()
+                            };
+                            let response_msg =
+                                Message::new(MessageType::MemberPartyResponse, payload);
                             return Ok(Response::builder()
                                 .status(StatusCode::OK)
                                 .body(Body::from(response_msg.to_bytes()))

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -96,6 +96,7 @@ struct WorkflowTriggers {
     pending_invitations: Arc<RwLock<Vec<PendingInvitation>>>,
     admin_api_url: String,
     synchronizer: String,
+    db: SqlitePool,
 }
 
 /// Start the HTTP server and a heartbeat system for peer status tracking
@@ -230,6 +231,7 @@ pub async fn start_server(
         pending_invitations: pending_invitations.clone(),
         admin_api_url: config.admin_api_url(),
         synchronizer: config.synchronizer().to_string(),
+        db: db.clone(),
     };
     tokio::spawn(async move {
         run_heartbeat(
@@ -674,6 +676,27 @@ async fn handle_incoming_connection(
                                 }
                             };
                             let response_msg = Message::new(MessageType::OwnerKeys, payload);
+                            return Ok(Response::builder()
+                                .status(StatusCode::OK)
+                                .body(Body::from(response_msg.to_bytes()))
+                                .unwrap());
+                        }
+                        MessageType::ListPeers => {
+                            tracing::debug!("Received ListPeers request");
+                            let payload = match triggers.db.get_all_peers().await {
+                                Ok(peers) => {
+                                    let ids: Vec<String> = peers
+                                        .into_iter()
+                                        .map(|p| p.participant_id.to_string())
+                                        .collect();
+                                    serde_json::to_vec(&ids).unwrap_or_else(|_| b"[]".to_vec())
+                                }
+                                Err(e) => {
+                                    tracing::error!("Failed to list peers: {e}");
+                                    b"[]".to_vec()
+                                }
+                            };
+                            let response_msg = Message::new(MessageType::PeerList, payload);
                             return Ok(Response::builder()
                                 .status(StatusCode::OK)
                                 .body(Body::from(response_msg.to_bytes()))

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -123,6 +123,24 @@ pub async fn start_server(
         );
     }
 
+    // Make the admin-role policy explicit at boot so a single-user deployment
+    // doesn't quietly lose authorization on multi-user upgrade. With
+    // `admin_role = None` (the default since the gating became opt-in),
+    // every authenticated caller passes `require_admin`.
+    match admin_role.as_deref() {
+        Some(role) if !role.is_empty() => {
+            tracing::info!("Admin gate active: requests must carry role '{role}'");
+        }
+        _ => {
+            tracing::warn!(
+                "DECPM_ADMIN_ROLE not set: every authenticated caller is treated as admin. \
+                 Set DECPM_ADMIN_ROLE=<role> to require a specific Keycloak role on \
+                 PUT /party-config, POST /kick, POST /auth/grant-rights, and other \
+                 admin-gated endpoints."
+            );
+        }
+    }
+
     let db_party_creds = db.get_all_party_credentials().await.unwrap_or_else(|e| {
         tracing::warn!("Failed to load party credentials from DB: {e}");
         Vec::new()

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -71,7 +71,7 @@ pub struct AppState {
     /// Inbound token validator — authenticates API callers.
     pub token_validator: TokenValidator,
     /// Role name that grants admin access to sensitive endpoints.
-    pub admin_role: String,
+    pub admin_role: Option<String>,
     /// Party credentials (mutable, hot-reloadable)
     pub party_credentials: Arc<RwLock<Vec<PartyCredentials>>>,
     /// Serializes unauthenticated `PUT /party-config` bootstrap calls so two
@@ -104,7 +104,7 @@ pub async fn start_server(
     port: u16,
     config: NodeConfig,
     db: SqlitePool,
-    admin_role: String,
+    admin_role: Option<String>,
     allowed_origin: Option<String>,
 ) -> Result {
     // Test-mode is a compile-time decision: it's `true` iff the binary was
@@ -156,7 +156,9 @@ pub async fn start_server(
     // `MockValidator` is compiled in only behind `cfg(any(test, feature =
     // "test-mode"))`, so a release binary cannot select it.
     #[cfg(any(test, feature = "test-mode"))]
-    let token_validator = TokenValidator::Mock(Arc::new(MockValidator::new(admin_role.clone())));
+    let token_validator = TokenValidator::Mock(Arc::new(MockValidator::new(
+        admin_role.clone().unwrap_or_default(),
+    )));
     #[cfg(not(any(test, feature = "test-mode")))]
     let token_validator = {
         let no_top_level_config = config.keycloak.is_none();

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -452,6 +452,7 @@ pub async fn start_server(
             .service(handlers::get_network_info)
             .service(handlers::get_party_config)
             .service(handlers::save_party_config)
+            .service(handlers::discover_member_party)
             .split_for_parts();
 
         let mut app = app.wrap(AuthMiddleware).wrap(cors);

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -426,6 +426,7 @@ pub async fn start_server(
             .service(handlers::get_auth_config)
             .service(handlers::get_auth_status)
             .service(handlers::test_auth)
+            .service(handlers::grant_rights)
             .service(handlers::get_governance)
             .service(handlers::get_governance_state)
             .service(handlers::get_vaults_handler)

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -258,6 +258,9 @@ pub struct ContractsRequest {
 pub struct DarsRequest {
     /// DAR files to upload (base64-encoded)
     pub dar_files: Vec<DarFile>,
+    /// Peer IDs to distribute to (required non-empty for /dars/distribute, ignored by /dars/upload)
+    #[serde(default)]
+    pub peer_ids: Vec<CantonId>,
 }
 
 /// Progress status of a workflow (kick, onboarding, etc.)

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -415,6 +415,19 @@ pub struct AuthTestResponse {
     pub results: Vec<AuthTestResult>,
 }
 
+/// One participant's member party for a given dec party. Empty `member_party_id` = peer not configured / unreachable.
+#[derive(Clone, Debug, Serialize, utoipa::ToSchema)]
+pub struct KnownMember {
+    pub participant_uid: String,
+    pub member_party_id: String,
+}
+
+/// Response for `GET /governance/known-members`.
+#[derive(Clone, Debug, Serialize, utoipa::ToSchema)]
+pub struct KnownMembersResponse {
+    pub members: Vec<KnownMember>,
+}
+
 /// Request to grant the configured user the rights they need to act on a dec party
 #[derive(Clone, Debug, Deserialize, utoipa::ToSchema)]
 pub struct GrantRightsRequest {
@@ -987,8 +1000,10 @@ pub struct PartyConfigRequest {
 pub struct PartyConfigResponse {
     /// The decentralized party ID
     pub dec_party_id: CantonId,
-    /// The member party ID (local to this node)
-    pub member_party_id: CantonId,
+    /// The member party ID (local to this node). `None` if no credentials
+    /// have been saved yet — the operator must provide one via PUT.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub member_party_id: Option<CantonId>,
     /// Canton/Ledger API user ID
     pub user_id: String,
     /// Keycloak server URL

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -415,17 +415,45 @@ pub struct AuthTestResponse {
     pub results: Vec<AuthTestResult>,
 }
 
-/// One participant's member party for a given dec party. Empty `member_party_id` = peer not configured / unreachable.
+/// One participant's member party for a given dec party. `None` member_party_id = peer not configured / unreachable.
 #[derive(Clone, Debug, Serialize, utoipa::ToSchema)]
 pub struct KnownMember {
     pub participant_uid: String,
-    pub member_party_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub member_party_id: Option<CantonId>,
 }
 
 /// Response for `GET /governance/known-members`.
 #[derive(Clone, Debug, Serialize, utoipa::ToSchema)]
 pub struct KnownMembersResponse {
     pub members: Vec<KnownMember>,
+}
+
+/// Request body for `POST /party-config/discover-member-party`. Same Keycloak
+/// shape as `PartyConfigRequest`, used to mint a one-shot token and look up
+/// the authenticated user's primary party from Canton's UserManagementService.
+#[derive(Clone, Debug, Deserialize, utoipa::ToSchema)]
+pub struct DiscoverMemberPartyRequest {
+    pub keycloak_url: String,
+    pub keycloak_realm: String,
+    pub keycloak_client_id: String,
+    #[serde(default)]
+    pub keycloak_client_secret: Option<String>,
+    #[serde(default)]
+    pub keycloak_username: Option<String>,
+    #[serde(default)]
+    pub keycloak_password: Option<String>,
+}
+
+/// Response for `POST /party-config/discover-member-party`. `primary_party`
+/// is `None` when Canton's user has no primary party assigned.
+#[derive(Clone, Debug, Serialize, utoipa::ToSchema)]
+pub struct DiscoverMemberPartyResponse {
+    pub user_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub primary_party: Option<CantonId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
 }
 
 /// Request to grant the configured user the rights they need to act on a dec party
@@ -1000,12 +1028,12 @@ pub struct PartyConfigRequest {
 pub struct PartyConfigResponse {
     /// The decentralized party ID
     pub dec_party_id: CantonId,
-    /// The member party ID (local to this node). `None` if no credentials
-    /// have been saved yet — the operator must provide one via PUT.
+    /// `None` when no credentials are saved yet — operator must provide one via PUT.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub member_party_id: Option<CantonId>,
-    /// Canton/Ledger API user ID
-    pub user_id: String,
+    /// `None` when no credentials are saved yet — operator picks via Discover or types.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_id: Option<String>,
     /// Keycloak server URL
     pub keycloak_url: String,
     /// Keycloak realm name

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -399,6 +399,27 @@ pub struct AuthTestResponse {
     pub results: Vec<AuthTestResult>,
 }
 
+/// Request to grant the configured user the rights they need to act on a dec party
+#[derive(Clone, Debug, Deserialize, utoipa::ToSchema)]
+pub struct GrantRightsRequest {
+    /// Decentralized party whose coordinator user should receive rights
+    pub dec_party_id: CantonId,
+    /// Keycloak client_id of the admin (validator) client whose service-account
+    /// user has ParticipantAdmin on Canton. Provided per-call by the operator;
+    /// never stored.
+    pub admin_client_id: String,
+    /// Keycloak client_secret matching admin_client_id. Provided per-call by
+    /// the operator; never stored.
+    pub admin_client_secret: String,
+}
+
+/// Response for the grant-rights endpoint
+#[derive(Clone, Debug, Serialize, utoipa::ToSchema)]
+pub struct GrantRightsResponse {
+    /// Refreshed rights status after the grant call
+    pub rights: RightsStatus,
+}
+
 // ============================================================================
 // Governance Types (Structured Actions)
 // ============================================================================

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -237,6 +237,22 @@ pub struct OnboardingRequest {
     pub peer_ids: Vec<String>,
 }
 
+/// One directed missing edge in the peer mesh: `from` does not have `to`
+/// configured as a peer.
+#[derive(Clone, Debug, Serialize, utoipa::ToSchema)]
+pub struct MissingPeerEdge {
+    pub from: String,
+    pub to: String,
+}
+
+/// Returned when onboarding pre-flight detects that selected peers are not
+/// fully meshed. The workflow is not started.
+#[derive(Clone, Debug, Serialize, utoipa::ToSchema)]
+pub struct OnboardingMeshErrorResponse {
+    pub error: String,
+    pub missing_edges: Vec<MissingPeerEdge>,
+}
+
 /// Request to deploy contracts for a decentralized party
 #[derive(Clone, Debug, Deserialize, utoipa::ToSchema)]
 pub struct ContractsRequest {

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -237,12 +237,27 @@ pub struct OnboardingRequest {
     pub peer_ids: Vec<String>,
 }
 
+/// Why a directed edge was reported missing. The frontend renders different
+/// remediation hints depending on which kind it sees: `MeshHole` is a true
+/// peer↔peer config gap ("on `from`, add `to` to the network config"), while
+/// `UnreachableFromCoordinator` is a coordinator-side reachability problem
+/// (the peer is unknown, has no public key, didn't answer, or replied with
+/// a malformed payload — fix the coordinator's view of `to`, or `to` itself).
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum MissingEdgeKind {
+    UnreachableFromCoordinator,
+    MeshHole,
+}
+
 /// One directed missing edge in the peer mesh: `from` does not have `to`
-/// configured as a peer.
+/// configured as a peer (`MeshHole`), or the coordinator could not query
+/// `to` at all (`UnreachableFromCoordinator`, `from` is the coordinator).
 #[derive(Clone, Debug, Serialize, utoipa::ToSchema)]
 pub struct MissingPeerEdge {
     pub from: String,
     pub to: String,
+    pub kind: MissingEdgeKind,
 }
 
 /// Returned when onboarding pre-flight detects that selected peers are not

--- a/src/workflow/dars/config.rs
+++ b/src/workflow/dars/config.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::workflow::contracts::DarFile;
+use crate::{participant_id::CantonId, workflow::contracts::DarFile};
 
 /// Configuration for DARs upload workflow
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -9,4 +9,6 @@ pub struct DarsConfig {
     pub dar_files: Vec<DarFile>,
     /// Workflow instance name for directory organization
     pub instance_name: String,
+    /// Selected peers — the only nodes the coordinator expects as attestors
+    pub peer_ids: Vec<CantonId>,
 }

--- a/src/workflow/dars/coordinator.rs
+++ b/src/workflow/dars/coordinator.rs
@@ -19,11 +19,19 @@ pub async fn start_coordinator(
 ) -> Result {
     tracing::info!("Initializing Noise server for DARs upload...");
 
+    let self_id = node_config.participant_id();
+    let excluded: Vec<String> = network_config
+        .peers
+        .iter()
+        .filter(|p| &p.participant_id != self_id && !config.peer_ids.contains(&p.participant_id))
+        .map(|p| p.participant_id.to_string())
+        .collect();
+
     let server = NoiseServer::new(
         node_config.clone(),
         network_config,
         DarsStep::WaitingForAttestors,
-        None, // No excluded participants
+        Some(excluded),
     )
     .await?;
     let server = Arc::new(server);

--- a/tests/common/phases/distribute_dars.rs
+++ b/tests/common/phases/distribute_dars.rs
@@ -31,23 +31,28 @@ pub async fn run(f: &mut Fixture) -> anyhow::Result<()> {
             .with_context(|| format!("reading DAR {}", path.display()))?;
         entries.push(json!({ "filename": filename, "data": B64.encode(&bytes) }));
     }
-    let req = json!({ "dar_files": entries });
+    let upload_req = json!({ "dar_files": entries });
 
     Scenario::with_ctx("distribute DARs", InvitationIds::default())
         .given("3 DAR files on disk", |_f, _| {
             Box::pin(async move { Ok(()) })
         })
         .when("P1 uploads and distributes DARs", {
-            let req = req.clone();
+            let upload_req = upload_req.clone();
+            let entries = entries.clone();
             move |f, _| {
-                let req = req.clone();
+                let upload_req = upload_req.clone();
+                let distribute_req = json!({
+                    "dar_files": entries,
+                    "peer_ids": [&f.p2.participant_id, &f.p3.participant_id],
+                });
                 Box::pin(async move {
                     let _: Value = f
-                        .post_json(f.p1.http, "/dars/upload", &req)
+                        .post_json(f.p1.http, "/dars/upload", &upload_req)
                         .await
                         .context("POST /dars/upload")?;
                     let _: Value = f
-                        .post_json(f.p1.http, "/dars/distribute", &req)
+                        .post_json(f.p1.http, "/dars/distribute", &distribute_req)
                         .await
                         .context("POST /dars/distribute")?;
                     Ok(())


### PR DESCRIPTION
## Summary

Branch-wide batch of UI and governance-flow improvements. Each commit is independent and atomic; the changes group into a few themes:

**UI polish**
- Tooltips across icon-only buttons / status indicators / forms (`feat: added tooltips`)
- Searchbar in the Packages view (`feat: added searchbar to packages view`)
- Audit Trail now sorted newest-first (`fix: sort gov audit trail in chronological descending order`)
- Removed redundant Add Field / Add Contract buttons from Gov Core Deployment (`fix: remove redundant buttons from gov core deployment`)
- Renames per the rename table: `RelTime` → `Proposal Timeout`, `Party Set` → `Member Set`, `Domain Proposals` → `Proposals`, `Package ID` → `Package Name / ID` (`fix: better naming convention`)
- Governance section moved into its own dialog/modal off Party Detail so the page is no longer dominated by it (`feat: move governance section to its own popup modal`)

**DAR distribution**
- Peer-picker mirrors the Onboarding flow; backend filters invites + coordinator's expected attestors by the selected `peer_ids` so distributing to a subset no longer hangs forever waiting on unselected nodes (`feat: select peers when uploading DARs`)

**Auth**
- Admin role gating made optional via `Option<String>`. Default is "no role required" — every authenticated caller passes. Set `DECPM_ADMIN_ROLE` to opt back into a strict role gate. Fixes the "missing required role: dpm-admin" 403 on Party Configuration save in single-user setups (`fix: fixed auth`)
- In-app **Grant Rights** button: opens a one-shot dialog asking for the validator client_id + secret. `ParticipantAdmin` is a Canton-side user right and lives on a separate Keycloak client (the same one used in Yaak). Credentials are sent only with that one request and never stored. Backend mints the admin token via `client_credentials` and uses it for `GrantUserRights`; per-party token still used for the read-only rights re-check (`feat: grant rights`)

**Onboarding pre-flight**
- New `ListPeers` / `PeerList` Noise messages let the coordinator query each selected peer for its network config. Onboarding is rejected with **422** if any selected peer pair isn't reciprocally configured. UI surfaces actionable per-node fix instructions (`On X, add: …`) instead of letting the workflow hang on attestor connections that can never establish (`feat: pre-flight peer mesh check before onboarding`)

**Member-party lookup**
- Party Configuration dialog can now resolve the member party from a freshly entered Keycloak client by minting a probe token and asking the local Canton instance, so operators no longer have to hand-enter the canton id. New `RequestMemberParty` / `MemberPartyResponse` Noise message lets attestors look up the same value via a peer (`feat: query member party id using credentials`)
- Gov Core deployment pre-populates the member set with parties already known to the coordinator (queried via the new Noise message above), so a fresh deployment doesn't start with an empty member list (`feat: pre-populate known member parties when deploying gov core`)

**Auto-refresh**
- Affected views now refresh themselves automatically after the actions that change them (governance confirm / execute, audit trail, packages refresh, etc.) instead of leaving the operator to hit reload (`fix: automatically refresh views after certain actions`)

## Test plan

- [x] Tooltips appear on icon-only buttons, status icons, GovernanceSection refresh icons, etc.
- [x] Packages view: search filters by name/id, count updates, both default and peer-comparison views filter
- [x] Audit Trail rows render newest-first; expand/collapse works
- [x] Gov Core deployment: Add Contract / Add Field buttons hidden; pre-populated contracts still render; member set is pre-filled with known parties
- [x] Renames visible in their respective dropdowns / dialog labels
- [x] Governance section opens in a modal from Party Detail; closing returns to the page without state loss
- [x] DAR distribute: peer checkbox list shown only in distribute mode; submit disabled with no peers; only selected peers receive invites and the coordinator only expects them as attestors
- [x] Save Party Configuration succeeds without `dpm-admin`/`decman-admin` role on the JWT (when `DECPM_ADMIN_ROLE` is unset). Setting it still enforces the role.
- [x] Grant Rights: clicking the button opens the credentials dialog; pasting the validator client_id + secret used in Yaak grants `actAs`+`readAs` on member and dec parties; rights chips flip green; secret never written to storage
- [x] Onboarding with a non-meshed peer set fails with 422 + a per-node fix list; after each missing peer is added on the right node, retry succeeds
- [x] Party Configuration: entering Keycloak client_id + secret resolves the member party automatically (no manual entry); attestor side gets the same answer via the new Noise lookup
- [x] After confirming/executing/expiring a governance action, the action card refreshes without manual reload; same for the audit trail and packages view after a refresh
- [x] Backend: \`cargo fmt && cargo clippy --all-targets --all-features -- -D warnings && cargo test --features test-mode\` clean
- [x] Frontend: \`npx tsc -b && npm run lint\` clean