### PR TITLE
fix(governance-core): validate threshold and timeout at GovernanceRules creation

### DIFF
--- a/daml/governance-core-test/daml/Governance/Test/RulesTest.daml
+++ b/daml/governance-core-test/daml/Governance/Test/RulesTest.daml
@@ -6,7 +6,7 @@ module Governance.Test.RulesTest where
 
 import DA.Assert
 import DA.Set as Set hiding (filter)
-import DA.Time (minutes)
+import DA.Time (minutes, seconds)
 import Daml.Script
 
 import Governance.Rules
@@ -49,4 +49,60 @@ testCustomConfiguration = script do
   [(_, rules)] <- query @GovernanceRules parties.governanceParty
   rules.threshold === 3
   rules.actionConfirmationTimeout === minutes 60
+
+-- | Reject creation with threshold of 0.
+testRejectZeroThresholdOnCreate = script do
+  parties <- allocateTestParties
+
+  submitMustFail parties.governanceParty $ createCmd GovernanceRules with
+    governanceParty = parties.governanceParty
+    members = getMembers parties
+    threshold = 0
+    actionConfirmationTimeout = minutes 30
+    additionalProposers = None
+
+-- | Reject creation with a negative threshold.
+testRejectNegativeThresholdOnCreate = script do
+  parties <- allocateTestParties
+
+  submitMustFail parties.governanceParty $ createCmd GovernanceRules with
+    governanceParty = parties.governanceParty
+    members = getMembers parties
+    threshold = -1
+    actionConfirmationTimeout = minutes 30
+    additionalProposers = None
+
+-- | Reject creation with threshold greater than member count.
+testRejectThresholdExceedingMembersOnCreate = script do
+  parties <- allocateTestParties
+
+  submitMustFail parties.governanceParty $ createCmd GovernanceRules with
+    governanceParty = parties.governanceParty
+    members = getMembers parties
+    threshold = 4
+    actionConfirmationTimeout = minutes 30
+    additionalProposers = None
+
+-- | Reject creation with actionConfirmationTimeout shorter than 10 seconds.
+testRejectShortTimeoutOnCreate = script do
+  parties <- allocateTestParties
+
+  submitMustFail parties.governanceParty $ createCmd GovernanceRules with
+    governanceParty = parties.governanceParty
+    members = getMembers parties
+    threshold = 2
+    actionConfirmationTimeout = seconds 5
+    additionalProposers = None
+
+-- | Threshold of exactly 1 with a single member is valid (boundary).
+testAllowMinimumThresholdOnCreate = script do
+  parties <- allocateTestParties
+
+  _rulesCid <- submit parties.governanceParty $ createCmd GovernanceRules with
+    governanceParty = parties.governanceParty
+    members = Set.fromList [parties.member1]
+    threshold = 1
+    actionConfirmationTimeout = seconds 10
+    additionalProposers = None
+  pure ()
 

--- a/daml/governance-core/daml/Governance/Rules.daml
+++ b/daml/governance-core/daml/Governance/Rules.daml
@@ -160,6 +160,9 @@ template GovernanceRules
     -- governance party on their participant with readAs rights. This keeps
     -- visibility as a topology concern rather than a contract modeling concern.
     ensure not (Set.null members)
+        && threshold >= 1
+        && threshold <= Set.size members
+        && actionConfirmationTimeout >= seconds 10
 
     -- ════════════════════════════════════════════════════════════════════════
     -- BUILT-IN: Governance self-management choices


### PR DESCRIPTION
## Summary
- Strengthens the `ensure` clause on `GovernanceRules` (`Rules.daml:162`) to enforce `1 <= threshold <= |members|` and `actionConfirmationTimeout >= 10 seconds` at creation time, mirroring the constraints already enforced by the self-management choices.
- Adds boundary tests for the four new rejection paths and one positive boundary (threshold = 1 with a single member, timeout = 10s exactly).

## Why
Per Quantstamp **PreAudit-DEC-01** (#90): the previous `ensure` only enforced `not (Set.null members)`. `validateThresholdForMemberCount` is invoked by `AddMemberAndSetThreshold` / `RemoveMemberAndSetThreshold` / `SetThreshold`, and the 10-second timeout floor is invoked by `SetActionConfirmationTimeout` — neither is checked at template creation. Result: a buggy bootstrap path could yield `threshold = 0` (unilateral execution) or sub-10s timeout (permanent deadlock).

Both invariants are pure expressions over the contract's own fields, so they belong in `ensure` for defense-in-depth.

## Test plan
- [x] `dpm build --all` clean
- [x] `governance-core-test` passes, including 5 new tests:
  - `testRejectZeroThresholdOnCreate`
  - `testRejectNegativeThresholdOnCreate`
  - `testRejectThresholdExceedingMembersOnCreate`
  - `testRejectShortTimeoutOnCreate`
  - `testAllowMinimumThresholdOnCreate`
- [x] `governance-token-custody-test`, `governance-utility-onboarding-test`, `governance-utility-credential-test` pass (no regression in downstream packages that create `GovernanceRules`)

Closes #90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)