### PR TITLE
docs(migration): rewrote MIGRATION_GUIDE.md for external single-participant audience

### DIFF
--- a/docs/MIGRATION_GUIDE.md
+++ b/docs/MIGRATION_GUIDE.md
@@ -1,6 +1,6 @@
-# DPM Migration Guide
+# Dec Party Manager Migration Guide
 
-How to move an existing single-participant DPM (Dec Party Manager) deployment to the current release.
+How to move an existing single-participant Dec Party Manager deployment to the current release.
 
 The format has changed substantially: configuration moved from a mounted TOML file to environment variables, the Service type changed from `LoadBalancer` to `ClusterIP` behind an Ingress, the ConfigMap is gone, and the admin UI is now gated by Keycloak. Rather than patching the old deployment in place, **the cleanest path is a fresh deployment**: tear the old deployment down, apply the new manifests, and re-establish your peer list with the other participants once everyone has redeployed. Because the new deployment generates a fresh Noise keypair on first start (and every other participant going through the same migration will too), there's no value in carrying the old peer list across — every public key in it is about to change. Treat this as a coordinated rebuild, not an in-place upgrade.
 
@@ -14,7 +14,7 @@ This guide assumes:
 
 1. **Tear down** the old Deployment, ConfigMap, Secret, and LoadBalancer Service.
 2. **Pull the latest image tag** and prepare new manifests (Secret, Deployment + PVC, Service, Ingress).
-3. **Apply the new manifests** and let DPM start clean.
+3. **Apply the new manifests** and let it start clean.
 4. **Re-share public keys** with the other participants and add them as peers in the new UI.
 5. **Re-enter party credentials** (Keycloak per-party client info) through the new UI.
 
@@ -36,7 +36,7 @@ The PVC contains the SQLite database and the Noise keypair; wiping it is what fo
 
 ## 2 — Pull the latest image
 
-The new DPM is published as a public container image:
+The Dec Party Manager is published as a public container image:
 
 ```
 public.ecr.aws/dlc-link/canton-decparty-manager:<tag>
@@ -50,13 +50,13 @@ To check the version of a running pod:
 kubectl -n <your-namespace> get deploy dec-party-manager -o jsonpath='{.spec.template.spec.containers[0].image}'
 ```
 
-Bumping the tag in the Deployment manifest and re-applying is how you upgrade DPM going forward — no schema migrations or config rewrites are required between minor releases.
+Bumping the tag in the Deployment manifest and re-applying is how you upgrade going forward. The application runs any required SQL migrations against its SQLite database automatically on startup, so a tag bump is the only operator step between releases.
 
 ## 3 — Apply the new manifests
 
-Below is a complete single-participant manifest set. Replace every `<...>` placeholder with values for your environment, save as a file, and apply with `kubectl apply -f <file>.yaml`.
+Below is the core single-participant manifest set. Replace every `<...>` placeholder with values for your environment, save as a file, and apply with `kubectl apply -f <file>.yaml`. Public exposure of the Noise port is environment-specific and is covered separately under "Service" below.
 
-### 4a. Namespace (skip if it already exists)
+### 3a. Namespace (skip if it already exists)
 
 ```yaml
 apiVersion: v1
@@ -65,7 +65,7 @@ metadata:
   name: <your-namespace>
 ```
 
-### 4b. Secret (configuration)
+### 3b. Secret (configuration)
 
 ```yaml
 apiVersion: v1
@@ -99,14 +99,15 @@ stringData:
   # DECPM_ADMIN_ROLE: "dpm-admin"
 
   # Optional: encryption key for secrets stored in the SQLite database
-  # (Keycloak client secrets per party). 32-byte random hex. If unset,
-  # secrets are stored in plaintext in the DB.
-  # DECPM_DB_ENCRYPTION_KEY: "<64-hex-chars>"
+  # (Keycloak client secrets per party). Any sufficiently long random
+  # passphrase — it is hashed with SHA-256 to derive the actual 32-byte
+  # key. If unset, secrets are stored in plaintext in the DB.
+  # DECPM_DB_ENCRYPTION_KEY: "<long-random-passphrase>"
 
   # Optional: tighten CORS to a specific origin if the UI is served from a
   # different host than the API (reverse-proxy / dev server). Defaults to
   # same-origin only, which is correct for the Ingress setup below.
-  # DECPM_ALLOWED_ORIGIN: "https://<ui-host>"
+  # DECPM_ALLOWED_ORIGIN: "https://<your-ui-host>"
 
   # Noise transport timeouts (seconds). Defaults are usually fine.
   DECPM_TIMEOUT_HANDSHAKE: "30"
@@ -115,7 +116,7 @@ stringData:
   DECPM_TIMEOUT_RETRY_DELAY: "5"
 ```
 
