### PR TITLE
chore(zarf): expose testnet noise port via NLB

### DIFF
--- a/docs/MIGRATION_GUIDE.md
+++ b/docs/MIGRATION_GUIDE.md
@@ -266,6 +266,8 @@ spec:
 
 ### 4d. Service
 
+The deployment uses two Services. The first is a `ClusterIP` that backs the Ingress for the HTTP admin UI; the second is a `LoadBalancer` that exposes the Noise port (9000) to the public internet so peers can reach you. Splitting them keeps `DECPM_PUBLIC_ADDRESS` pointed at a stable, dedicated endpoint and avoids putting the admin UI on a raw load balancer.
+
 ```yaml
 apiVersion: v1
 kind: Service
@@ -283,9 +285,28 @@ spec:
       targetPort: 9000
   selector:
     app.kubernetes.io/name: dec-party-manager
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dec-party-manager-noise
+  namespace: <your-namespace>
+  annotations:
+    # AWS EKS example — use the cloud-provider annotation appropriate for
+    # your cluster (or omit for a Classic ELB / on-prem MetalLB).
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+spec:
+  type: LoadBalancer
+  ports:
+    - name: noise
+      port: 9000
+      targetPort: 9000
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: dec-party-manager
 ```
 
-The Noise port (9000) must also be reachable from the public internet for peers to connect. Depending on your cluster, you may need a separate `LoadBalancer`-type Service, a `NodePort`, or another mechanism (MetalLB, native cloud load balancer, etc.) for the `noise` port specifically. The HTTP UI does not need to be exposed publicly — it is reached through the Ingress (next).
+After applying, read the LoadBalancer's external hostname (or IP) with `kubectl -n <your-namespace> get svc dec-party-manager-noise` and set `DECPM_PUBLIC_ADDRESS` in the Secret to that value, then restart the Deployment so the new env is picked up. If you are not on EKS, replace the annotation with whatever your cluster's cloud-provider integration expects, or use a `NodePort` / MetalLB / external load balancer of your choice — the only requirement is that peers can reach port 9000 at `DECPM_PUBLIC_ADDRESS` over raw TCP. The HTTP UI does not need to be exposed publicly — it is reached through the Ingress (next).
 
 ### 4e. Ingress (Traefik example)
 

--- a/zarf/deployments/testnet/deployment.yaml
+++ b/zarf/deployments/testnet/deployment.yaml
@@ -44,7 +44,7 @@ spec:
               mountPath: /app
       containers:
         - name: dec-party-manager
-          image: public.ecr.aws/dlc-link/canton-decparty-manager:0.0.31
+          image: public.ecr.aws/dlc-link/canton-decparty-manager:0.1.1
           imagePullPolicy: Always
           command:
             [
@@ -100,6 +100,27 @@ spec:
       port: 80
       targetPort: 8080
       protocol: TCP
+    - name: noise
+      port: 9000
+      targetPort: 9000
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: dec-party-manager
+    app.kubernetes.io/instance: participant-1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dec-party-manager-1-noise
+  namespace: catalyst-canton
+  labels:
+    app.kubernetes.io/name: dec-party-manager
+    app.kubernetes.io/instance: participant-1
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+spec:
+  type: LoadBalancer
+  ports:
     - name: noise
       port: 9000
       targetPort: 9000


### PR DESCRIPTION
## Summary

The previous testnet migration moved `dec-party-manager-1` to a `ClusterIP` Service fronted by a Traefik Ingress (devnet-style), which works for the HTTP admin UI but leaves the Noise port (9000) with no public path. Peers reading `DECPM_PUBLIC_ADDRESS` were pointed at a stale Classic ELB hostname (`ac4d02121799a43bc99dfbff9f919755-…`) that no longer resolves (NXDOMAIN), so all external noise traffic was failing.

This PR adds a dedicated `dec-party-manager-1-noise` Service (`type: LoadBalancer`, port 9000 only, AWS NLB annotation) alongside the existing ClusterIP + Ingress. The existing HTTPS path through Traefik is untouched, and `DECPM_PUBLIC_ADDRESS` now has a real, dedicated TCP endpoint to point at.

Also bumps the image tag to `0.1.1` and documents the two-service pattern in `docs/MIGRATION_GUIDE.md` (§4d) so downstream operators don't run into the same gap.

## Why split into two Services instead of going back to mainnet's single LB?

- Keeps TLS-terminated HTTPS for the admin UI through Traefik (mainnet currently serves it in cleartext over a Classic ELB — a small wart we don't have to inherit).
- Noise traffic is already encrypted at the app layer, so a raw TCP NLB is the right shape and doesn't need TLS.
- `DECPM_PUBLIC_ADDRESS` ends up pinned to a stable, single-purpose endpoint.

## Operator follow-up after merge + apply

```bash
NLB=$(kubectl -n catalyst-canton get svc dec-party-manager-1-noise -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
kubectl -n catalyst-canton patch secret dec-party-manager-1-secrets \
  --type=json -p='[{"op":"replace","path":"/data/DECPM_PUBLIC_ADDRESS","value":"'$(echo -n "$NLB" | base64)'"}]'
kubectl -n catalyst-canton rollout restart deploy/dec-party-manager-1
```

## Test plan

- [x] Applied locally on `ibtc-testnet` — NLB `a42d15b9ae86445d0b74404b816ca681-d641e0f4e37b3475.elb.us-east-1.amazonaws.com` came up, endpoint backed by the pod IP
- [x] External DNS resolves (8.8.8.8 / 1.1.1.1) and `nc -vz <nlb> 9000` succeeds against all three AZ IPs
- [ ] Verify peers reconnect after `DECPM_PUBLIC_ADDRESS` is repointed and the deployment is rolled