### PR TITLE
fix(governance-action): proposer-controlled cancel on GovernableAction

### DIFF
--- a/daml/governance-action-v0/daml/Governance/Action.daml
+++ b/daml/governance-action-v0/daml/Governance/Action.daml
@@ -43,3 +43,12 @@ interface GovernableAction where
   choice GovernableAction_Cancel : ()
     controller (view this).governanceParty
     do pure ()
+
+  -- | Proposer-driven cancellation. Lets the original proposer retract a
+  -- proposal they submitted in error without requiring a governance vote.
+  -- Outstanding confirmations against a now-archived proposal are harmless:
+  -- ExecuteConfirmedAction would fetch the proposal and fail, so the only
+  -- effect is that the proposal contract is consumed.
+  choice GovernableAction_ProposerCancel : ()
+    controller (view this).proposer
+    do pure ()

--- a/daml/governance-core-test/daml/Governance/Test/ConfirmationTest.daml
+++ b/daml/governance-core-test/daml/Governance/Test/ConfirmationTest.daml
@@ -8,7 +8,7 @@ import DA.Assert
 import DA.Time (minutes)
 import Daml.Script
 
-import Governance.Action (GovernableAction)
+import Governance.Action (GovernableAction, GovernableAction_Cancel(..), GovernableAction_ProposerCancel(..))
 import Governance.Confirmation
 import Governance.Rules
 import Governance.MockActions
@@ -178,3 +178,59 @@ testRejectWrongGovernanceParty = script do
     exerciseCmd rulesCid GovernanceRules_ConfirmAction with
       confirmer = parties.member1
       actionProposalCid = proposalIfaceCid
+
+-- | Proposer can cancel their own proposal via GovernableAction_ProposerCancel.
+testProposerCanCancelOwnProposal = script do
+  parties <- allocateTestParties
+  _rulesCid <- createTestGovernance parties
+
+  proposalCid <- submit parties.member1 $ createCmd MockProposal with
+    governanceParty = parties.governanceParty
+    proposer = parties.member1
+    label = "TestAction"
+    payload = "test"
+
+  let proposalIfaceCid = toInterfaceContractId @GovernableAction proposalCid
+
+  submit parties.member1 $
+    exerciseCmd proposalIfaceCid GovernableAction_ProposerCancel
+
+  proposals <- query @MockProposal parties.governanceParty
+  proposals === []
+
+-- | A different member cannot cancel via GovernableAction_ProposerCancel —
+-- the choice is gated to the original proposer only.
+testNonProposerCannotProposerCancel = script do
+  parties <- allocateTestParties
+  _rulesCid <- createTestGovernance parties
+
+  proposalCid <- submit parties.member1 $ createCmd MockProposal with
+    governanceParty = parties.governanceParty
+    proposer = parties.member1
+    label = "TestAction"
+    payload = "test"
+
+  let proposalIfaceCid = toInterfaceContractId @GovernableAction proposalCid
+
+  submitMustFail (memberContext parties.member2 parties.governanceParty) $
+    exerciseCmd proposalIfaceCid GovernableAction_ProposerCancel
+
+-- | The governance-party cancel path remains available alongside the new
+-- proposer-cancel path.
+testGovernancePartyCanStillCancel = script do
+  parties <- allocateTestParties
+  _rulesCid <- createTestGovernance parties
+
+  proposalCid <- submit parties.member1 $ createCmd MockProposal with
+    governanceParty = parties.governanceParty
+    proposer = parties.member1
+    label = "TestAction"
+    payload = "test"
+
+  let proposalIfaceCid = toInterfaceContractId @GovernableAction proposalCid
+
+  submit parties.governanceParty $
+    exerciseCmd proposalIfaceCid GovernableAction_Cancel
+
+  proposals <- query @MockProposal parties.governanceParty
+  proposals === []

--- a/daml/governance-core/daml/Governance/Rules.daml
+++ b/daml/governance-core/daml/Governance/Rules.daml
@@ -436,10 +436,13 @@ template GovernanceRules
           executedAt = now
         pure ExecuteConfirmedActionResult with ..
 
-    -- Note: Proposal cancellation is NOT a governance choice. Proposers cancel
-    -- their own proposals directly via template-specific choices. Governance-level
-    -- cancellation (e.g., cleaning up stale proposals) should go through the
-    -- standard vote flow as a GovernableAction itself.
+    -- Note: Proposal cancellation lives on the GovernableAction interface,
+    -- not as a GovernanceRules choice. The interface exposes two paths:
+    --   * GovernableAction_ProposerCancel — controlled by the proposer, lets
+    --     them retract their own proposal without a governance vote.
+    --   * GovernableAction_Cancel — controlled by governanceParty, used when
+    --     governance needs to clean up a stale proposal (typically via the
+    --     standard vote flow as a GovernableAction itself).
 
     -- | Expire a stale action confirmation.
     nonconsuming choice GovernanceRules_ExpireConfirmation : ()


### PR DESCRIPTION
## Summary
- Adds `GovernableAction_ProposerCancel` to the `GovernableAction` interface (`Action.daml`), controlled by `(view this).proposer`. Existing `GovernableAction_Cancel` (controlled by `governanceParty`) is preserved unchanged — the two paths are complementary.
- Updates the misleading comment in `Rules.daml:439-442` (formerly claimed proposer-cancel was implemented via template-specific choices, which no template actually did).
- Adds three tests on `MockProposal`:
  - `testProposerCanCancelOwnProposal`
  - `testNonProposerCannotProposerCancel`
  - `testGovernancePartyCanStillCancel`

## Why
Per Quantstamp **PreAudit-DEC-03** (#92): with only `GovernableAction_Cancel` available, a proposer who submitted a wrong or duplicate proposal had no on-chain path to retract it — every misfire required a full governance vote. The audit recommended Option A (interface-level proposer-cancel), which lives in `Action.daml` and propagates to every implementing template with no per-template diff.

Optional companion fix from the audit (proposal expiry) is deliberately out of scope — that's a feature, not a security-relevant gap, and warrants its own discussion.

## Test plan
- [x] `dpm build --all` clean
- [x] `governance-core-test` passes (50 tests including 3 new)
- [x] `governance-token-custody-test`, `governance-utility-onboarding-test`, `governance-utility-credential-test` pass (no regression — every existing `interface instance GovernableAction` template inherits the new choice transparently)

Closes #92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)