-### 4c. Deployment + PersistentVolumeClaim
+### 3c. Deployment + PersistentVolumeClaim
 
 ```yaml
 apiVersion: v1
@@ -190,7 +191,7 @@ spec:
             claimName: dec-party-manager-data
 ```
 
-### 4d. Service
+### 3d. Service
 
 ```yaml
 apiVersion: v1
@@ -213,7 +214,7 @@ spec:
 
 The Noise port (9000) must also be reachable from the public internet for peers to connect. Depending on your cluster, you may need a separate `LoadBalancer`-type Service, a `NodePort`, or another mechanism (MetalLB, native cloud load balancer, etc.) for the `noise` port specifically. The HTTP UI does not need to be exposed publicly — it is reached through the Ingress (next).
 
-### 4e. Ingress (Traefik example)
+### 3e. Ingress (Traefik example)
 
 ```yaml
 apiVersion: networking.k8s.io/v1
@@ -249,52 +250,54 @@ Once the pod is `Running`, hit `https://<your-ui-host>` in a browser. Keycloak s
 
 ## 4 — Re-establish peers
 
-The new DPM has generated a fresh Noise keypair on first start. None of the other participants know it yet, and you do not yet know any of theirs (assuming they are also redeploying). The peer list has to be rebuilt from scratch by exchanging public keys out-of-band.
+The fresh deployment has generated a new Noise keypair on first start. None of the other participants know it yet, and you do not yet know any of theirs (assuming they are also redeploying). The peer list has to be rebuilt from scratch by exchanging public keys out-of-band.
 
-For each participant in your network:
+The UI makes the round-trip simple. For each participant in your network:
 
-1. Find your own public key + public address. In the UI, open the "Network Config" panel — your local node's public key is shown there. (Same value is reachable via `GET /keys/status`.) Note your `DECPM_PUBLIC_ADDRESS` and Noise port (default `9000`).
-2. Share that information with each peer through whatever out-of-band channel you use (chat, email, ticket). They need: your `participant_id`, a friendly name, the public address, the Noise port, and the public key.
-3. Collect the same information from each of them.
-4. In the "Network Config" panel, add each peer with their newly-shared values and save.
+1. Open the **Network** panel.
+2. Click **Share my data** — this copies your own peer entry (participant id, friendly name, public address, Noise port, public key) to the clipboard as JSON.
+3. Send that JSON to your peer through whatever out-of-band channel you use (chat, email, ticket).
+4. When a peer sends you their JSON, click **Paste from Clipboard** in your **Network** panel and save. The peer is added with all the right fields filled in.
 
-The "Participants Status" panel shows handshake / reachability state per peer; healthy peers will turn green within seconds of both sides having added each other.
+Repeat with every participant. The "Participants Status" indicators turn green within seconds once both sides have added each other.
 
-If a peer is migrating ahead of you, share your old public key and let them add you with that value temporarily — once you have redeployed, share the new key and they can update their entry.
+If a peer is migrating ahead of you, share your old peer data and let them add you with those values temporarily — once you have redeployed, click **Share my data** again and re-send so they can update their entry.
 
 ## 5 — Re-enter party credentials
 
-For each decentralized party your node manages, open the "Party Config" dialog and re-enter the Keycloak settings (URL, realm, client ID, client secret). DPM uses these to obtain Canton ledger tokens on behalf of each party.
+For each decentralized party your node manages, open the "Party Config" dialog and re-enter the Keycloak settings (URL, realm, client ID, client secret). The application uses these to obtain Canton ledger tokens on behalf of each party.
 
 ## Configuration reference
 
