### PR TITLE
docs: caught up governance docs with v0-rc4 and recent UI/governance polish

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -371,6 +371,7 @@ interface GovernableAction where
 
 data GovernableActionView = GovernableActionView with
     governanceParty : Party    -- The party whose authority is required
+    proposer        : Party    -- The party that proposed this action (required for proposer authorization)
     actionLabel     : Text     -- Human-readable label (e.g., "Transfer", "GenericVote")
     description     : Text     -- Description recorded in the execution result
 ```
@@ -386,12 +387,15 @@ The `GovernanceRules` contract (from `Governance.Rules`) is the core governance 
 
 ```
 GovernanceRules {
-    governanceParty          : Party      -- The decentralized governance party
-    members                  : Set Party  -- Committee members authorized to vote
-    threshold                : Int        -- Minimum confirmations required (1 <= threshold <= |members|)
-    actionConfirmationTimeout : RelTime   -- Confirmation validity period (minimum 10 seconds)
+    governanceParty          : Party                  -- The decentralized governance party
+    members                  : Set Party              -- Committee members authorized to vote
+    threshold                : Int                    -- Minimum confirmations required (1 <= threshold <= |members|)
+    actionConfirmationTimeout : RelTime               -- Confirmation validity period (minimum 10 seconds)
+    additionalProposers      : Optional (Set Party)   -- Allowlist of non-member proposers; None means "no allowlist"
 }
 ```
+
+The `additionalProposers` field (added in `v0-rc4`) lets a committee grant propose-only rights to parties that are not full voting members — for example, an admin console, a monitoring script, or a regulatory officer. The authoritative on-chain proposer set is `members ∪ fromOptional Set.empty additionalProposers`. `GovernanceRules_ConfirmAction` enforces that every proposal's `proposer` is in this set; outsider proposals are rejected at confirm time even if a member tries to confirm them. The two `SelfAction_*AdditionalProposer` variants below mutate this allowlist under the same threshold consensus as committee changes.
 
 The contract provides two distinct paths for governance actions:
 
@@ -405,6 +409,8 @@ Self-management actions modify the `GovernanceRules` contract itself. They use a
 | `SelfAction_RemoveMemberAndSetThreshold` | removedMember, newThresholdAfterRemove | Remove a governance member |
 | `SelfAction_SetThreshold` | updatedThreshold | Change the approval threshold |
 | `SelfAction_SetTimeout` | updatedTimeout | Change the confirmation expiry timeout |
+| `SelfAction_AddAdditionalProposer` | additionalProposer | Grant propose-only rights to a non-member party |
+| `SelfAction_RemoveAdditionalProposer` | additionalProposer | Revoke propose-only rights from a party (normalizes the allowlist back to `None` when it becomes empty) |
 
 Choices on `GovernanceRules` for self-management:
 - `GovernanceRules_ConfirmGovernanceAction` -- Submit a self-action confirmation

--- a/docs/INTEGRATION_GUIDE.md
+++ b/docs/INTEGRATION_GUIDE.md
@@ -871,6 +871,7 @@ Each participant's Ledger API user needs:
 | POST | `/network-config` | Save peer list to database | `[{ "participant_id": "...", "name": "...", "address": "...", "port": 9000, "public_key": "..." }]` | `{ "success": true }` |
 | GET | `/party-config/{dec_party_id}` | Get party config (secrets masked) | -- | Party config JSON |
 | PUT | `/party-config` | Save/update party credentials | Party config JSON | `{ "success": true }` |
+| POST | `/party-config/discover-member-party` | Discover a member party's Canton ID via Keycloak (admin-only) | `{ keycloak_url, keycloak_realm, keycloak_client_id, keycloak_client_secret? \| keycloak_username + keycloak_password }` | `DiscoverMemberPartyResponse` |
 
 ### Keys
 
@@ -884,6 +885,7 @@ Each participant's Ledger API user needs:
 |--------|----------|-------------|--------------|----------|
 | GET | `/decentralized-parties` | List decentralized parties | `prefix` (optional) | `{ "parties": [...] }` |
 | GET | `/participants-status` | Peer connectivity status | -- | `{ "statuses": [...] }` |
+| GET | `/packages/compare-peers` | Cross-check vetted-package IDs across peers (admin-only) | -- | `{ "missing_on": [...], "extra_on": [...] }` |
 
 ### Workflows
 
@@ -912,8 +914,10 @@ Each participant's Ledger API user needs:
 
 | Method | Endpoint | Description | Response |
 |--------|----------|-------------|----------|
+| GET | `/auth-config` | Get the configured auth provider (mock or keycloak) | `{ "provider": "..." }` |
 | GET | `/auth/status` | Get auth status for all parties | `{ "parties": [...] }` |
 | POST | `/auth/test` | Test authentication | `{ "results": [...] }` |
+| POST | `/auth/grant-rights` | Grant Canton actAs/readAs rights to a party (admin-only) | `{ "rights": { ... } }` |
 
 ### Governance
 
@@ -952,6 +956,8 @@ All governance mutation endpoints accept a `governance_type` field that selects 
 }
 ```
 
