### PR TITLE
fix(parties): unblocked peer owner_key resolution on devnet (#149)

### DIFF
--- a/src/server/handlers/parties.rs
+++ b/src/server/handlers/parties.rs
@@ -241,7 +241,23 @@ pub async fn resolve_owner_keys_from_peers(
         };
 
         let psk = keypair.derive_psk(&peer_pub_key);
-        let msg = Message::new_empty(MessageType::RequestOwnerKeys);
+        // Tell the peer which parties we want owner_keys for. See #149: peer
+        // used to enumerate the whole synchronizer to build a namespace→party
+        // map; we now pass the namespaces (via the full party_ids) directly so
+        // the peer can skip that scan.
+        let request_payload = match serde_json::to_vec(
+            &parties
+                .iter()
+                .map(|p| p.party_id.to_string())
+                .collect::<Vec<_>>(),
+        ) {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::warn!("Failed to serialise RequestOwnerKeys payload: {e}");
+                continue;
+            }
+        };
+        let msg = Message::new(MessageType::RequestOwnerKeys, request_payload);
 
         tracing::debug!("Requesting owner keys from {peer_uid}");
         let response = match tokio::time::timeout(

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -27,8 +27,8 @@ use canton_proto_rs::com::digitalasset::canton::{
         v30::public_key,
     },
     topology::admin::v30::{
-        BaseQuery, ListDecentralizedNamespaceDefinitionRequest, ListPartyToParticipantRequest,
-        StoreId, Synchronizer, base_query, store_id, synchronizer,
+        BaseQuery, ListDecentralizedNamespaceDefinitionRequest, StoreId, Synchronizer, base_query,
+        store_id, synchronizer,
         topology_manager_read_service_client::TopologyManagerReadServiceClient,
     },
 };
@@ -54,7 +54,7 @@ use crate::{
     },
     server::middleware::AuthMiddleware,
     server::peer_status::LastSeen,
-    utils::{compute_fingerprint, get_synchronizer_id_from_url},
+    utils::{self, compute_fingerprint},
     workflow::{self, WorkflowType},
 };
 