-| Variable | Default | Notes |
-|---|---|---|
-| `DECPM_LISTEN_ADDRESS` | `0.0.0.0` | Noise transport bind address |
-| `DECPM_NOISE_PORT` | `9000` | Noise transport port |
-| `DECPM_PUBLIC_ADDRESS` | — | **Required.** Hostname peers use to reach this node |
-| `DECPM_CANTON_ADMIN_HOST` | — | **Required.** Canton Admin API host |
-| `DECPM_CANTON_ADMIN_PORT` | — | **Required.** Canton Admin API port (typ. `5002`) |
-| `DECPM_CANTON_LEDGER_HOST` | — | **Required.** Canton Ledger API host |
-| `DECPM_CANTON_LEDGER_PORT` | — | **Required.** Canton Ledger API port (typ. `5001`) |
-| `DECPM_CANTON_SYNCHRONIZER` | — | **Required.** Synchronizer name (`global` for mainnet) |
-| `DECPM_CANTON_NETWORK` | — | **Required.** `mainnet`, `testnet`, or `devnet` |
-| `DECPM_KEYCLOAK_URL` | — | **Required.** Keycloak server URL for frontend auth |
-| `DECPM_KEYCLOAK_REALM` | — | **Required.** Keycloak realm |
-| `DECPM_KEYCLOAK_CLIENT_ID` | — | **Required.** Keycloak client used by the SPA |
-| `DECPM_ADMIN_ROLE` | unset | Optional Keycloak role required for privileged endpoints |
-| `DECPM_ALLOWED_ORIGIN` | same-origin | Optional CORS origin if UI host ≠ API host |
-| `DECPM_DB_ENCRYPTION_KEY` | unset | Optional encryption key for secrets at rest in the SQLite DB |
-| `DECPM_TIMEOUT_HANDSHAKE` | `30` | Noise handshake timeout (seconds) |
-| `DECPM_TIMEOUT_MESSAGE` | `120` | Noise message timeout (seconds) |
-| `DECPM_TIMEOUT_RETRY_ATTEMPTS` | `3` | Connection retry attempts |
-| `DECPM_TIMEOUT_RETRY_DELAY` | `5` | Connection retry delay (seconds) |
+Most variables have a default that's only useful for local development (loopback Canton, devnet, etc.). For a Kubernetes deployment you should set every variable in the "Set for K8s" column even when there is a code default — the defaults shown are what the binary falls back to if the variable is unset, not what your cluster wants.
 
-## Note: keeping the existing PVC
+| Variable | Code default | Set for K8s? | Notes |
+|---|---|---|---|
+| `DECPM_LISTEN_ADDRESS` | `0.0.0.0` | optional | Noise transport bind address |
+| `DECPM_NOISE_PORT` | `9000` | optional | Noise transport port |
+| `DECPM_PUBLIC_ADDRESS` | falls back to `DECPM_LISTEN_ADDRESS` | **yes** | Hostname peers use to reach this node from the public internet |
+| `DECPM_CANTON_ADMIN_HOST` | `127.0.0.1` | **yes** | Canton Admin API host |
+| `DECPM_CANTON_ADMIN_PORT` | `5002` | optional | Canton Admin API port |
+| `DECPM_CANTON_LEDGER_HOST` | `127.0.0.1` | **yes** | Canton Ledger API host |
+| `DECPM_CANTON_LEDGER_PORT` | `5001` | optional | Canton Ledger API port |
+| `DECPM_CANTON_SYNCHRONIZER` | `global` | optional | Synchronizer name |
+| `DECPM_CANTON_NETWORK` | `devnet` | **yes** | `mainnet`, `testnet`, or `devnet` |
+| `DECPM_KEYCLOAK_URL` | unset | **yes** | Keycloak server URL for frontend auth |
+| `DECPM_KEYCLOAK_REALM` | unset | **yes** | Keycloak realm |
+| `DECPM_KEYCLOAK_CLIENT_ID` | unset | **yes** | Keycloak client used by the SPA |
+| `DECPM_ADMIN_ROLE` | unset | recommended | Keycloak role required for privileged endpoints. If unset, every authenticated caller is treated as admin. |
+| `DECPM_ALLOWED_ORIGIN` | same-origin | optional | CORS origin if UI host ≠ API host |
+| `DECPM_DB_ENCRYPTION_KEY` | unset | recommended | Random passphrase (hashed via SHA-256) protecting party secrets at rest. If unset, secrets are stored in plaintext in the SQLite DB. |
+| `DECPM_TIMEOUT_HANDSHAKE` | `30` | optional | Noise handshake timeout (seconds) |
+| `DECPM_TIMEOUT_MESSAGE` | `120` | optional | Noise message timeout (seconds) |
+| `DECPM_TIMEOUT_RETRY_ATTEMPTS` | `3` | optional | Connection retry attempts |
+| `DECPM_TIMEOUT_RETRY_DELAY` | `5` | optional | Connection retry delay (seconds) |
 