+The server populates the `proposer` field on the proposal contract automatically (using the calling party's identity). As of `v0-rc4`, that proposer must be a member of the targeted `GovernanceRules` or appear in its `additionalProposers` allowlist; otherwise the auto-confirmation step rejects the proposal at confirm time.
+
 Available proposal types:
 
 | Type | Fields | Description |
@@ -986,6 +992,19 @@ Available proposal types:
   "governance_type": "core_self"
 }
 ```
+
+Available `core_self` action types (DAML `GovernanceSelfAction` variants):
+
+| `type` | Required fields | DAML variant |
+|---|---|---|
+| `governance_add_member` | `member`, `new_threshold` | `SelfAction_AddMemberAndSetThreshold` |
+| `governance_remove_member` | `member`, `new_threshold` | `SelfAction_RemoveMemberAndSetThreshold` |
+| `governance_set_threshold` | `new_threshold` | `SelfAction_SetThreshold` |
+| `governance_set_timeout` | `new_timeout_microseconds` | `SelfAction_SetTimeout` |
+| `governance_add_additional_proposer` | `additional_proposer` (party id) | `SelfAction_AddAdditionalProposer` |
+| `governance_remove_additional_proposer` | `additional_proposer` (party id) | `SelfAction_RemoveAdditionalProposer` |
+
+The two `*_additional_proposer` variants (added in `v0-rc4`) mutate the `additionalProposers` allowlist on `GovernanceRules`. See ARCHITECTURE.md for the proposer-authorization model.
 
 **For domain actions (`governance_type: "core_domain"`):**
 

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -790,7 +790,7 @@ curl -X POST http://custodian-a:8080/governance/propose \
 
 ### Governance Self-Management
 
-The `GovernanceRules` contract supports self-management actions (add/remove members, change threshold, change timeout) through the `core_self` governance type. These do not require proposals -- they use value-based matching like `VaultGovernanceRules`.
+The `GovernanceRules` contract supports self-management actions (add/remove members, change threshold, change timeout, manage the additional-proposers allowlist) through the `core_self` governance type. These do not require proposals -- they use value-based matching like `VaultGovernanceRules`.
 
 **Add a new member:**
 
@@ -840,6 +840,24 @@ curl -X POST http://custodian-a:8080/governance/confirm \
     "governance_type": "core_self"
   }'
 ```
+
+**Grant propose-only rights to a non-member (`v0-rc4`+):**
+
+```bash
+curl -X POST http://custodian-a:8080/governance/confirm \
+  -H "Content-Type: application/json" \
+  -d '{
+    "party_id": "joint-vault::1220...",
+    "rules_contract_id": "<governance-rules-cid>",
+    "action": {
+      "type": "governance_add_additional_proposer",
+      "additional_proposer": "ops-console::1220..."
+    },
+    "governance_type": "core_self"
+  }'
+```
+
+`governance_remove_additional_proposer` (with the same `additional_proposer` field) revokes the right and normalizes the `additionalProposers` allowlist back to `None` once it becomes empty. After execution the named party can call `POST /governance/propose` against this `GovernanceRules` without holding a member seat -- the on-chain proposer-authorization rule (member ∪ allowlist) accepts them at confirm time.
 
 After threshold confirmations are collected, execute with:
 


### PR DESCRIPTION
## Summary

Sanity-check pass over \`docs/\` after PRs #74 (rc4 / additionalProposers allowlist) and #71 (UI/governance polish) merged. Mostly accurate already — package IDs are correctly rc4 across all four files and \`MIGRATION_GUIDE.md\` is fully clean. Three files needed catch-up:

### \`docs/ARCHITECTURE.md\`
- Added \`proposer : Party\` to the \`GovernableActionView\` shape.
- Added \`additionalProposers : Optional (Set Party)\` to the \`GovernanceRules\` schema block, plus a paragraph explaining the proposer-authorization model.
- Added \`SelfAction_AddAdditionalProposer\` / \`SelfAction_RemoveAdditionalProposer\` rows to the \`GovernanceSelfAction\` variant table.

### \`docs/INTEGRATION_GUIDE.md\`
- Added missing routes to API reference: \`GET /auth-config\`, \`POST /auth/grant-rights\`, \`POST /party-config/discover-member-party\`, \`GET /packages/compare-peers\`.
- Added a full \`core_self\` action-type table covering all six DAML \`GovernanceSelfAction\` variants (the four existing ones plus the two new \`*_additional_proposer\` ones).
- Noted on \`POST /governance/propose\` that the server forwards the calling party as \`proposer\`, and that as of v0-rc4 the proposer must be a member or in the \`additionalProposers\` allowlist.

### \`docs/USE_CASES.md\`
- Added a \`governance_add_additional_proposer\` example to the Governance Self-Management section, with a note about \`governance_remove_additional_proposer\` and the canonical-\`None\` normalization.
- Updated the section intro to mention the new allowlist actions.

### Out of scope (gap, but not a doc bug)
- \`/governance/state\` does not yet surface \`additionalProposers\` — \`extract_governance_state\` in \`src/server/queries.rs:1106\` doesn't pull the field. The doc example is accurate as-is. Surfacing the field through the API is a separate change.

## Test plan
- [ ] Visual review of the diff