### PR TITLE
fix(governance-core): governanceId to disambiguate parallel rules instances

### DIFF
--- a/daml/governance-action-v0/daml/Governance/Action.daml
+++ b/daml/governance-action-v0/daml/Governance/Action.daml
@@ -11,6 +11,12 @@ data GovernableActionView = GovernableActionView
   with
     governanceParty : Party
       -- ^ The governance party whose authority is required to execute this action.
+    governanceId : Text
+      -- ^ Stable identifier of the specific GovernanceRules instance this
+      -- proposal targets. Required for strict matching at confirmation /
+      -- execution time so a proposal authored against one rules instance
+      -- cannot be processed by a parallel rules instance that happens to
+      -- share the same `governanceParty`.
     proposer : Party
       -- ^ The party that proposed this action. Used by GovernanceRules to enforce
       -- the on-chain proposer authorization rule (must be a member or an

--- a/daml/governance-core-test/daml/Governance/MockActions.daml
+++ b/daml/governance-core-test/daml/Governance/MockActions.daml
@@ -23,6 +23,7 @@ template MockActionResult
 template MockProposal
   with
     governanceParty : Party
+    governanceId : Text
     proposer : Party
     label : Text
     payload : Text
@@ -33,6 +34,7 @@ template MockProposal
     interface instance GovernableAction for MockProposal where
       view = GovernableActionView with
         governanceParty
+        governanceId
         proposer
         actionLabel = label
         description = payload
@@ -49,6 +51,7 @@ template MockProposal
 template MockFailingProposal
   with
     governanceParty : Party
+    governanceId : Text
     proposer : Party
   where
     signatory proposer
@@ -57,6 +60,7 @@ template MockFailingProposal
     interface instance GovernableAction for MockFailingProposal where
       view = GovernableActionView with
         governanceParty
+        governanceId
         proposer
         actionLabel = "MockFailing"
         description = "Mock action that always fails"
@@ -84,6 +88,7 @@ template MockProtectedResource
 template MockAuthorityProposal
   with
     governanceParty : Party
+    governanceId : Text
     proposer : Party
     resourceCid : ContractId MockProtectedResource
     newValue : Text
@@ -94,6 +99,7 @@ template MockAuthorityProposal
     interface instance GovernableAction for MockAuthorityProposal where
       view = GovernableActionView with
         governanceParty
+        governanceId
         proposer
         actionLabel = "MockAuthorityTest"
         description = "Mock authority flow test"

--- a/daml/governance-core-test/daml/Governance/Test/AuthorizationTest.daml
+++ b/daml/governance-core-test/daml/Governance/Test/AuthorizationTest.daml
@@ -28,6 +28,7 @@ testAuthorityFlowsThroughInterface = script do
 
   proposalCid <- submit parties.member1 $ createCmd MockAuthorityProposal with
     governanceParty = parties.governanceParty
+    governanceId = testGovernanceId
     proposer = parties.member1
     resourceCid
     newValue = "updated via governance"
@@ -47,6 +48,7 @@ testNonMemberCanCreateProposal = script do
 
   _proposalCid <- submit parties.outsider $ createCmd MockProposal with
     governanceParty = parties.governanceParty
+    governanceId = testGovernanceId
     proposer = parties.outsider
     label = "OutsiderProposal"
     payload = "from outsider"
@@ -61,6 +63,7 @@ testAdditionalProposerProposalCanBeExecutedByMembers = script do
 
   rulesCid <- submit parties.governanceParty $ createCmd GovernanceRules with
     governanceParty = parties.governanceParty
+    governanceId = testGovernanceId
     members = getMembers parties
     threshold = 2
     actionConfirmationTimeout = minutes 30
@@ -68,6 +71,7 @@ testAdditionalProposerProposalCanBeExecutedByMembers = script do
 
   proposalCid <- submit parties.outsider $ createCmd MockProposal with
     governanceParty = parties.governanceParty
+    governanceId = testGovernanceId
     proposer = parties.outsider
     label = "OutsiderProposal"
     payload = "from outsider"
@@ -88,6 +92,7 @@ testNonMemberCannotUseGovernanceChoices = script do
 
   proposalCid <- submit parties.member1 $ createCmd MockProposal with
     governanceParty = parties.governanceParty
+    governanceId = testGovernanceId
     proposer = parties.member1
     label = "TestAction"
     payload = "test"
@@ -115,6 +120,7 @@ testDuplicateConfirmationsRejected = script do
 
   proposalCid <- submit parties.member1 $ createCmd MockProposal with
     governanceParty = parties.governanceParty
+    governanceId = testGovernanceId
     proposer = parties.member1
     label = "TestAction"
     payload = "test"
@@ -145,6 +151,7 @@ testMemberProposerAcceptedAtConfirm = script do
 
   proposalCid <- submit parties.member1 $ createCmd MockProposal with
     governanceParty = parties.governanceParty
+    governanceId = testGovernanceId
     proposer = parties.member1
     label = "MemberProposed"
     payload = "ok"
@@ -165,6 +172,7 @@ testAdditionalProposerAcceptedAtConfirm = script do
   -- Build governance rules where `outsider` is an additional proposer.
   rulesCid <- submit parties.governanceParty $ createCmd GovernanceRules with
     governanceParty = parties.governanceParty
+    governanceId = testGovernanceId
     members = getMembers parties
     threshold = 2
     actionConfirmationTimeout = minutes 30
@@ -172,6 +180,7 @@ testAdditionalProposerAcceptedAtConfirm = script do
 
   proposalCid <- submit parties.outsider $ createCmd MockProposal with
     governanceParty = parties.governanceParty
+    governanceId = testGovernanceId
     proposer = parties.outsider
     label = "AdditionalProposerProposed"
     payload = "ok"
@@ -194,6 +203,7 @@ testUnauthorizedProposerRejectedAtConfirm = script do
   -- `outsider` is neither a member nor an additional proposer.
   proposalCid <- submit parties.outsider $ createCmd MockProposal with
     governanceParty = parties.governanceParty
+    governanceId = testGovernanceId
     proposer = parties.outsider
     label = "UnauthorizedProposed"
     payload = "should reject"

--- a/daml/governance-core-test/daml/Governance/Test/ConfirmationTest.daml
+++ b/daml/governance-core-test/daml/Governance/Test/ConfirmationTest.daml
@@ -21,6 +21,7 @@ testMemberCanConfirm = script do
 
   proposalCid <- submit parties.member1 $ createCmd MockProposal with
     governanceParty = parties.governanceParty
+    governanceId = testGovernanceId
     proposer = parties.member1
     label = "TestAction"
     payload = "test"
@@ -43,6 +44,7 @@ testNonMemberCannotConfirm = script do
 
   proposalCid <- submit parties.member1 $ createCmd MockProposal with
     governanceParty = parties.governanceParty
+    governanceId = testGovernanceId
     proposer = parties.member1
     label = "TestAction"
     payload = "test"
@@ -61,6 +63,7 @@ testConfirmerCanCancel = script do
 
   proposalCid <- submit parties.member1 $ createCmd MockProposal with
     governanceParty = parties.governanceParty
+    governanceId = testGovernanceId
     proposer = parties.member1
     label = "TestAction"
     payload = "test"
@@ -83,6 +86,7 @@ testExpireStaleConfirmation = script do
 
   rulesCid <- submit parties.governanceParty $ createCmd GovernanceRules with
     governanceParty = parties.governanceParty
+    governanceId = testGovernanceId
     members = getMembers parties
     threshold = 2
     actionConfirmationTimeout = minutes 3
@@ -90,6 +94,7 @@ testExpireStaleConfirmation = script do
 
   proposalCid <- submit parties.member1 $ createCmd MockProposal with
     governanceParty = parties.governanceParty
+    governanceId = testGovernanceId
     proposer = parties.member1
     label = "TestAction"
     payload = "test"
@@ -118,6 +123,7 @@ testCannotExpireValidConfirmation = script do
 
   proposalCid <- submit parties.member1 $ createCmd MockProposal with
     governanceParty = parties.governanceParty
+    governanceId = testGovernanceId
     proposer = parties.member1
     label = "TestAction"
     payload = "test"
@@ -141,6 +147,7 @@ testNonMemberCannotExpire = script do
 
   proposalCid <- submit parties.member1 $ createCmd MockProposal with
     governanceParty = parties.governanceParty
+    governanceId = testGovernanceId
     proposer = parties.member1
     label = "TestAction"
     payload = "test"
@@ -168,6 +175,7 @@ testRejectWrongGovernanceParty = script do
 
   proposalCid <- submit parties.member1 $ createCmd MockProposal with
     governanceParty = wrongParty
+    governanceId = testGovernanceId
     proposer = parties.member1
     label = "TestAction"
     payload = "test"
@@ -178,3 +186,166 @@ testRejectWrongGovernanceParty = script do
     exerciseCmd rulesCid GovernanceRules_ConfirmAction with
       confirmer = parties.member1
       actionProposalCid = proposalIfaceCid
+
+-- | A proposal whose `governanceId` does not match the rules instance's
+-- `governanceId` is rejected at confirmation time. Both instances share
+-- the same `governanceParty`, so the party-only match used to allow it.
+testRejectWrongGovernanceId = script do
+  parties <- allocateTestParties
+  rulesCidA <- submit parties.governanceParty $ createCmd GovernanceRules with
+    governanceParty = parties.governanceParty
+    governanceId = "instance-A"
+    members = getMembers parties
+    threshold = 2
+    actionConfirmationTimeout = minutes 30
+    additionalProposers = None
+
+  -- Proposal targets instance A.
+  proposalCid <- submit parties.member1 $ createCmd MockProposal with
+    governanceParty = parties.governanceParty
+    governanceId = "instance-A"
+    proposer = parties.member1
+    label = "TestAction"
+    payload = "test"
+
+  let proposalIfaceCid = toInterfaceContractId @GovernableAction proposalCid
+
+  -- Confirmation on instance A succeeds.
+  _ <- submit (memberContext parties.member1 parties.governanceParty) $
+    exerciseCmd rulesCidA GovernanceRules_ConfirmAction with
+      confirmer = parties.member1
+      actionProposalCid = proposalIfaceCid
+
+  -- A second rules contract on the same party but with a different
+  -- governanceId refuses to confirm the proposal authored against A.
+  rulesCidB <- submit parties.governanceParty $ createCmd GovernanceRules with
+    governanceParty = parties.governanceParty
+    governanceId = "instance-B"
+    members = getMembers parties
+    threshold = 2
+    actionConfirmationTimeout = minutes 30
+    additionalProposers = None
+
+  submitMustFail (memberContext parties.member2 parties.governanceParty) $
+    exerciseCmd rulesCidB GovernanceRules_ConfirmAction with
+      confirmer = parties.member2
+      actionProposalCid = proposalIfaceCid
+
+-- | Confirmations gathered against instance A cannot be replayed against
+-- instance B (same `governanceParty`, different `governanceId`).
+testRejectCrossInstanceConfirmationReplay = script do
+  parties <- allocateTestParties
+
+  rulesCidA <- submit parties.governanceParty $ createCmd GovernanceRules with
+    governanceParty = parties.governanceParty
+    governanceId = "instance-A"
+    members = getMembers parties
+    threshold = 2
+    actionConfirmationTimeout = minutes 30
+    additionalProposers = None
+
+  rulesCidB <- submit parties.governanceParty $ createCmd GovernanceRules with
+    governanceParty = parties.governanceParty
+    governanceId = "instance-B"
+    members = getMembers parties
+    threshold = 2
+    actionConfirmationTimeout = minutes 30
+    additionalProposers = None
+
+  proposalCidA <- submit parties.member1 $ createCmd MockProposal with
+    governanceParty = parties.governanceParty
+    governanceId = "instance-A"
+    proposer = parties.member1
+    label = "TestAction"
+    payload = "test"
+
+  let proposalIfaceCidA = toInterfaceContractId @GovernableAction proposalCidA
+
+  conf1 <- submit (memberContext parties.member1 parties.governanceParty) $
+    exerciseCmd rulesCidA GovernanceRules_ConfirmAction with
+      confirmer = parties.member1
+      actionProposalCid = proposalIfaceCidA
+  conf2 <- submit (memberContext parties.member2 parties.governanceParty) $
+    exerciseCmd rulesCidA GovernanceRules_ConfirmAction with
+      confirmer = parties.member2
+      actionProposalCid = proposalIfaceCidA
+
+  submitMustFail (memberContext parties.member1 parties.governanceParty) $
+    exerciseCmd rulesCidB GovernanceRules_ExecuteConfirmedAction with
+      executor = parties.member1
+      actionProposalCid = proposalIfaceCidA
+      confirmations = [conf1.confirmationCid, conf2.confirmationCid]
+
+-- | Self-confirmations gathered against instance A cannot be replayed
+-- against instance B.
+testRejectCrossInstanceSelfConfirmationReplay = script do
+  parties <- allocateTestParties
+
+  rulesCidA <- submit parties.governanceParty $ createCmd GovernanceRules with
+    governanceParty = parties.governanceParty
+    governanceId = "instance-A"
+    members = getMembers parties
+    threshold = 2
+    actionConfirmationTimeout = minutes 30
+    additionalProposers = None
+
+  rulesCidB <- submit parties.governanceParty $ createCmd GovernanceRules with
+    governanceParty = parties.governanceParty
+    governanceId = "instance-B"
+    members = getMembers parties
+    threshold = 2
+    actionConfirmationTimeout = minutes 30
+    additionalProposers = None
+
+  let action = SelfAction_SetThreshold with updatedThreshold = 3
+
+  selfConf1 <- submit (memberContext parties.member1 parties.governanceParty) $
+    exerciseCmd rulesCidA GovernanceRules_ConfirmGovernanceAction with
+      confirmer = parties.member1
+      action
+  selfConf2 <- submit (memberContext parties.member2 parties.governanceParty) $
+    exerciseCmd rulesCidA GovernanceRules_ConfirmGovernanceAction with
+      confirmer = parties.member2
+      action
+
+  submitMustFail (memberContext parties.member1 parties.governanceParty) $
+    exerciseCmd rulesCidB GovernanceRules_ExecuteGovernanceAction with
+      executor = parties.member1
+      action
+      confirmations = [selfConf1.confirmationCid, selfConf2.confirmationCid]
+
+-- | Self-management `create this with ...` preserves `governanceId` across
+-- the rewrite chain (it is not present in the with-record, so it is copied
+-- unchanged). Without this the audit's fix would self-defeat after the
+-- first self-management action.
+testGovernanceIdPreservedAcrossSelfActions = script do
+  parties <- allocateTestParties
+
+  rulesCid <- submit parties.governanceParty $ createCmd GovernanceRules with
+    governanceParty = parties.governanceParty
+    governanceId = "persistent-id"
+    members = getMembers parties
+    threshold = 2
+    actionConfirmationTimeout = minutes 30
+    additionalProposers = None
+
+  let action = SelfAction_SetThreshold with updatedThreshold = 3
+
+  selfConf1 <- submit (memberContext parties.member1 parties.governanceParty) $
+    exerciseCmd rulesCid GovernanceRules_ConfirmGovernanceAction with
+      confirmer = parties.member1
+      action
+  selfConf2 <- submit (memberContext parties.member2 parties.governanceParty) $
+    exerciseCmd rulesCid GovernanceRules_ConfirmGovernanceAction with
+      confirmer = parties.member2
+      action
+
+  _ <- submit (memberContext parties.member1 parties.governanceParty) $
+    exerciseCmd rulesCid GovernanceRules_ExecuteGovernanceAction with
+      executor = parties.member1
+      action
+      confirmations = [selfConf1.confirmationCid, selfConf2.confirmationCid]
+
+  [(_, rules)] <- query @GovernanceRules parties.governanceParty
+  rules.governanceId === "persistent-id"
+  rules.threshold === 3

--- a/daml/governance-core-test/daml/Governance/Test/ExecutionTest.daml
+++ b/daml/governance-core-test/daml/Governance/Test/ExecutionTest.daml
@@ -43,6 +43,7 @@ when_proposal_confirmed_and_executed : ExecutionFixture -> Script FullFlowResult
 when_proposal_confirmed_and_executed f = do
   proposalCid <- submit f.parties.member1 $ createCmd MockProposal with
     governanceParty = f.parties.governanceParty
+    governanceId = testGovernanceId
     proposer = f.parties.member1
     label = "TestAction"
     payload = "hello governance"
@@ -80,6 +81,7 @@ testExecutionWithExtraConfirmations = script do
 
   proposalCid <- submit parties.member1 $ createCmd MockProposal with
     governanceParty = parties.governanceParty
+    governanceId = testGovernanceId
     proposer = parties.member1
     label = "ExtraConfs"
     payload = "extra"
@@ -100,6 +102,7 @@ testInsufficientConfirmations = script do
 
   proposalCid <- submit parties.member1 $ createCmd MockProposal with
     governanceParty = parties.governanceParty
+    governanceId = testGovernanceId
     proposer = parties.member1
     label = "TestAction"
     payload = "test"
@@ -122,6 +125,7 @@ testNonMemberCannotExecute = script do
 
   proposalCid <- submit parties.member1 $ createCmd MockProposal with
     governanceParty = parties.governanceParty
+    governanceId = testGovernanceId
     proposer = parties.member1
     label = "TestAction"
     payload = "test"
@@ -143,6 +147,7 @@ testExpiredConfirmationsDontCount = script do
 
   rulesCid <- submit parties.governanceParty $ createCmd GovernanceRules with
     governanceParty = parties.governanceParty
+    governanceId = testGovernanceId
     members = getMembers parties
     threshold = 2
     actionConfirmationTimeout = minutes 3
@@ -150,6 +155,7 @@ testExpiredConfirmationsDontCount = script do
 
   proposalCid <- submit parties.member1 $ createCmd MockProposal with
     governanceParty = parties.governanceParty
+    governanceId = testGovernanceId
     proposer = parties.member1
     label = "TestAction"
     payload = "test"
@@ -181,6 +187,7 @@ testFailingActionExecution = script do
 
   proposalCid <- submit parties.member1 $ createCmd MockFailingProposal with
     governanceParty = parties.governanceParty
+    governanceId = testGovernanceId
     proposer = parties.member1
 
   let proposalIfaceCid = toInterfaceContractId @GovernableAction proposalCid
@@ -201,12 +208,14 @@ testConfirmationsCannotBeMixed = script do
 
   proposalA <- submit parties.member1 $ createCmd MockProposal with
     governanceParty = parties.governanceParty
+    governanceId = testGovernanceId
     proposer = parties.member1
     label = "ActionA"
     payload = "a"
 
   proposalB <- submit parties.member1 $ createCmd MockProposal with
     governanceParty = parties.governanceParty
+    governanceId = testGovernanceId
     proposer = parties.member1
     label = "ActionB"
     payload = "b"

--- a/daml/governance-core-test/daml/Governance/Test/GenericVoteTest.daml
+++ b/daml/governance-core-test/daml/Governance/Test/GenericVoteTest.daml
@@ -54,6 +54,7 @@ when_vote_proposed_confirmed_executed : GenericVoteFixture -> Script VoteResult
 when_vote_proposed_confirmed_executed f = do
   proposalCid <- submit f.parties.member1 $ createCmd GenericVoteProposal with
     governanceParty = f.parties.governanceParty
+    governanceId = testGovernanceId
     proposer = f.parties.member1
     description = "We should switch to dark theme for our website"
 
@@ -70,6 +71,7 @@ when_all_members_confirm_and_execute : GenericVoteFixture -> Script VoteResult
 when_all_members_confirm_and_execute f = do
   proposalCid <- submit f.parties.member2 $ createCmd GenericVoteProposal with
     governanceParty = f.parties.governanceParty
+    governanceId = testGovernanceId
     proposer = f.parties.member2
     description = "Allocate budget for new infrastructure"
 
@@ -86,11 +88,13 @@ when_two_votes_proposed_and_executed : GenericVoteFixture -> Script MultiVoteRes
 when_two_votes_proposed_and_executed f = do
   proposalA <- submit f.parties.member1 $ createCmd GenericVoteProposal with
     governanceParty = f.parties.governanceParty
+    governanceId = testGovernanceId
     proposer = f.parties.member1
     description = "Proposal A: expand to new market"
 
   proposalB <- submit f.parties.member2 $ createCmd GenericVoteProposal with
     governanceParty = f.parties.governanceParty
+    governanceId = testGovernanceId
     proposer = f.parties.member2
     description = "Proposal B: hire more developers"
 

--- a/daml/governance-core-test/daml/Governance/Test/RulesTest.daml
+++ b/daml/governance-core-test/daml/Governance/Test/RulesTest.daml
@@ -30,6 +30,7 @@ testRejectEmptyMembers = script do
 
   submitMustFail parties.governanceParty $ createCmd GovernanceRules with
     governanceParty = parties.governanceParty
+    governanceId = testGovernanceId
     members = Set.empty
     threshold = 2
     actionConfirmationTimeout = minutes 30
@@ -41,6 +42,7 @@ testCustomConfiguration = script do
 
   _rulesCid <- submit parties.governanceParty $ createCmd GovernanceRules with
     governanceParty = parties.governanceParty
+    governanceId = testGovernanceId
     members = getMembers parties
     threshold = 3
     actionConfirmationTimeout = minutes 60

--- a/daml/governance-core-test/daml/Governance/Test/SelfActionTest.daml
+++ b/daml/governance-core-test/daml/Governance/Test/SelfActionTest.daml
@@ -213,6 +213,7 @@ testRemoveAdditionalProposer = script do
   -- Start with `outsider` already in additionalProposers.
   rulesCid <- submit parties.governanceParty $ createCmd GovernanceRules with
     governanceParty = parties.governanceParty
+    governanceId = testGovernanceId
     members = getMembers parties
     threshold = 2
     actionConfirmationTimeout = minutes 30
@@ -241,6 +242,7 @@ testAdditionalProposerSeedsSelfAction = script do
 
   rulesCid <- submit parties.governanceParty $ createCmd GovernanceRules with
     governanceParty = parties.governanceParty
+    governanceId = testGovernanceId
     members = getMembers parties
     threshold = 2
     actionConfirmationTimeout = minutes 30
@@ -272,6 +274,7 @@ testAdditionalProposerAloneCannotExecute = script do
 
   rulesCid <- submit parties.governanceParty $ createCmd GovernanceRules with
     governanceParty = parties.governanceParty
+    governanceId = testGovernanceId
     members = getMembers parties
     threshold = 2
     actionConfirmationTimeout = minutes 30
@@ -298,6 +301,7 @@ testStrangerCannotConfirmSelfAction = script do
 
   rulesCid <- submit parties.governanceParty $ createCmd GovernanceRules with
     governanceParty = parties.governanceParty
+    governanceId = testGovernanceId
     members = getMembers parties
     threshold = 2
     actionConfirmationTimeout = minutes 30

--- a/daml/governance-core-test/daml/Governance/TestUtils.daml
+++ b/daml/governance-core-test/daml/Governance/TestUtils.daml
@@ -39,6 +39,12 @@ allocateTestParties = do
 getMembers : TestParties -> Set Party
 getMembers parties = Set.fromList [parties.member1, parties.member2, parties.member3]
 
+-- | Standard test governance instance identifier. Tests that need to model
+-- two coexisting rules contracts (e.g., disambiguation tests) construct
+-- their own distinct strings instead of reusing this one.
+testGovernanceId : Text
+testGovernanceId = "test-governance"
+
 -- | Build the submission context for a member acting with readAs on governance party.
 -- Simulates the Canton topology where members host the governance party.
 memberContext member gp = actAs member <> readAs gp
@@ -49,6 +55,7 @@ createTestGovernance : TestParties -> Script (ContractId GovernanceRules)
 createTestGovernance parties =
   submit parties.governanceParty $ createCmd GovernanceRules with
     governanceParty = parties.governanceParty
+    governanceId = testGovernanceId
     members = getMembers parties
     threshold = 2
     actionConfirmationTimeout = minutes 30

--- a/daml/governance-core/daml/Governance/Confirmation.daml
+++ b/daml/governance-core/daml/Governance/Confirmation.daml
@@ -14,6 +14,11 @@ template GovernanceConfirmation
   with
     governanceParty : Party
       -- ^ The governance party this confirmation belongs to.
+    governanceId : Text
+      -- ^ Stable identifier of the specific GovernanceRules instance this
+      -- confirmation was created against. Checked at execute time so
+      -- confirmations gathered for one rules instance cannot be replayed
+      -- against a parallel instance with different members / threshold.
     confirmer : Party
       -- ^ The governance member who created this confirmation.
     actionProposalCid : ContractId GovernableAction

--- a/daml/governance-core/daml/Governance/GenericVote.daml
+++ b/daml/governance-core/daml/Governance/GenericVote.daml
@@ -17,6 +17,8 @@ template GenericVoteProposal
   with
     governanceParty : Party
       -- ^ The governance party this vote belongs to.
+    governanceId : Text
+      -- ^ Stable identifier of the targeting GovernanceRules instance.
     proposer : Party
       -- ^ The member who proposed this vote.
     description : Text
@@ -28,6 +30,7 @@ template GenericVoteProposal
     interface instance GovernableAction for GenericVoteProposal where
       view = GovernableActionView with
         governanceParty
+        governanceId
         proposer
         actionLabel = "GenericVote"
         description

--- a/daml/governance-core/daml/Governance/Rules.daml
+++ b/daml/governance-core/daml/Governance/Rules.daml
@@ -53,6 +53,11 @@ template GovernanceSelfConfirmation
   with
     governanceParty : Party
       -- ^ The governance party this confirmation belongs to.
+    governanceId : Text
+      -- ^ Stable identifier of the specific GovernanceRules instance this
+      -- self-confirmation was created against. Checked at execute time so
+      -- confirmations cannot be replayed across parallel rules instances
+      -- that happen to share the same `governanceParty`.
     confirmer : Party
       -- ^ The governance member who created this confirmation.
     action : GovernanceSelfAction
@@ -142,6 +147,14 @@ template GovernanceRules
     governanceParty : Party
       -- ^ The decentralized governance party. Members host this party on their
       -- participants with readAs rights for visibility.
+    governanceId : Text
+      -- ^ Stable, immutable identifier for this governance instance. Set
+      -- once at bootstrap (e.g., a UUID) and preserved across every
+      -- self-management `create this with ...` rewrite. Lets confirmations,
+      -- self-confirmations, and proposals match a specific rules instance
+      -- rather than relying on `governanceParty` alone — which would
+      -- conflate parallel rules contracts that share a party (e.g., during
+      -- a bootstrap, upgrade, or migration).
     members : Set Party
       -- ^ Set of governance members who can confirm and execute actions.
     threshold : Int
@@ -280,6 +293,7 @@ template GovernanceRules
         now <- getTime
         confirmationCid <- create GovernanceSelfConfirmation with
           governanceParty
+          governanceId
           confirmer
           action
           expiresAt = now `addRelTime` actionConfirmationTimeout
@@ -304,6 +318,8 @@ template GovernanceRules
         -- before counting threshold — only member votes count toward N.
         now <- getTime
         fetched <- mapA (\cid -> exercise cid GovernanceSelfConfirmation_Consume) confirmations
+        require "All confirmations must target this governance instance"
+          (all (\c -> c.governanceId == governanceId) fetched)
         let valid = filter (\c -> c.expiresAt > now) fetched
         let memberVotes = filter (\c -> c.confirmer `Set.member` members) valid
         require "All confirmations must match the action being executed"
@@ -374,8 +390,9 @@ template GovernanceRules
       do
         require "Confirmer is a governance member" (confirmer `Set.member` members)
         actionView <- view <$> fetch actionProposalCid
-        require "Proposal targets this governance"
-          (actionView.governanceParty == governanceParty)
+        require "Proposal targets this governance instance"
+          (actionView.governanceParty == governanceParty
+            && actionView.governanceId == governanceId)
         -- Proposer must be a member or an additional proposer. Canton has
         -- already enforced that the on-chain `proposer` field is authentic
         -- (the submitting participant must `actAs` that party); this check
@@ -383,12 +400,10 @@ template GovernanceRules
         require "Proposer is authorized (member or additional proposer)"
           (actionView.proposer `Set.member` members
             || optional False (Set.member actionView.proposer) additionalProposers)
-        -- TODO: governanceParty match alone doesn't distinguish between multiple
-        -- GovernanceRules instances for the same party. A static governance ID
-        -- field should be added to provide strict matching.
         now <- getTime
         confirmationCid <- create GovernanceConfirmation with
           governanceParty
+          governanceId
           confirmer
           actionProposalCid
           actionLabel = actionView.actionLabel
@@ -410,6 +425,8 @@ template GovernanceRules
         -- Consume and validate confirmations
         now <- getTime
         fetched <- mapA (\cid -> exercise cid GovernanceConfirmation_Consume) confirmations
+        require "All confirmations must target this governance instance"
+          (all (\c -> c.governanceId == governanceId) fetched)
         let valid = filter (\c -> c.expiresAt > now) fetched
         require "All confirmations must reference the same proposal"
           (all (\c -> c.actionProposalCid == actionProposalCid) valid)

--- a/daml/governance-token-custody-test/daml/Governance/TokenCustody/Test/AcceptTransferTest.daml
+++ b/daml/governance-token-custody-test/daml/Governance/TokenCustody/Test/AcceptTransferTest.daml
@@ -98,6 +98,7 @@ when_transfer_accepted_via_governance f = do
   transferInstructionCid <- createTransferOffer f.parties f.result 75.0
   proposalCid <- submit f.parties.member1 $ createCmd AcceptTransferProposal with
     governanceParty = f.parties.governanceParty
+    governanceId = testGovernanceId
     proposer = f.parties.member1
     transferInstructionCid
     extraArgs = buildAcceptExtraArgs f.result
@@ -112,6 +113,7 @@ when_withdrawn_offer_fails f = do
   transferInstructionCid <- createTransferOffer f.parties f.result 75.0
   proposalCid <- submit f.parties.member1 $ createCmd AcceptTransferProposal with
     governanceParty = f.parties.governanceParty
+    governanceId = testGovernanceId
     proposer = f.parties.member1
     transferInstructionCid
     extraArgs = buildAcceptExtraArgs f.result
@@ -135,6 +137,7 @@ when_non_member_confirmation_fails f = do
   transferInstructionCid <- createTransferOffer f.parties f.result 75.0
   proposalCid <- submit f.parties.member1 $ createCmd AcceptTransferProposal with
     governanceParty = f.parties.governanceParty
+    governanceId = testGovernanceId
     proposer = f.parties.member1
     transferInstructionCid
     extraArgs = buildAcceptExtraArgs f.result

--- a/daml/governance-token-custody-test/daml/Governance/TokenCustody/Test/OfferTransferTest.daml
+++ b/daml/governance-token-custody-test/daml/Governance/TokenCustody/Test/OfferTransferTest.daml
@@ -58,6 +58,7 @@ createOfferProposal parties result holdingCids amount = do
   now <- getTime
   submit parties.member1 $ createCmd TransferProposal with
     governanceParty = parties.governanceParty
+    governanceId = testGovernanceId
     proposer = parties.member1
     transferFactoryCid = coerceContractId result.allocationFactoryCid
     expectedAdmin = parties.registrar
@@ -86,6 +87,7 @@ when_zero_amount_proposal_creation_fails f = do
   now <- getTime
   submitMustFail f.parties.member1 $ createCmd TransferProposal with
     governanceParty = f.parties.governanceParty
+    governanceId = testGovernanceId
     proposer = f.parties.member1
     transferFactoryCid = coerceContractId f.result.allocationFactoryCid
     expectedAdmin = f.parties.registrar

--- a/daml/governance-token-custody-test/daml/Governance/TokenCustody/Test/SendTokensTest.daml
+++ b/daml/governance-token-custody-test/daml/Governance/TokenCustody/Test/SendTokensTest.daml
@@ -80,6 +80,7 @@ when_zero_amount_proposal_creation_fails f = do
   now <- getTime
   submitMustFail f.parties.member1 $ createCmd TransferProposal with
     governanceParty = f.parties.governanceParty
+    governanceId = testGovernanceId
     proposer = f.parties.member1
     transferFactoryCid = coerceContractId preapprovalCid
     expectedAdmin = f.parties.registrar
@@ -94,6 +95,7 @@ when_insufficient_confirmations_fails f = do
   now <- getTime
   proposalCid <- submit f.parties.member1 $ createCmd TransferProposal with
     governanceParty = f.parties.governanceParty
+    governanceId = testGovernanceId
     proposer = f.parties.member1
     transferFactoryCid = coerceContractId preapprovalCid
     expectedAdmin = f.parties.registrar
@@ -116,6 +118,7 @@ when_non_member_confirmation_fails f = do
   now <- getTime
   proposalCid <- submit f.parties.member1 $ createCmd TransferProposal with
     governanceParty = f.parties.governanceParty
+    governanceId = testGovernanceId
     proposer = f.parties.member1
     transferFactoryCid = coerceContractId preapprovalCid
     expectedAdmin = f.parties.registrar
@@ -137,6 +140,7 @@ when_tokens_sent_via_governance f = do
   now <- getTime
   proposalCid <- submit f.parties.member1 $ createCmd TransferProposal with
     governanceParty = f.parties.governanceParty
+    governanceId = testGovernanceId
     proposer = f.parties.member1
     transferFactoryCid = coerceContractId preapprovalCid
     expectedAdmin = f.parties.registrar

--- a/daml/governance-token-custody-test/daml/Governance/TokenCustody/Test/SetupCcPreapprovalTest.daml
+++ b/daml/governance-token-custody-test/daml/Governance/TokenCustody/Test/SetupCcPreapprovalTest.daml
@@ -43,6 +43,7 @@ when_full_flow_with_dso : SetupCcFixture -> Script [TransferPreapprovalProposal]
 when_full_flow_with_dso f = do
   proposalCid <- submit f.parties.member1 $ createCmd SetupCcPreapprovalProposal with
     governanceParty = f.parties.governanceParty
+    governanceId = testGovernanceId
     proposer = f.parties.member1
     provider = f.parties.outsider
     expectedDso = Some f.parties.dso
@@ -59,6 +60,7 @@ when_non_member_confirmation_fails : SetupCcFixture -> Script ()
 when_non_member_confirmation_fails f = do
   proposalCid <- submit f.parties.member1 $ createCmd SetupCcPreapprovalProposal with
     governanceParty = f.parties.governanceParty
+    governanceId = testGovernanceId
     proposer = f.parties.member1
     provider = f.parties.outsider
     expectedDso = None
@@ -74,6 +76,7 @@ when_full_flow_without_dso : SetupCcFixture -> Script [TransferPreapprovalPropos
 when_full_flow_without_dso f = do
   proposalCid <- submit f.parties.member1 $ createCmd SetupCcPreapprovalProposal with
     governanceParty = f.parties.governanceParty
+    governanceId = testGovernanceId
     proposer = f.parties.member1
     provider = f.parties.outsider
     expectedDso = None

--- a/daml/governance-token-custody-test/daml/Governance/TokenCustody/Test/SetupTokenPreapprovalTest.daml
+++ b/daml/governance-token-custody-test/daml/Governance/TokenCustody/Test/SetupTokenPreapprovalTest.daml
@@ -65,6 +65,7 @@ when_full_flow_executed : PreapprovalFixture -> Script ()
 when_full_flow_executed f = do
   proposalCid <- submit f.parties.member1 $ createCmd SetupTokenPreapprovalProposal with
     governanceParty = f.parties.governanceParty
+    governanceId = testGovernanceId
     proposer = f.parties.member1
     operator = f.parties.outsider
     instrumentAdmin = f.parties.registrar
@@ -78,6 +79,7 @@ when_non_member_confirmation_fails : PreapprovalFixture -> Script ()
 when_non_member_confirmation_fails f = do
   proposalCid <- submit f.parties.member1 $ createCmd SetupTokenPreapprovalProposal with
     governanceParty = f.parties.governanceParty
+    governanceId = testGovernanceId
     proposer = f.parties.member1
     operator = f.parties.outsider
     instrumentAdmin = f.parties.registrar
@@ -92,6 +94,7 @@ when_all_instruments_flow_executed : PreapprovalFixture -> Script ()
 when_all_instruments_flow_executed f = do
   proposalCid <- submit f.parties.member1 $ createCmd SetupTokenPreapprovalProposal with
     governanceParty = f.parties.governanceParty
+    governanceId = testGovernanceId
     proposer = f.parties.member1
     operator = f.parties.outsider
     instrumentAdmin = f.parties.registrar
@@ -106,6 +109,7 @@ when_e2e_tokens_received f = do
   let instrument = testInstrumentId f.parties.registrar
   proposalCid <- submit f.parties.member1 $ createCmd SetupTokenPreapprovalProposal with
     governanceParty = f.parties.governanceParty
+    governanceId = testGovernanceId
     proposer = f.parties.member1
     operator = f.result.operator
     instrumentAdmin = f.parties.registrar

--- a/daml/governance-token-custody-test/daml/Governance/TokenCustody/TestUtils.daml
+++ b/daml/governance-token-custody-test/daml/Governance/TokenCustody/TestUtils.daml
@@ -51,6 +51,10 @@ allocateTokenTestParties = do
 getMembers : TokenTestParties -> Set Party
 getMembers parties = Set.fromList [parties.member1, parties.member2, parties.member3]
 
+-- | Standard test governance instance identifier.
+testGovernanceId : Text
+testGovernanceId = "test-token-custody-governance"
+
 -- | Build submission context for a member with readAs on governance party.
 memberContext : Party -> Party -> SubmitOptions
 memberContext member gp = actAs member <> readAs gp
@@ -60,6 +64,7 @@ createTestGovernance : TokenTestParties -> Script (ContractId GovernanceRules)
 createTestGovernance parties =
   submit parties.governanceParty $ createCmd GovernanceRules with
     governanceParty = parties.governanceParty
+    governanceId = testGovernanceId
     members = getMembers parties
     threshold = 2
     actionConfirmationTimeout = minutes 30

--- a/daml/governance-token-custody/daml/Governance/TokenCustody/AcceptTransfer.daml
+++ b/daml/governance-token-custody/daml/Governance/TokenCustody/AcceptTransfer.daml
@@ -21,6 +21,8 @@ template AcceptTransferProposal
   with
     governanceParty : Party
       -- ^ The governance party whose authority is required.
+    governanceId : Text
+      -- ^ Stable identifier of the targeting GovernanceRules instance.
     proposer : Party
       -- ^ The member proposing to accept this transfer.
     transferInstructionCid : ContractId TransferInstruction
@@ -34,6 +36,7 @@ template AcceptTransferProposal
     interface instance GovernableAction for AcceptTransferProposal where
       view = GovernableActionView with
         governanceParty
+        governanceId
         proposer
         actionLabel = "AcceptTransfer"
         description = "Accept incoming token transfer"

--- a/daml/governance-token-custody/daml/Governance/TokenCustody/SetupCcPreapproval.daml
+++ b/daml/governance-token-custody/daml/Governance/TokenCustody/SetupCcPreapproval.daml
@@ -21,6 +21,8 @@ template SetupCcPreapprovalProposal
   with
     governanceParty : Party
       -- ^ The governance party whose authority is required.
+    governanceId : Text
+      -- ^ Stable identifier of the targeting GovernanceRules instance.
     proposer : Party
       -- ^ The member proposing this preapproval setup.
     provider : Party
@@ -34,6 +36,7 @@ template SetupCcPreapprovalProposal
     interface instance GovernableAction for SetupCcPreapprovalProposal where
       view = GovernableActionView with
         governanceParty
+        governanceId
         proposer
         actionLabel = "SetupCcPreapproval"
         description = "Set up Canton Coin transfer preapproval"

--- a/daml/governance-token-custody/daml/Governance/TokenCustody/SetupTokenPreapproval.daml
+++ b/daml/governance-token-custody/daml/Governance/TokenCustody/SetupTokenPreapproval.daml
@@ -20,6 +20,8 @@ template SetupTokenPreapprovalProposal
   with
     governanceParty : Party
       -- ^ The governance party whose authority is required.
+    governanceId : Text
+      -- ^ Stable identifier of the targeting GovernanceRules instance.
     proposer : Party
       -- ^ The member proposing this preapproval setup.
     operator : Party
@@ -35,6 +37,7 @@ template SetupTokenPreapprovalProposal
     interface instance GovernableAction for SetupTokenPreapprovalProposal where
       view = GovernableActionView with
         governanceParty
+        governanceId
         proposer
         actionLabel = "SetupTokenPreapproval"
         description = "Set up utility token transfer preapproval"

--- a/daml/governance-token-custody/daml/Governance/TokenCustody/TransferProposal.daml
+++ b/daml/governance-token-custody/daml/Governance/TokenCustody/TransferProposal.daml
@@ -38,6 +38,8 @@ template TransferProposal
   with
     governanceParty : Party
       -- ^ The governance party whose authority is required.
+    governanceId : Text
+      -- ^ Stable identifier of the targeting GovernanceRules instance.
     proposer : Party
       -- ^ The member proposing this transfer.
     transferFactoryCid : ContractId TransferFactory
@@ -58,6 +60,7 @@ template TransferProposal
     interface instance GovernableAction for TransferProposal where
       view = GovernableActionView with
         governanceParty
+        governanceId
         proposer
         actionLabel = "Transfer"
         description = "Transfer tokens from governance party"

--- a/daml/governance-utility-credential-test/daml/Governance/UtilityCredential/Test/AcceptFreeCredentialTest.daml
+++ b/daml/governance-utility-credential-test/daml/Governance/UtilityCredential/Test/AcceptFreeCredentialTest.daml
@@ -63,6 +63,7 @@ when_accept_free_executed : Fixture -> Script ()
 when_accept_free_executed f = do
   proposalCid <- submit f.parties.member1 $ createCmd AcceptFreeCredential with
     governanceParty = f.parties.governanceParty
+    governanceId = testGovernanceId
     proposer = f.parties.member1
     userServiceCid = f.userServiceCid
     credentialOfferCid = f.offerCid
@@ -94,6 +95,7 @@ when_outsider_confirms_accept : Fixture -> Script ()
 when_outsider_confirms_accept f = do
   proposalCid <- submit f.parties.member1 $ createCmd AcceptFreeCredential with
     governanceParty = f.parties.governanceParty
+    governanceId = testGovernanceId
     proposer = f.parties.member1
     userServiceCid = f.userServiceCid
     credentialOfferCid = f.offerCid

--- a/daml/governance-utility-credential-test/daml/Governance/UtilityCredential/Test/OfferFreeCredentialTest.daml
+++ b/daml/governance-utility-credential-test/daml/Governance/UtilityCredential/Test/OfferFreeCredentialTest.daml
@@ -37,6 +37,7 @@ when_offer_free_executed : Fixture -> Script ()
 when_offer_free_executed f = do
   proposalCid <- submit f.parties.member1 $ createCmd OfferFreeCredential with
     governanceParty = f.parties.governanceParty
+    governanceId = testGovernanceId
     proposer = f.parties.member1
     userServiceCid = f.userServiceCid
     holder = f.parties.holder
@@ -73,6 +74,7 @@ when_outsider_confirms : Fixture -> Script ()
 when_outsider_confirms f = do
   proposalCid <- submit f.parties.member1 $ createCmd OfferFreeCredential with
     governanceParty = f.parties.governanceParty
+    governanceId = testGovernanceId
     proposer = f.parties.member1
     userServiceCid = f.userServiceCid
     holder = f.parties.holder

--- a/daml/governance-utility-credential-test/daml/Governance/UtilityCredential/Test/OfferPaidCredentialTest.daml
+++ b/daml/governance-utility-credential-test/daml/Governance/UtilityCredential/Test/OfferPaidCredentialTest.daml
@@ -47,6 +47,7 @@ when_offer_paid_executed : Fixture -> Script ()
 when_offer_paid_executed f = do
   proposalCid <- submit f.parties.member1 $ createCmd OfferPaidCredential with
     governanceParty = f.parties.governanceParty
+    governanceId = testGovernanceId
     proposer = f.parties.member1
     userServiceCid = f.userServiceCid
     holder = f.parties.holder

--- a/daml/governance-utility-credential-test/daml/Governance/UtilityCredential/TestUtils.daml
+++ b/daml/governance-utility-credential-test/daml/Governance/UtilityCredential/TestUtils.daml
@@ -46,6 +46,10 @@ allocateCredentialTestParties = do
 getMembers : CredentialTestParties -> Set Party
 getMembers parties = Set.fromList [parties.member1, parties.member2, parties.member3]
 
+-- | Standard test governance instance identifier.
+testGovernanceId : Text
+testGovernanceId = "test-credential-governance"
+
 -- | Build submission context for a member with readAs on governance party.
 memberContext : Party -> Party -> SubmitOptions
 memberContext member gp = actAs member <> readAs gp
@@ -55,6 +59,7 @@ createTestGovernance : CredentialTestParties -> Script (ContractId GovernanceRul
 createTestGovernance parties =
   submit parties.governanceParty $ createCmd GovernanceRules with
     governanceParty = parties.governanceParty
+    governanceId = testGovernanceId
     members = getMembers parties
     threshold = 2
     actionConfirmationTimeout = minutes 30

--- a/daml/governance-utility-credential/daml/Governance/UtilityCredential/AcceptFreeCredential.daml
+++ b/daml/governance-utility-credential/daml/Governance/UtilityCredential/AcceptFreeCredential.daml
@@ -20,6 +20,8 @@ template AcceptFreeCredential
     governanceParty : Party
       -- ^ The governance party whose authority is required.
       -- Must equal the `user` field of the referenced UserService.
+    governanceId : Text
+      -- ^ Stable identifier of the targeting GovernanceRules instance.
     proposer : Party
       -- ^ The member proposing this acceptance.
     userServiceCid : ContractId UserService
@@ -33,6 +35,7 @@ template AcceptFreeCredential
     interface instance GovernableAction for AcceptFreeCredential where
       view = GovernableActionView with
         governanceParty
+        governanceId
         proposer
         actionLabel = "AcceptFreeCredential"
         description = "Accept free credential offer"

--- a/daml/governance-utility-credential/daml/Governance/UtilityCredential/OfferFreeCredential.daml
+++ b/daml/governance-utility-credential/daml/Governance/UtilityCredential/OfferFreeCredential.daml
@@ -21,6 +21,8 @@ template OfferFreeCredential
     governanceParty : Party
       -- ^ The governance party whose authority is required.
       -- Must equal the `user` field of the referenced UserService.
+    governanceId : Text
+      -- ^ Stable identifier of the targeting GovernanceRules instance.
     proposer : Party
       -- ^ The member proposing this offer.
     userServiceCid : ContractId UserService
@@ -40,6 +42,7 @@ template OfferFreeCredential
     interface instance GovernableAction for OfferFreeCredential where
       view = GovernableActionView with
         governanceParty
+        governanceId
         proposer
         actionLabel = "OfferFreeCredential"
         description = "Offer free credential [" <> id <> "]"

--- a/daml/governance-utility-credential/daml/Governance/UtilityCredential/OfferPaidCredential.daml
+++ b/daml/governance-utility-credential/daml/Governance/UtilityCredential/OfferPaidCredential.daml
@@ -22,6 +22,8 @@ template OfferPaidCredential
     governanceParty : Party
       -- ^ The governance party whose authority is required.
       -- Must equal the `user` field of the referenced UserService.
+    governanceId : Text
+      -- ^ Stable identifier of the targeting GovernanceRules instance.
     proposer : Party
       -- ^ The member proposing this offer.
     userServiceCid : ContractId UserService
@@ -45,6 +47,7 @@ template OfferPaidCredential
     interface instance GovernableAction for OfferPaidCredential where
       view = GovernableActionView with
         governanceParty
+        governanceId
         proposer
         actionLabel = "OfferPaidCredential"
         description = "Offer paid credential [" <> id <> "]"

--- a/daml/governance-utility-onboarding-test/daml/Governance/UtilityOnboarding/Test/AcceptBurnRequestTest.daml
+++ b/daml/governance-utility-onboarding-test/daml/Governance/UtilityOnboarding/Test/AcceptBurnRequestTest.daml
@@ -77,6 +77,7 @@ seedHoldingForRequester parties rulesCid artifacts holder amount = do
         meta = Metadata with values = TextMap.empty
   proposalCid <- submit parties.member1 $ createCmd AcceptMintRequest with
     governanceParty = parties.governanceParty
+    governanceId = testGovernanceId
     proposer = parties.member1
     mintRequestCid = mintResult.mintRequestCid
     instrumentConfigurationCid = artifacts.instrumentConfigurationCid
@@ -130,6 +131,7 @@ when_accept_burn_request_executed : Fixture -> Script ()
 when_accept_burn_request_executed f = do
   proposalCid <- submit f.parties.member1 $ createCmd AcceptBurnRequest with
     governanceParty = f.parties.governanceParty
+    governanceId = testGovernanceId
     proposer = f.parties.member1
     burnRequestCid = f.burnRequestCid
     instrumentConfigurationCid = f.artifacts.instrumentConfigurationCid
@@ -160,6 +162,7 @@ when_outsider_confirms_accept_burn : Fixture -> Script ()
 when_outsider_confirms_accept_burn f = do
   proposalCid <- submit f.parties.member1 $ createCmd AcceptBurnRequest with
     governanceParty = f.parties.governanceParty
+    governanceId = testGovernanceId
     proposer = f.parties.member1
     burnRequestCid = f.burnRequestCid
     instrumentConfigurationCid = f.artifacts.instrumentConfigurationCid

--- a/daml/governance-utility-onboarding-test/daml/Governance/UtilityOnboarding/Test/AcceptMintRequestTest.daml
+++ b/daml/governance-utility-onboarding-test/daml/Governance/UtilityOnboarding/Test/AcceptMintRequestTest.daml
@@ -87,6 +87,7 @@ when_accept_mint_request_executed : Fixture -> Script ()
 when_accept_mint_request_executed f = do
   proposalCid <- submit f.parties.member1 $ createCmd AcceptMintRequest with
     governanceParty = f.parties.governanceParty
+    governanceId = testGovernanceId
     proposer = f.parties.member1
     mintRequestCid = f.mintRequestCid
     instrumentConfigurationCid = f.artifacts.instrumentConfigurationCid
@@ -119,6 +120,7 @@ when_outsider_confirms_accept_mint : Fixture -> Script ()
 when_outsider_confirms_accept_mint f = do
   proposalCid <- submit f.parties.member1 $ createCmd AcceptMintRequest with
     governanceParty = f.parties.governanceParty
+    governanceId = testGovernanceId
     proposer = f.parties.member1
     mintRequestCid = f.mintRequestCid
     instrumentConfigurationCid = f.artifacts.instrumentConfigurationCid

--- a/daml/governance-utility-onboarding-test/daml/Governance/UtilityOnboarding/Test/BurnProposalTest.daml
+++ b/daml/governance-utility-onboarding-test/daml/Governance/UtilityOnboarding/Test/BurnProposalTest.daml
@@ -63,6 +63,7 @@ when_burn_offered f = do
         meta = Metadata with values = TextMap.fromList [("bridge-id", "xyz-789")]
   proposalCid <- submit f.parties.member1 $ createCmd BurnProposal with
     governanceParty = f.parties.governanceParty
+    governanceId = testGovernanceId
     proposer = f.parties.member1
     allocationFactoryCid = f.artifacts.allocationFactoryCid
     instrumentId = mkInstrumentId f.parties
@@ -103,6 +104,7 @@ when_zero_amount_burn f = do
   now <- getTime
   submitMustFail f.parties.member1 $ createCmd BurnProposal with
     governanceParty = f.parties.governanceParty
+    governanceId = testGovernanceId
     proposer = f.parties.member1
     allocationFactoryCid = f.artifacts.allocationFactoryCid
     instrumentId = mkInstrumentId f.parties

--- a/daml/governance-utility-onboarding-test/daml/Governance/UtilityOnboarding/Test/GranularActionsTest.daml
+++ b/daml/governance-utility-onboarding-test/daml/Governance/UtilityOnboarding/Test/GranularActionsTest.daml
@@ -65,6 +65,7 @@ given_governance_with_operator_as_additional_proposer = do
   parties <- allocateOnboardingTestParties
   rulesCid <- submit parties.governanceParty $ createCmd GovernanceRules with
     governanceParty = parties.governanceParty
+    governanceId = testGovernanceId
     members = getMembers parties
     threshold = 2
     actionConfirmationTimeout = minutes 30
@@ -75,6 +76,7 @@ when_provision_provider_service : GovFixture -> Script ()
 when_provision_provider_service f = do
   proposalCid <- submit f.parties.operator $ createCmd ProvisionProviderService with
     governanceParty = f.parties.governanceParty
+    governanceId = testGovernanceId
     proposer = f.parties.operator
   let proposalInterfaceCid : ContractId GovernableAction = toInterfaceContractId proposalCid
   _ <- confirmAndExecute f.parties f.rulesCid proposalInterfaceCid
@@ -98,6 +100,7 @@ when_create_provider_service_request : GovFixture -> Script ()
 when_create_provider_service_request f = do
   proposalCid <- submit f.parties.member1 $ createCmd CreateProviderServiceRequest with
     governanceParty = f.parties.governanceParty
+    governanceId = testGovernanceId
     proposer = f.parties.member1
     operator = f.parties.operator
     provider = f.parties.governanceParty
@@ -123,6 +126,7 @@ when_create_user_service_request : GovFixture -> Script ()
 when_create_user_service_request f = do
   proposalCid <- submit f.parties.member1 $ createCmd CreateUserServiceRequest with
     governanceParty = f.parties.governanceParty
+    governanceId = testGovernanceId
     proposer = f.parties.member1
     operator = f.parties.operator
     user = f.parties.governanceParty
@@ -148,6 +152,7 @@ when_set_beneficiaries : SetupFixture -> Script ()
 when_set_beneficiaries f = do
   proposalCid <- submit f.parties.member1 $ createCmd SetProviderAppRewardBeneficiaries with
     governanceParty = f.parties.governanceParty
+    governanceId = testGovernanceId
     proposer = f.parties.member1
     instrumentConfigurationCid = f.artifacts.instrumentConfigurationCid
     providerAppRewardBeneficiaries = None
@@ -176,6 +181,7 @@ when_set_enable_result_contracts : SetupFixture -> Script ()
 when_set_enable_result_contracts f = do
   proposalCid <- submit f.parties.member1 $ createCmd SetEnableResultContracts with
     governanceParty = f.parties.governanceParty
+    governanceId = testGovernanceId
     proposer = f.parties.member1
     registrarServiceCid = f.artifacts.registrarServiceCid
     enableResultContracts = Some True
@@ -204,6 +210,7 @@ when_create_delegated_proxy : GovFixture -> Script ()
 when_create_delegated_proxy f = do
   proposalCid <- submit f.parties.member1 $ createCmd CreateDelegatedBatchedMarkersProxy with
     governanceParty = f.parties.governanceParty
+    governanceId = testGovernanceId
     proposer = f.parties.member1
     operator = f.parties.operator
   let proposalInterfaceCid : ContractId GovernableAction = toInterfaceContractId proposalCid

--- a/daml/governance-utility-onboarding-test/daml/Governance/UtilityOnboarding/Test/MintProposalTest.daml
+++ b/daml/governance-utility-onboarding-test/daml/Governance/UtilityOnboarding/Test/MintProposalTest.daml
@@ -63,6 +63,7 @@ when_mint_offered f = do
         meta = Metadata with values = TextMap.fromList [("bridge-id", "xyz-789")]
   proposalCid <- submit f.parties.member1 $ createCmd MintProposal with
     governanceParty = f.parties.governanceParty
+    governanceId = testGovernanceId
     proposer = f.parties.member1
     allocationFactoryCid = f.artifacts.allocationFactoryCid
     instrumentId = mkInstrumentId f.parties
@@ -103,6 +104,7 @@ when_zero_amount f = do
   now <- getTime
   submitMustFail f.parties.member1 $ createCmd MintProposal with
     governanceParty = f.parties.governanceParty
+    governanceId = testGovernanceId
     proposer = f.parties.member1
     allocationFactoryCid = f.artifacts.allocationFactoryCid
     instrumentId = mkInstrumentId f.parties

--- a/daml/governance-utility-onboarding-test/daml/Governance/UtilityOnboarding/Test/SetupUtilityTest.daml
+++ b/daml/governance-utility-onboarding-test/daml/Governance/UtilityOnboarding/Test/SetupUtilityTest.daml
@@ -35,6 +35,7 @@ when_setup_executed f = do
   providerCid <- initProviderService f.parties
   proposalCid <- submit f.parties.member1 $ createCmd SetupUtility with
     governanceParty = f.parties.governanceParty
+    governanceId = testGovernanceId
     proposer = f.parties.member1
     providerServiceCid = providerCid
     operator = f.parties.operator
@@ -69,6 +70,7 @@ when_setup_without_optional_steps f = do
   providerCid <- initProviderService f.parties
   proposalCid <- submit f.parties.member1 $ createCmd SetupUtility with
     governanceParty = f.parties.governanceParty
+    governanceId = testGovernanceId
     proposer = f.parties.member1
     providerServiceCid = providerCid
     operator = f.parties.operator
@@ -101,6 +103,7 @@ when_non_member_confirms f = do
   providerCid <- initProviderService f.parties
   proposalCid <- submit f.parties.member1 $ createCmd SetupUtility with
     governanceParty = f.parties.governanceParty
+    governanceId = testGovernanceId
     proposer = f.parties.member1
     providerServiceCid = providerCid
     operator = f.parties.operator

--- a/daml/governance-utility-onboarding-test/daml/Governance/UtilityOnboarding/TestUtils.daml
+++ b/daml/governance-utility-onboarding-test/daml/Governance/UtilityOnboarding/TestUtils.daml
@@ -46,6 +46,9 @@ allocateOnboardingTestParties = do
 getMembers : OnboardingTestParties -> Set Party
 getMembers parties = Set.fromList [parties.member1, parties.member2, parties.member3]
 
+testGovernanceId : Text
+testGovernanceId = "test-onboarding-governance"
+
 memberContext : Party -> Party -> SubmitOptions
 memberContext member gp = actAs member <> readAs gp
 
@@ -53,6 +56,7 @@ createTestGovernance : OnboardingTestParties -> Script (ContractId GovernanceRul
 createTestGovernance parties =
   submit parties.governanceParty $ createCmd GovernanceRules with
     governanceParty = parties.governanceParty
+    governanceId = testGovernanceId
     members = getMembers parties
     threshold = 2
     actionConfirmationTimeout = minutes 30
@@ -117,6 +121,7 @@ setupUtilityForTest parties rulesCid = do
   providerCid <- initProviderService parties
   proposalCid <- submit parties.member1 $ createCmd SetupUtility with
     governanceParty = parties.governanceParty
+    governanceId = testGovernanceId
     proposer = parties.member1
     providerServiceCid = providerCid
     operator = parties.operator

--- a/daml/governance-utility-onboarding/daml/Governance/TokenIssuance/AcceptBurnRequest.daml
+++ b/daml/governance-utility-onboarding/daml/Governance/TokenIssuance/AcceptBurnRequest.daml
@@ -23,6 +23,7 @@ import Governance.Action
 template AcceptBurnRequest
   with
     governanceParty : Party
+    governanceId : Text
     proposer : Party
     burnRequestCid : ContractId BurnRequest
     instrumentConfigurationCid : ContractId InstrumentConfiguration
@@ -35,6 +36,7 @@ template AcceptBurnRequest
     interface instance GovernableAction for AcceptBurnRequest where
       view = GovernableActionView with
         governanceParty
+        governanceId
         proposer
         actionLabel = "AcceptBurnRequest"
         description

--- a/daml/governance-utility-onboarding/daml/Governance/TokenIssuance/AcceptMintRequest.daml
+++ b/daml/governance-utility-onboarding/daml/Governance/TokenIssuance/AcceptMintRequest.daml
@@ -23,6 +23,7 @@ import Governance.Action
 template AcceptMintRequest
   with
     governanceParty : Party
+    governanceId : Text
     proposer : Party
     mintRequestCid : ContractId MintRequest
     instrumentConfigurationCid : ContractId InstrumentConfiguration
@@ -35,6 +36,7 @@ template AcceptMintRequest
     interface instance GovernableAction for AcceptMintRequest where
       view = GovernableActionView with
         governanceParty
+        governanceId
         proposer
         actionLabel = "AcceptMintRequest"
         description

--- a/daml/governance-utility-onboarding/daml/Governance/TokenIssuance/BurnProposal.daml
+++ b/daml/governance-utility-onboarding/daml/Governance/TokenIssuance/BurnProposal.daml
@@ -25,6 +25,7 @@ import Governance.Action
 template BurnProposal
   with
     governanceParty : Party
+    governanceId : Text
     proposer : Party
     allocationFactoryCid : ContractId AllocationFactory
     instrumentId : InstrumentId
@@ -45,6 +46,7 @@ template BurnProposal
     interface instance GovernableAction for BurnProposal where
       view = GovernableActionView with
         governanceParty
+        governanceId
         proposer
         actionLabel = "Burn"
         description

--- a/daml/governance-utility-onboarding/daml/Governance/TokenIssuance/MintProposal.daml
+++ b/daml/governance-utility-onboarding/daml/Governance/TokenIssuance/MintProposal.daml
@@ -24,6 +24,7 @@ import Governance.Action
 template MintProposal
   with
     governanceParty : Party
+    governanceId : Text
     proposer : Party
     allocationFactoryCid : ContractId AllocationFactory
     instrumentId : InstrumentId
@@ -44,6 +45,7 @@ template MintProposal
     interface instance GovernableAction for MintProposal where
       view = GovernableActionView with
         governanceParty
+        governanceId
         proposer
         actionLabel = "Mint"
         description

--- a/daml/governance-utility-onboarding/daml/Governance/UtilityOnboarding/CreateDelegatedBatchedMarkersProxy.daml
+++ b/daml/governance-utility-onboarding/daml/Governance/UtilityOnboarding/CreateDelegatedBatchedMarkersProxy.daml
@@ -14,6 +14,7 @@ import Governance.Action
 template CreateDelegatedBatchedMarkersProxy
   with
     governanceParty : Party
+    governanceId : Text
     proposer : Party
     operator : Party
   where
@@ -23,6 +24,7 @@ template CreateDelegatedBatchedMarkersProxy
     interface instance GovernableAction for CreateDelegatedBatchedMarkersProxy where
       view = GovernableActionView with
         governanceParty
+        governanceId
         proposer
         actionLabel = "CreateDelegatedBatchedMarkersProxy"
         description = "Authorize operator to create batched markers for the provider."

--- a/daml/governance-utility-onboarding/daml/Governance/UtilityOnboarding/CreateProviderServiceRequest.daml
+++ b/daml/governance-utility-onboarding/daml/Governance/UtilityOnboarding/CreateProviderServiceRequest.daml
@@ -12,6 +12,7 @@ import Governance.Action
 template CreateProviderServiceRequest
   with
     governanceParty : Party
+    governanceId : Text
     proposer : Party
     operator : Party
     provider : Party
@@ -22,6 +23,7 @@ template CreateProviderServiceRequest
     interface instance GovernableAction for CreateProviderServiceRequest where
       view = GovernableActionView with
         governanceParty
+        governanceId
         proposer
         actionLabel = "CreateProviderServiceRequest"
         description = "Create a ProviderServiceRequest for onboarding."

--- a/daml/governance-utility-onboarding/daml/Governance/UtilityOnboarding/CreateUserServiceRequest.daml
+++ b/daml/governance-utility-onboarding/daml/Governance/UtilityOnboarding/CreateUserServiceRequest.daml
@@ -12,6 +12,7 @@ import Governance.Action
 template CreateUserServiceRequest
   with
     governanceParty : Party
+    governanceId : Text
     proposer : Party
     operator : Party
     user : Party
@@ -22,6 +23,7 @@ template CreateUserServiceRequest
     interface instance GovernableAction for CreateUserServiceRequest where
       view = GovernableActionView with
         governanceParty
+        governanceId
         proposer
         actionLabel = "CreateUserServiceRequest"
         description = "Create a UserServiceRequest for onboarding."

--- a/daml/governance-utility-onboarding/daml/Governance/UtilityOnboarding/ProvisionProviderService.daml
+++ b/daml/governance-utility-onboarding/daml/Governance/UtilityOnboarding/ProvisionProviderService.daml
@@ -29,6 +29,7 @@ import Governance.Action
 template ProvisionProviderService
   with
     governanceParty : Party
+    governanceId : Text
     proposer : Party
   where
     signatory proposer
@@ -37,6 +38,7 @@ template ProvisionProviderService
     interface instance GovernableAction for ProvisionProviderService where
       view = GovernableActionView with
         governanceParty
+        governanceId
         proposer
         actionLabel = "ProvisionProviderService"
         description = "Provision a ProviderService with operator = proposer and provider = governanceParty."

--- a/daml/governance-utility-onboarding/daml/Governance/UtilityOnboarding/SetEnableResultContracts.daml
+++ b/daml/governance-utility-onboarding/daml/Governance/UtilityOnboarding/SetEnableResultContracts.daml
@@ -13,6 +13,7 @@ import Governance.Action
 template SetEnableResultContracts
   with
     governanceParty : Party
+    governanceId : Text
     proposer : Party
     registrarServiceCid : ContractId RegistrarService
     enableResultContracts : Optional Bool
@@ -23,6 +24,7 @@ template SetEnableResultContracts
     interface instance GovernableAction for SetEnableResultContracts where
       view = GovernableActionView with
         governanceParty
+        governanceId
         proposer
         actionLabel = "SetEnableResultContracts"
         description = "Toggle result-contract emission on RegistrarService."

--- a/daml/governance-utility-onboarding/daml/Governance/UtilityOnboarding/SetProviderAppRewardBeneficiaries.daml
+++ b/daml/governance-utility-onboarding/daml/Governance/UtilityOnboarding/SetProviderAppRewardBeneficiaries.daml
@@ -15,6 +15,7 @@ import Governance.Action
 template SetProviderAppRewardBeneficiaries
   with
     governanceParty : Party
+    governanceId : Text
     proposer : Party
     instrumentConfigurationCid : ContractId InstrumentConfiguration
     providerAppRewardBeneficiaries : Optional [AppRewardBeneficiary]
@@ -25,6 +26,7 @@ template SetProviderAppRewardBeneficiaries
     interface instance GovernableAction for SetProviderAppRewardBeneficiaries where
       view = GovernableActionView with
         governanceParty
+        governanceId
         proposer
         actionLabel = "SetProviderAppRewardBeneficiaries"
         description = "Set provider app reward beneficiaries on InstrumentConfiguration."

--- a/daml/governance-utility-onboarding/daml/Governance/UtilityOnboarding/SetupUtility.daml
+++ b/daml/governance-utility-onboarding/daml/Governance/UtilityOnboarding/SetupUtility.daml
@@ -20,6 +20,7 @@ import Governance.Action
 template SetupUtility
   with
     governanceParty : Party
+    governanceId : Text
     proposer : Party
     providerServiceCid : ContractId ProviderService
     operator : Party
@@ -33,6 +34,7 @@ template SetupUtility
     interface instance GovernableAction for SetupUtility where
       view = GovernableActionView with
         governanceParty
+        governanceId
         proposer
         actionLabel = "SetupUtility"
         description = "Composite onboarding: register instrument " <> instrumentIdText


### PR DESCRIPTION
## Summary
Adds an immutable `governanceId : Text` to `GovernanceRules`, `GovernableActionView`, `GovernanceConfirmation`, and `GovernanceSelfConfirmation`. Confirm/execute checks now require the proposal's and each consumed confirmation's `governanceId` to match the rules instance's `governanceId`. Removes the TODO comment in `ConfirmAction`.

Every proposal template that implements `GovernableAction` (~17 production templates + 3 test mocks) gained a `governanceId : Text` field and passes it through to the view.

## Why
Per Quantstamp **#93**: the previous proposal-targeting check (`actionView.governanceParty == governanceParty`) does not distinguish between multiple `GovernanceRules` contracts that share a `governanceParty`. A latent attack/mistake surface: if a bootstrap, upgrade, or migration ever produces a second instance, proposals and confirmations could be processed against the wrong rules contract — possibly enforcing a weaker threshold. Today there is presumably one rules instance per party so the bug is latent, but the audit flagged it as worth fixing before mainnet rather than after.

`governanceId` is preserved across all self-management rewrites because each `create this with ...` does not set the field. A test (`testGovernanceIdPreservedAcrossSelfActions`) asserts this invariant after exercising the self-management path.

## What's not in this PR
- **No migration code for live testnet/RC4 contracts.** The audit explicitly flagged this as an open operational question. Existing contracts have no `governanceId` and require either a one-time upgrade path or a clean cutover — that's a deployment decision, not a code one.
- **No upgrade story for the package itself.** The packages are `v0`/`-v0` and the field addition is a breaking schema change. Consumers compiling against the new DARs will need to supply `governanceId` everywhere — that's done in this PR for the test packages.

## Test plan
- [x] `dpm build --all` clean
- [x] `governance-core-test` passes (51 tests including 4 new disambiguation tests):
  - `testRejectWrongGovernanceId` — proposal authored against instance A cannot be confirmed on instance B
  - `testRejectCrossInstanceConfirmationReplay` — confirmations from instance A cannot execute on instance B
  - `testRejectCrossInstanceSelfConfirmationReplay` — same for self-confirmations
  - `testGovernanceIdPreservedAcrossSelfActions` — `governanceId` survives a `SetThreshold` rewrite
- [x] `governance-token-custody-test`, `governance-utility-onboarding-test`, `governance-utility-credential-test` pass (no regression after every proposal template gained the new field)

Closes #93.

🤖 Generated with [Claude Code](https://claude.com/claude-code)