-If you would rather not regenerate your Noise keypair (so peers don't have to update their entries for you), you can keep the existing PVC and only replace the Deployment, Service, ConfigMap, and Ingress resources. The new DPM reads its existing SQLite database on first start, so your peer list and Noise keypair carry over automatically.
+## Note: keeping the existing Noise keypair
 
-The trade-off: if there have been schema changes between your old version and the latest, the new DPM may need to migrate the database in place. If the migration fails or you hit unexpected behavior, fall back to the clean-slate approach above.
+If you would rather not regenerate your Noise keypair (so peers don't have to update their entry for you), you can preserve the keypair file from your old PVC. The keypair is stored as a file in the data directory (not in the SQLite database), so it survives a clean redeploy as long as you keep the same PVC mounted at `/app`.
+
+The peer list and party credentials do **not** carry over: those live in the SQLite database, which the new format introduces. The first time the new application starts on the preserved PVC it will create a fresh database alongside the existing keypair file. You will still need to re-establish peers (Step 4) and re-enter party credentials (Step 5) — the only thing you save is the round-trip with peers having to update their entry for you.
 
 ## Troubleshooting
 

--- a/docs/MIGRATION_GUIDE.md
+++ b/docs/MIGRATION_GUIDE.md
@@ -1,140 +1,203 @@
-# Migration Guide
+# DPM Migration Guide
 
-How to migrate DPM deployment files from the old format to the new format.
+How to move an existing single-participant DPM (Dec Party Manager) deployment to the current release.
 
-## Configuration: TOML File Replaced by Environment Variables
+The format has changed substantially: configuration moved from a mounted TOML file to environment variables, the Service type changed from `LoadBalancer` to `ClusterIP` behind an Ingress, the ConfigMap is gone, and the admin UI is now gated by Keycloak. Rather than patching the old deployment in place, **the cleanest path is a fresh deployment**: tear the old deployment down, apply the new manifests, and re-establish your peer list with the other participants once everyone has redeployed. Because the new deployment generates a fresh Noise keypair on first start (and every other participant going through the same migration will too), there's no value in carrying the old peer list across — every public key in it is about to change. Treat this as a coordinated rebuild, not an in-place upgrade.
 
-The old format used a `node.toml` file mounted via a ConfigMap:
+This guide assumes:
+- One participant per cluster (the most common external setup).
+- A working Kubernetes cluster with a Traefik (or other) Ingress controller.
+- Access to a Keycloak realm you control (or that an operator has set up for you).
+- You already have a Canton participant node running and reachable from the cluster.
 
-```toml
-[node]
-listen_address = "0.0.0.0"
-public_address = "<address>"
-port = 9000
+## Migration at a glance
 
-[canton]
-admin_api_host = "<host>"
-admin_api_port = 5002
-ledger_api_host = "<host>"
-ledger_api_port = 5001
-synchronizer = "global"
-network = "<network>"
+1. **Tear down** the old Deployment, ConfigMap, Secret, and LoadBalancer Service.
+2. **Pull the latest image tag** and prepare new manifests (Secret, Deployment + PVC, Service, Ingress).
+3. **Apply the new manifests** and let DPM start clean.
+4. **Re-share public keys** with the other participants and add them as peers in the new UI.
+5. **Re-enter party credentials** (Keycloak per-party client info) through the new UI.
 
-[timeouts]
-handshake_timeout_secs = 30
-message_timeout_secs = 120
-connection_retry_attempts = 3
-connection_retry_delay_secs = 5
+Total downtime is typically a few minutes per participant. The longer step is the cross-team coordination needed to re-share Noise public keys after everyone redeploys.
+
+## 1 — Tear down the old deployment
+
+Delete the old resources cleanly. From a workstation with `kubectl` access:
+
+```bash
+kubectl -n <your-namespace> delete deployment <your-old-deployment>
+kubectl -n <your-namespace> delete service <your-old-service>
+kubectl -n <your-namespace> delete configmap <your-old-configmap>
+kubectl -n <your-namespace> delete secret <your-old-secret>
+kubectl -n <your-namespace> delete pvc <your-old-pvc>
 ```
 
-The new format uses `DECPM_*` environment variables in a Secret:
+The PVC contains the SQLite database and the Noise keypair; wiping it is what forces a clean start. Your peers will see your new public key once the new deployment is up — that is expected, and they will be doing the same. If you would rather not regenerate the keypair (for example, if you are migrating ahead of your peers and want to stay reachable on your existing key), see the note at the end about keeping the existing PVC.
+
+## 2 — Pull the latest image
+
+The new DPM is published as a public container image:
+
+```
+public.ecr.aws/dlc-link/canton-decparty-manager:<tag>
+```
+
+Use the latest tagged release (for example `0.0.30`). Pin the version explicitly — do not use `latest`. If your cluster cannot pull from Public ECR directly, mirror the image into your own registry first.
+
+To check the version of a running pod:
+
+```bash
+kubectl -n <your-namespace> get deploy dec-party-manager -o jsonpath='{.spec.template.spec.containers[0].image}'
+```
+
+Bumping the tag in the Deployment manifest and re-applying is how you upgrade DPM going forward — no schema migrations or config rewrites are required between minor releases.
+
+## 3 — Apply the new manifests
+
+Below is a complete single-participant manifest set. Replace every `<...>` placeholder with values for your environment, save as a file, and apply with `kubectl apply -f <file>.yaml`.
+
+### 4a. Namespace (skip if it already exists)
 
 ```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: <your-namespace>
+```
+
+### 4b. Secret (configuration)
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dec-party-manager-secrets
+  namespace: <your-namespace>
+type: Opaque
 stringData:
-  DECPM_PUBLIC_ADDRESS: "<address>"
-  DECPM_CANTON_ADMIN_HOST: "<host>"
+  # Public address that peers use to reach this node over the Noise transport.
+  # Must be reachable from the public internet on the Noise port (9000 by default).
+  DECPM_PUBLIC_ADDRESS: "<your-public-host>"
+
+  # Canton participant node connection (Admin + Ledger gRPC APIs).
+  DECPM_CANTON_ADMIN_HOST: "<canton-admin-host>"
   DECPM_CANTON_ADMIN_PORT: "5002"
-  DECPM_CANTON_LEDGER_HOST: "<host>"
+  DECPM_CANTON_LEDGER_HOST: "<canton-ledger-host>"
   DECPM_CANTON_LEDGER_PORT: "5001"
-  DECPM_CANTON_NETWORK: "<network>"
+  DECPM_CANTON_NETWORK: "mainnet"          # mainnet | testnet | devnet
   DECPM_CANTON_SYNCHRONIZER: "global"
-  DECPM_KEYCLOAK_URL: "<keycloak-url>"
-  DECPM_KEYCLOAK_REALM: "<realm>"
-  DECPM_KEYCLOAK_CLIENT_ID: "<client-id>"
+
+  # Keycloak (gates the admin UI).
+  DECPM_KEYCLOAK_URL: "https://<your-keycloak-host>"
+  DECPM_KEYCLOAK_REALM: "<your-realm>"
+  DECPM_KEYCLOAK_CLIENT_ID: "<frontend-client-id>"
+
+  # Optional: require a specific Keycloak role on every authenticated caller
+  # before they can hit privileged endpoints (PUT /party-config, /kick, etc.).
+  # If unset, every authenticated user is treated as admin — fine for a
+  # single-operator deployment, dangerous for shared environments.
+  # DECPM_ADMIN_ROLE: "dpm-admin"
+
+  # Optional: encryption key for secrets stored in the SQLite database
+  # (Keycloak client secrets per party). 32-byte random hex. If unset,
+  # secrets are stored in plaintext in the DB.
+  # DECPM_DB_ENCRYPTION_KEY: "<64-hex-chars>"
+
+  # Optional: tighten CORS to a specific origin if the UI is served from a
+  # different host than the API (reverse-proxy / dev server). Defaults to
+  # same-origin only, which is correct for the Ingress setup below.
+  # DECPM_ALLOWED_ORIGIN: "https://<ui-host>"
+
+  # Noise transport timeouts (seconds). Defaults are usually fine.
   DECPM_TIMEOUT_HANDSHAKE: "30"
   DECPM_TIMEOUT_MESSAGE: "120"
   DECPM_TIMEOUT_RETRY_ATTEMPTS: "3"
   DECPM_TIMEOUT_RETRY_DELAY: "5"
 ```
 
-TOML field to env var mapping:
-
-| TOML (`node.toml`) | Environment Variable |
-|---------------------|---------------------|
-| `node.listen_address` | `DECPM_LISTEN_ADDRESS` (defaults to `0.0.0.0`) |
-| `node.public_address` | `DECPM_PUBLIC_ADDRESS` |
-| `node.port` | `DECPM_NOISE_PORT` (defaults to `9000`) |
-| `canton.admin_api_host` | `DECPM_CANTON_ADMIN_HOST` |
-| `canton.admin_api_port` | `DECPM_CANTON_ADMIN_PORT` |
-| `canton.ledger_api_host` | `DECPM_CANTON_LEDGER_HOST` |
-| `canton.ledger_api_port` | `DECPM_CANTON_LEDGER_PORT` |
-| `canton.synchronizer` | `DECPM_CANTON_SYNCHRONIZER` |
-| `canton.network` | `DECPM_CANTON_NETWORK` |
-| `timeouts.handshake_timeout_secs` | `DECPM_TIMEOUT_HANDSHAKE` |
-| `timeouts.message_timeout_secs` | `DECPM_TIMEOUT_MESSAGE` |
-| `timeouts.connection_retry_attempts` | `DECPM_TIMEOUT_RETRY_ATTEMPTS` |
-| `timeouts.connection_retry_delay_secs` | `DECPM_TIMEOUT_RETRY_DELAY` |
-| *(not in TOML)* | `DECPM_KEYCLOAK_URL` |
-| *(not in TOML)* | `DECPM_KEYCLOAK_REALM` |
-| *(not in TOML)* | `DECPM_KEYCLOAK_CLIENT_ID` |
-
-The Keycloak variables are new -- they gate frontend access via Keycloak authentication.
-
-## ConfigMap Removed
-
-The old format required a ConfigMap to mount the TOML file and a `copy-config` initContainer to copy it into the persistent volume:
+### 4c. Deployment + PersistentVolumeClaim
 
 ```yaml
-# OLD -- remove this
-initContainers:
-  - name: copy-config
-    image: busybox:latest
-    command:
-      - sh
-      - -c
-      - |
-        mkdir -p /app/config /app/data
-        cp /config-readonly/* /app/config/
-volumes:
-  - name: config
-    configMap:
-      name: dec-party-manager-1-config
-```
-
-The new format replaces it with a simpler initContainer that only ensures the data directory exists, and loads config from the Secret via `envFrom`:
-
-```yaml
-# NEW
-initContainers:
-  - name: init-data
-    image: busybox:latest
-    command: ["sh", "-c", "mkdir -p /app/data"]
-    volumeMounts:
-      - name: data
-        mountPath: /app
-containers:
-  - name: dec-party-manager
-    env:
-      - name: RUST_LOG
-        value: dec_party_manager=debug,tokio_noise=error,hyper_noise=error
-    envFrom:
-      - secretRef:
-          name: dec-party-manager-1-secrets
-```
-
-The ConfigMap resource can be deleted entirely.
-
-## Service: LoadBalancer to ClusterIP + Ingress
-
-The old format exposed both HTTP and Noise ports via a LoadBalancer service:
-
-```yaml
-# OLD
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dec-party-manager-data
+  namespace: <your-namespace>
 spec:
-  type: LoadBalancer
-  ports:
-    - name: http
-      port: 80
-      targetPort: 8080
-    - name: noise
-      port: 9000
-      targetPort: 9000
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dec-party-manager
+  namespace: <your-namespace>
+  labels:
+    app.kubernetes.io/name: dec-party-manager
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: dec-party-manager
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: dec-party-manager
+    spec:
+      initContainers:
+        - name: init-data
+          image: busybox:latest
+          command: ["sh", "-c", "mkdir -p /app/data"]
+          volumeMounts:
+            - name: data
+              mountPath: /app
+      containers:
+        - name: dec-party-manager
+          image: public.ecr.aws/dlc-link/canton-decparty-manager:<tag>
+          imagePullPolicy: Always
+          command:
+            - dec-party-manager
+            - -d
+            - /app
+            - serve
+            - --host
+            - 0.0.0.0
+            - --port
+            - "8080"
+          ports:
+            - name: http
+              containerPort: 8080
+            - name: noise
+              containerPort: 9000
+          volumeMounts:
+            - name: data
+              mountPath: /app
+          resources:
+            requests: { memory: "128Mi", cpu: "100m" }
+            limits:   { memory: "512Mi", cpu: "500m" }
+          env:
+            - name: RUST_LOG
+              value: dec_party_manager=info,tokio_noise=error,hyper_noise=error
+          envFrom:
+            - secretRef:
+                name: dec-party-manager-secrets
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: dec-party-manager-data
 ```
 
-The new format uses ClusterIP with a Traefik Ingress for HTTP:
+### 4d. Service
 
 ```yaml
-# NEW -- Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: dec-party-manager
+  namespace: <your-namespace>
 spec:
   type: ClusterIP
   ports:
@@ -144,48 +207,98 @@ spec:
     - name: noise
       port: 9000
       targetPort: 9000
+  selector:
+    app.kubernetes.io/name: dec-party-manager
 ```
 
+The Noise port (9000) must also be reachable from the public internet for peers to connect. Depending on your cluster, you may need a separate `LoadBalancer`-type Service, a `NodePort`, or another mechanism (MetalLB, native cloud load balancer, etc.) for the `noise` port specifically. The HTTP UI does not need to be exposed publicly — it is reached through the Ingress (next).
+
+### 4e. Ingress (Traefik example)
+
 ```yaml
-# NEW -- Ingress
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: dec-party-manager-1-ingress
-  namespace: catalyst-canton
+  name: dec-party-manager
+  namespace: <your-namespace>
 spec:
   ingressClassName: traefik
   rules:
-    - host: dec-party-manager-1.<env>.canton.ibtc.network
+    - host: <your-ui-host>
       http:
         paths:
           - path: /
             pathType: Prefix
             backend:
               service:
-                name: dec-party-manager-1
+                name: dec-party-manager
                 port:
                   number: 80
 ```
 
-## Per-Participant Layout
+Adapt the `ingressClassName` and TLS configuration to your cluster's Ingress controller (nginx, Contour, etc.). Make sure `<your-ui-host>` resolves to the cluster and is registered as a valid redirect URI on your Keycloak client.
 
-The old format used a single `deployment.yaml` per environment.
+### Apply
 
-The new format uses a directory per participant, each with its own `deployment.yaml` and `secrets.yaml`:
-
-```
-deployments/
-  <environment>/
-    participant1/
-      deployment.yaml
-      secrets.yaml
-    participant2/
-      deployment.yaml
-      secrets.yaml
-    participant3/
-      deployment.yaml
-      secrets.yaml
+```bash
+kubectl apply -f <each-of-the-above>.yaml
+kubectl -n <your-namespace> rollout status deploy/dec-party-manager
 ```
 
-Each participant's Secret points to its own Canton node and can have its own Keycloak client. The Deployment labels distinguish coordinator (`app.kubernetes.io/component: coordinator`) from peers (`app.kubernetes.io/component: peer`).
+Once the pod is `Running`, hit `https://<your-ui-host>` in a browser. Keycloak should challenge for login.
+
+## 4 — Re-establish peers
+
+The new DPM has generated a fresh Noise keypair on first start. None of the other participants know it yet, and you do not yet know any of theirs (assuming they are also redeploying). The peer list has to be rebuilt from scratch by exchanging public keys out-of-band.
+
+For each participant in your network:
+
+1. Find your own public key + public address. In the UI, open the "Network Config" panel — your local node's public key is shown there. (Same value is reachable via `GET /keys/status`.) Note your `DECPM_PUBLIC_ADDRESS` and Noise port (default `9000`).
+2. Share that information with each peer through whatever out-of-band channel you use (chat, email, ticket). They need: your `participant_id`, a friendly name, the public address, the Noise port, and the public key.
+3. Collect the same information from each of them.
+4. In the "Network Config" panel, add each peer with their newly-shared values and save.
+
+The "Participants Status" panel shows handshake / reachability state per peer; healthy peers will turn green within seconds of both sides having added each other.
+
+If a peer is migrating ahead of you, share your old public key and let them add you with that value temporarily — once you have redeployed, share the new key and they can update their entry.
+
+## 5 — Re-enter party credentials
+
+For each decentralized party your node manages, open the "Party Config" dialog and re-enter the Keycloak settings (URL, realm, client ID, client secret). DPM uses these to obtain Canton ledger tokens on behalf of each party.
+
+## Configuration reference
+
+| Variable | Default | Notes |
+|---|---|---|
+| `DECPM_LISTEN_ADDRESS` | `0.0.0.0` | Noise transport bind address |
+| `DECPM_NOISE_PORT` | `9000` | Noise transport port |
+| `DECPM_PUBLIC_ADDRESS` | — | **Required.** Hostname peers use to reach this node |
+| `DECPM_CANTON_ADMIN_HOST` | — | **Required.** Canton Admin API host |
+| `DECPM_CANTON_ADMIN_PORT` | — | **Required.** Canton Admin API port (typ. `5002`) |
+| `DECPM_CANTON_LEDGER_HOST` | — | **Required.** Canton Ledger API host |
+| `DECPM_CANTON_LEDGER_PORT` | — | **Required.** Canton Ledger API port (typ. `5001`) |
+| `DECPM_CANTON_SYNCHRONIZER` | — | **Required.** Synchronizer name (`global` for mainnet) |
+| `DECPM_CANTON_NETWORK` | — | **Required.** `mainnet`, `testnet`, or `devnet` |
+| `DECPM_KEYCLOAK_URL` | — | **Required.** Keycloak server URL for frontend auth |
+| `DECPM_KEYCLOAK_REALM` | — | **Required.** Keycloak realm |
+| `DECPM_KEYCLOAK_CLIENT_ID` | — | **Required.** Keycloak client used by the SPA |
+| `DECPM_ADMIN_ROLE` | unset | Optional Keycloak role required for privileged endpoints |
+| `DECPM_ALLOWED_ORIGIN` | same-origin | Optional CORS origin if UI host ≠ API host |
+| `DECPM_DB_ENCRYPTION_KEY` | unset | Optional encryption key for secrets at rest in the SQLite DB |
+| `DECPM_TIMEOUT_HANDSHAKE` | `30` | Noise handshake timeout (seconds) |
+| `DECPM_TIMEOUT_MESSAGE` | `120` | Noise message timeout (seconds) |
+| `DECPM_TIMEOUT_RETRY_ATTEMPTS` | `3` | Connection retry attempts |
+| `DECPM_TIMEOUT_RETRY_DELAY` | `5` | Connection retry delay (seconds) |
+
+## Note: keeping the existing PVC
+
+If you would rather not regenerate your Noise keypair (so peers don't have to update their entries for you), you can keep the existing PVC and only replace the Deployment, Service, ConfigMap, and Ingress resources. The new DPM reads its existing SQLite database on first start, so your peer list and Noise keypair carry over automatically.
+
+The trade-off: if there have been schema changes between your old version and the latest, the new DPM may need to migrate the database in place. If the migration fails or you hit unexpected behavior, fall back to the clean-slate approach above.
+
+## Troubleshooting
+
+- **Pod is `CrashLoopBackOff`**: `kubectl logs` will usually show a missing required env var. Compare against the configuration reference above.
+- **UI loads but Keycloak login fails**: confirm `<your-ui-host>` is registered as a valid redirect URI on your Keycloak client, and that `DECPM_KEYCLOAK_URL` / `_REALM` / `_CLIENT_ID` match the realm.
+- **Peers shown as unreachable**: check that the Noise port (9000) is exposed publicly, that `DECPM_PUBLIC_ADDRESS` resolves to that endpoint, and that the peer has your current public key.
+- **Privileged endpoints return 403**: you have `DECPM_ADMIN_ROLE` set but the calling user doesn't have that role assigned in Keycloak. Either grant the role or unset the variable.


### PR DESCRIPTION
## Summary

Reworked \`docs/MIGRATION_GUIDE.md\` as a standalone document we can hand to an external team migrating their existing single-participant DPM install to the current release. The previous version was fine as a delta against an internal Bitsafe deployment but assumed too much context (multi-participant directory layout, ibtc.network hostnames, in-repo references) for an outside reader.

### Approach
- **Clean-slate redeploy** is the recommended path. Patching the old TOML/ConfigMap deployment in place is no longer realistic given the breadth of changes.
- **No "save the peer list" step.** Because every participant going through this migration regenerates their Noise keypair on first start, the saved list would be entirely stale. The guide reframes peer setup as a coordinated out-of-band public-key exchange — identical to first-time onboarding, just at scale.
- **Generic placeholders throughout** (\`<your-namespace>\`, \`<your-public-host>\`, \`<your-ui-host>\`) — no Bitsafe / ibtc.network / catalyst-canton hostnames.
- **Single-participant manifests.** Removed \`participant-1\` / \`coordinator\` / \`attestor\` labels; replaced \`dec-party-manager-1\` with \`dec-party-manager\` throughout.
- **Image tag callout** with \`public.ecr.aws/dlc-link/canton-decparty-manager:<tag>\` and an explicit "pin a real tag, do not use latest" note. Mentions registry mirroring for clusters that can't pull from Public ECR.
- **Configuration reference table** rebuilt from \`src/cli.rs\` — every \`DECPM_*\` variable with default + required-marker.
- **Troubleshooting section** for the four most likely operator gotchas.
- **Escape hatch:** "Note: keeping the existing PVC" for someone migrating ahead of their peers who wants to stay reachable on their existing key.

### What was deliberately left out
- Multi-participant deployment patterns (per-participant directory, coordinator/attestor labels). External teams typically run one node.
- Specific Keycloak realm / client setup. Assumes the operator already has Keycloak; just lists the three env vars.
- Any in-repo links — the doc is meant to ship standalone.

### Diff
+245 / -132 in \`docs/MIGRATION_GUIDE.md\` (rewrite, not append).

### Test plan
- [ ] Skim-read by someone who has not seen this PR's discussion thread
- [ ] (Optional) walk through the 5 steps against a scratch cluster