@@ -128,8 +128,11 @@ pub struct AppState {
 #[derive(Clone)]
 struct WorkflowTriggers {
     pending_invitations: Arc<RwLock<Vec<PendingInvitation>>>,
+    /// Full node config — read by handler arms that need the participant
+    /// identity, admin URL, or synchronizer alias as a bundle (e.g.
+    /// `list_my_owner_keys`'s P2P filter, see #149).
+    config: NodeConfig,
     admin_api_url: String,
-    synchronizer: String,
     /// Cache for chunked ListPackages responses, keyed by the requesting
     /// peer's pubkey (hex). Populated when a ListPackages response exceeds
     /// `MAX_PAYLOAD_SIZE`; consumed by subsequent GetChunk requests from the
@@ -1067,8 +1070,8 @@ pub async fn start_server(
     let heartbeat_notify = listener_notify.clone();
     let heartbeat_triggers = WorkflowTriggers {
         pending_invitations: pending_invitations.clone(),
+        config: config.clone(),
         admin_api_url: config.admin_api_url(),
-        synchronizer: config.synchronizer().to_string(),
         list_packages_chunk_cache: Arc::new(Mutex::new(HashMap::new())),
         db: db.clone(),
         party_credentials: party_credentials.clone(),
@@ -1716,16 +1719,24 @@ async fn handle_incoming_connection(
                         }
                         MessageType::RequestOwnerKeys => {
                             tracing::debug!("Received RequestOwnerKeys request");
-                            let admin_url = triggers.admin_api_url.clone();
-                            let synchronizer = triggers.synchronizer.clone();
-                            let payload = match list_my_owner_keys(&admin_url, &synchronizer).await
-                            {
-                                Ok(data) => data,
-                                Err(e) => {
-                                    tracing::error!("Failed to list owner keys: {e}");
-                                    b"[]".to_vec()
-                                }
-                            };
+                            // Payload is a JSON array of decentralized party_ids
+                            // the caller wants this node's owner_keys for (see
+                            // #149: peer no longer enumerates the synchronizer).
+                            // A malformed or absent payload is treated as
+                            // "nothing requested" — return an empty list rather
+                            // than fall back to a slow whole-synchronizer scan.
+                            let requested_party_ids: Vec<String> =
+                                serde_json::from_slice(&msg.payload).unwrap_or_default();
+                            let payload =
+                                match list_my_owner_keys(&triggers.config, &requested_party_ids)
+                                    .await
+                                {
+                                    Ok(data) => data,
+                                    Err(e) => {
+                                        tracing::error!("Failed to list owner keys: {e}");
+                                        b"[]".to_vec()
+                                    }
+                                };
                             let response_msg = Message::new(MessageType::OwnerKeys, payload);
                             return Ok(Response::builder()
                                 .status(StatusCode::OK)
@@ -2452,10 +2463,41 @@ async fn run_dars_peer_listener(
     }
 }
 
-/// Query Canton for this node's owner keys across all decentralized parties.
-/// Returns JSON: `[{"party_id": "prefix::namespace", "owner_key": "fingerprint"}, ...]`
-async fn list_my_owner_keys(admin_api_url: &str, synchronizer_alias: &str) -> Result<Vec<u8>> {
-    let channel = tonic::transport::Channel::from_shared(admin_api_url.to_string())?
+/// Query Canton for this node's owner keys across a caller-supplied set of
+/// decentralized parties. Returns JSON:
+/// `[{"party_id": "prefix::namespace", "owner_key": "fingerprint"}, ...]`.
+///
+/// `requested_party_ids` is the list of parties the caller cares about, sent
+/// in the Noise `RequestOwnerKeys` payload by `resolve_owner_keys_from_peers`.
+/// Building the `namespace → party_id` map directly from this list lets us
+/// skip the unfiltered `list_party_to_participant` call that previously
+/// scanned every party on the synchronizer — that scan does not complete
+/// within the Noise budget against a kubectl-tunneled Canton admin API on
+/// devnet (~170 parties, never returns within 60s; see #149).
+async fn list_my_owner_keys(
+    config: &NodeConfig,
+    requested_party_ids: &[String],
+) -> Result<Vec<u8>> {
+    if requested_party_ids.is_empty() {
+        return Ok(b"[]".to_vec());
+    }
+
+    // Caller provides full party_ids ("prefix::namespace_fingerprint"). The
+    // namespace is the suffix after the final "::"; we use it to look up the
+    // matching `DecentralizedNamespaceDefinition` entry. Party IDs without
+    // "::" are dropped (malformed; nothing we could match against).
+    let namespace_to_party: HashMap<String, &str> = requested_party_ids
+        .iter()
+        .filter_map(|pid| {
+            pid.rsplit_once("::")
+                .map(|(_, ns)| (ns.to_string(), pid.as_str()))
+        })
+        .collect();
+    if namespace_to_party.is_empty() {
+        return Ok(b"[]".to_vec());
+    }
+
+    let channel = tonic::transport::Channel::from_shared(config.admin_api_url())?
         .connect()
         .await?;
 
@@ -2479,7 +2521,8 @@ async fn list_my_owner_keys(admin_api_url: &str, synchronizer_alias: &str) -> Re
         }
     }
 
-    let synchronizer_id = get_synchronizer_id_from_url(admin_api_url, synchronizer_alias).await?;
+    // Cached after first call (`get_synchronizer_id` memoises via OnceCell).
+    let synchronizer_id = utils::get_synchronizer_id(config).await?;
 
     let base_query = BaseQuery {
         store: Some(StoreId {
@@ -2494,39 +2537,21 @@ async fn list_my_owner_keys(admin_api_url: &str, synchronizer_alias: &str) -> Re
         protocol_version: None,
     };
 
-    // Get all decentralized namespace definitions
+    // Get all decentralized namespace definitions. The response is bounded by
+    // the number of decentralized parties allocated on the synchronizer
+    // (49 entries observed on devnet — completes in <1s).
     let dns_response = topology_client
         .list_decentralized_namespace_definition(tonic::Request::new(
             ListDecentralizedNamespaceDefinitionRequest {
-                base_query: Some(base_query.clone()),
+                base_query: Some(base_query),
                 filter_namespace: String::new(),
             },
         ))
         .await?
         .into_inner();
 
-    // Get P2P mappings to resolve full party_id (prefix::namespace)
-    let p2p_response = topology_client
-        .list_party_to_participant(tonic::Request::new(ListPartyToParticipantRequest {
-            base_query: Some(base_query),
-            filter_party: String::new(),
-            filter_participant: String::new(),
-        }))
-        .await?
-        .into_inner();
-
-    // Build namespace → full party_id map from P2P data
-    let namespace_to_party: HashMap<String, String> = p2p_response
-        .results
-        .into_iter()
-        .filter_map(|r| {
-            let p = r.item?;
-            let ns = p.party.rsplit_once("::")?.1.to_string();
-            Some((ns, p.party))
-        })
-        .collect();
-
-    // Match this node's fingerprints against each party's owners list
+    // Match this node's fingerprints against each party's owners list, but
+    // only for namespaces the caller asked about.
     let mut entries = Vec::new();
     for result in dns_response.results {
         let Some(item) = result.item else { continue };

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use bytes::{Buf, BufMut, BytesMut};
 use prost::Message;
-use tokio::fs;
+use tokio::{fs, sync::OnceCell};
 
 use anyhow::Context;
 use canton_proto_rs::com::{
@@ -271,12 +271,30 @@ pub fn compute_fingerprint(key: &SigningPublicKey) -> String {
     fingerprint
 }
 
-/// Get synchronizer ID from config
+/// Process-wide cache for the resolved physical synchronizer ID.
 ///
-/// Queries the participant's synchronizer connectivity service to get the physical
-/// synchronizer ID for the configured synchronizer alias.
+/// The ID is stable for the lifetime of a DPM process (it only changes if the
+/// node is reprovisioned against a different synchronizer, which requires a
+/// restart). Resolving it costs a fresh gRPC channel + a one-shot
+/// `get_synchronizer_id` call against the Canton admin API — observed at
+/// ~4.3s median over a kubectl-tunneled devnet (see #149). Caching it
+/// eliminates that cost from every call site that previously resolved it
+/// per request.
+static SYNCHRONIZER_ID_CACHE: OnceCell<String> = OnceCell::const_new();
+
+/// Get synchronizer ID from config (cached after first successful resolution).
+///
+/// Queries the participant's synchronizer connectivity service to get the
+/// physical synchronizer ID for the configured synchronizer alias. The result
+/// is memoised in a process-wide [`SYNCHRONIZER_ID_CACHE`]; subsequent calls
+/// return the cached value without any network round trip.
 pub async fn get_synchronizer_id(config: &NodeConfig) -> Result<String> {
-    get_synchronizer_id_from_url(&config.admin_api_url(), config.synchronizer()).await
+    SYNCHRONIZER_ID_CACHE
+        .get_or_try_init(|| async {
+            get_synchronizer_id_from_url(&config.admin_api_url(), config.synchronizer()).await
+        })
+        .await
+        .cloned()
 }
 
 /// Get the physical synchronizer ID from a Canton Admin API URL and alias


### PR DESCRIPTION
## The bug (#149)

Each owner-participant of a decentralized party holds its **own** namespace-signing key. The fingerprint of that key is that participant's `owner_key` for the party — and **the other peers can't derive it from Canton's topology state**, because the key lives in the vault of the participant that controls it, not in any topology mapping the other peers can read.

So every peer has to **learn** every co-owner's `owner_key` over the wire. The mechanism: a background task `resolve_owner_keys_from_peers` sends a Noise `RequestOwnerKeys` to each peer; the peer responds with its `owner_key`s; the caller writes them to its local DB. After a couple of cycles, every node has the same `(party, peer, owner_key)` map — "**converged**".

On devnet this never happens. The Noise call to every peer times out every cycle (`Noise request to <peer> failed: Hyper error: connection closed before message completed` — **42–51 such warnings per test run** observed pre-fix), the response is never parsed, the DB update never fires. The owner_key snapshot harness from PR #142 captured the pattern across all 9 happy-path phases on devnet:

```
[P1's view, P2's view, P3's view] of [P1, P2, P3] owner_keys:
P1=[Y,N,N]  P2=[N,Y,N]  P3=[N,N,Y]   ← diagonal only, every phase, forever
```

Each node has its **own** `owner_key` (the diagonal `Y`s) but never picks up the other two. Localnet for comparison converges within one cycle:

```
phase 1:  P1=[Y,Y,Y]  P2=[N,Y,N]  P3=[N,N,Y]   ← coordinator already converged
phase 2+: P1=[Y,Y,Y]  P2=[Y,Y,Y]  P3=[Y,Y,Y]   ← rest catch up next /decentralized-parties
```

The visible failure is the `owner_key_resilience` integration-test scenario tripping on its first assertion ("P3 owner_key was resolved in an earlier phase"). The deeper failure is that owner_key resolution is silently broken on devnet — `refresh_and_cache_parties` is fire-and-forget, so the resolve never bubbles up to any HTTP response and just looks like a permanently-stale cache.

## Root cause

The peer-side handler `list_my_owner_keys` (`src/server/mod.rs`) was making three Canton admin-gRPC calls. The third — `list_party_to_participant` with an empty `filter_party` — scans **every** party-to-participant mapping on the synchronizer (~170 on devnet) just to build a `namespace → party_id` lookup. Against a `kubectl port-forward` to an EKS Canton, that call does not return within 60s. `hyper-noise`'s server wrapper cancels the in-flight handler at `NOISE_REQUEST_TIMEOUT` (10s), drops the TCP connection, and the client's body-read fails with the "connection closed" hyper error.

Localnet was unaffected because docker-compose Canton has a handful of parties and completes in milliseconds.

(Aside: Canton's `filter_participant` field is a **post-filter** applied in memory after the topology store has already enumerated everything — only `filter_party` is pushed into the store query. Verified empirically; tried as a fix and ruled out mid-PR.)

## The fix

Two changes, both in `src/`:

1. **Skip `list_party_to_participant` entirely.** The caller `resolve_owner_keys_from_peers` already has the list of parties it cares about. It now serialises those `party_id`s into the Noise `RequestOwnerKeys` payload (previously empty). The peer-side `list_my_owner_keys` builds the `namespace → party_id` map directly from this list, queries only `list_decentralized_namespace_definition` and `list_my_keys`, and intersects DNS owners with this node's namespace-key fingerprints. The whole-synchronizer scan is gone — work scales with the caller's interest, not with mesh size.
2. **Cache `synchronizer_id` at process scope.** `utils::get_synchronizer_id` now memoises via `tokio::sync::OnceCell`. The synchronizer ID is stable for the lifetime of a DPM process; resolving it cost ~4.3s per call on devnet. All six existing callers benefit automatically (no signature changes).

## Wire-format change

`RequestOwnerKeys` previously carried an empty payload. It now carries a JSON-serialised `Vec<String>` of full `party_id`s. The peer decodes; an absent or malformed payload yields `[]` (no slow fallback — the old unfiltered path *is* the bug). All mesh members must run this fix together; mixed old/new during a rolling upgrade means old callers get nothing from new peers and new callers get the old broken behaviour from old peers.

## Verification

- **Localnet IT — full pass.** `cargo test --test governance_workflows -- --ignored --nocapture` finishes in 1245s, 1 passed / 0 failed, covering all 16 happy-path scenarios plus chaos phases.
- **Devnet IT — fix is decisively doing its job (indirect evidence).** Across multiple post-fix devnet runs: **0** `Hyper error: connection closed before message completed` warnings, **0** `Noise request to … failed` warnings, **0** `Failed to list owner keys` errors. Pre-fix runs produced 42–51 of these per run; the resolve flow was failing on every cycle. Post-fix it succeeds silently.
- **Devnet IT — `owner_key_resilience` PASSED end-to-end on devnet.** Full 16 happy-path scenarios + the first 4 chaos phases (`kick`, `identity_survives_dismiss`, `cancel_cascades`, `start_handler_conflict_409`) all green; `owner_key survives a cache refresh` completed in 62.2s with the pre-phase owner_key snapshot showing all three peers' views converged (`P1=Y P2=Y P3=Y`). Zero `Hyper error: connection closed` warnings, zero `Noise request failed` warnings, zero `Failed to list owner keys` errors across the whole 962s run. The run later died on a chaos phase (most likely G1 `restart_coordinator_resume`) with `poll_until exhausted deadline of 240s` — an orthogonal test-harness/timing issue, not anything in #149's flow.

## Test plan

- [x] `cargo fmt --all -- --check` clean (CI) ✓
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean (CI) ✓
- [x] `cargo test` clean — unit tests (CI) ✓
- [x] `cargo test … --test governance_workflows -- --ignored --nocapture` clean on localnet (CI Integration Tests) ✓
- [x] Devnet end-to-end: `./integration-tests/run.sh --target devnet --verbose` completes `owner_key_resilience` cleanly; the run log shows 0 `Hyper error: connection closed` warnings (verified 2026-05-18 on devnet against fix tip a1b29f0). ✓

## Notes

- This branch is **based on PR #142** (`test/integration-tests/extend-to-devnet`), not `main`: the devnet IT scaffolding plus `owner_key_resilience` scenario live there, and #142's `stop_nodes` reap fix (`349a1df`) is required to run the devnet IT at all. Re-target to `main` after #142 merges, or merge via #142.
- `list_my_owner_keys`'s signature now takes `(&NodeConfig, &[String])`; one Noise handler arm in `src/server/mod.rs` is updated. No other internal callers.
- `WorkflowTriggers` gains a `config: NodeConfig` field (read by `list_my_owner_keys`); its previous `synchronizer: String` field is dropped (it was only used by the old `list_my_owner_keys`).

Closes #149.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

