### PR TITLE
fix(governance-core): reject promoting an additionalProposer to member

### DIFF
--- a/daml/governance-core-test/daml/Governance/Test/SelfActionTest.daml
+++ b/daml/governance-core-test/daml/Governance/Test/SelfActionTest.daml
@@ -309,3 +309,29 @@ testStrangerCannotConfirmSelfAction = script do
     exerciseCmd rulesCid GovernanceRules_ConfirmGovernanceAction with
       confirmer = parties.outsider
       action
+
+-- | Reject promoting an existing `additionalProposer` to member; the
+-- `members` and `additionalProposers` sets must remain disjoint.
+testRejectAddMemberWhoIsAdditionalProposer = script do
+  parties <- allocateTestParties
+
+  -- Start with `outsider` already in additionalProposers.
+  rulesCid <- submit parties.governanceParty $ createCmd GovernanceRules with
+    governanceParty = parties.governanceParty
+    members = getMembers parties
+    threshold = 2
+    actionConfirmationTimeout = minutes 30
+    additionalProposers = Some (Set.singleton parties.outsider)
+
+  let action = SelfAction_AddMemberAndSetThreshold with
+        newMember = parties.outsider
+        newThresholdAfterAdd = 3
+
+  confirmationCids <- submitSelfConfirmations parties.governanceParty rulesCid action
+    [parties.member1, parties.member2]
+
+  submitMustFail (memberContext parties.member1 parties.governanceParty) $
+    exerciseCmd rulesCid GovernanceRules_ExecuteGovernanceAction with
+      executor = parties.member1
+      action
+      confirmations = confirmationCids

--- a/daml/governance-core/daml/Governance/Rules.daml
+++ b/daml/governance-core/daml/Governance/Rules.daml
@@ -177,6 +177,8 @@ template GovernanceRules
       controller governanceParty
       do
         require "Not yet a member" (member `Set.notMember` members)
+        require "Member must not also be an additional proposer"
+          (optional True (Set.notMember member) additionalProposers)
         let newMembers = Set.insert member members
         validateThresholdForMemberCount (Set.size newMembers) newThreshold
         governanceRulesCid <- create this with


### PR DESCRIPTION
## Summary
- Adds a symmetric disjointness check in `GovernanceRules_AddMemberAndSetThreshold` (`Rules.daml:179`): a party already in `additionalProposers` cannot be added as a `member`. Matches the existing check in `GovernanceRules_AddAdditionalProposer` (`Rules.daml:236-237`).
- Adds `testRejectAddMemberWhoIsAdditionalProposer` covering the new failure path.

## Why
Per Quantstamp **PreAudit-DEC-02** (#91): the disjointness invariant between `members` and `additionalProposers` was enforced one-way only. `ConfirmAction` uses union semantics (`member ∈ members ∨ member ∈ additionalProposers`) so a duplicate didn't grant extra voting power directly, but it left a stated invariant unenforced — and the removal flows (`RemoveMember…` / `RemoveAdditionalProposer`) don't touch the opposite set, so once a duplicate exists it behaves non-obviously.

Chose strict-reject over auto-promote per the audit's recommendation — same semantics as `AddAdditionalProposer`, no implicit field rewrites for the operator.

## Test plan
- [x] `dpm build --all` clean
- [x] `governance-core-test` passes, including new `testRejectAddMemberWhoIsAdditionalProposer`
- [x] `governance-token-custody-test`, `governance-utility-onboarding-test`, `governance-utility-credential-test` pass (no regression)

Closes #91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)