### PR TITLE
fix(auth): switched to Quarkus-style Keycloak token URL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,7 +670,7 @@ dependencies = [
 [[package]]
 name = "canton-proto-rs"
 version = "3.4.0"
-source = "git+ssh://git@github.com/DLC-link/canton-lib?branch=main#e5b459f62715ee903d9cd8fdd0c4411252356e4e"
+source = "git+ssh://git@github.com/DLC-link/canton-lib?branch=main#305ad23d92a27450df2c99b93d2123ff952d9a47"
 dependencies = [
  "prost",
  "prost-types",
@@ -839,7 +839,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.5.0"
-source = "git+ssh://git@github.com/DLC-link/canton-lib?branch=main#e5b459f62715ee903d9cd8fdd0c4411252356e4e"
+source = "git+ssh://git@github.com/DLC-link/canton-lib?branch=main#305ad23d92a27450df2c99b93d2123ff952d9a47"
 dependencies = [
  "canton-api-client",
  "rust_decimal",
@@ -2186,7 +2186,7 @@ dependencies = [
 [[package]]
 name = "keycloak"
 version = "0.5.0"
-source = "git+ssh://git@github.com/DLC-link/canton-lib?branch=main#e5b459f62715ee903d9cd8fdd0c4411252356e4e"
+source = "git+ssh://git@github.com/DLC-link/canton-lib?branch=main#305ad23d92a27450df2c99b93d2123ff952d9a47"
 dependencies = [
  "base64",
  "reqwest 0.12.28",

--- a/deploy-all.sh
+++ b/deploy-all.sh
@@ -4,7 +4,7 @@ set -e
 
 aws sso login
 
-TAG="0.1.1"
+TAG="0.1.2"
 IMAGE="public.ecr.aws/dlc-link/canton-decparty-manager"
 DEPLOY_DIR="zarf/deployments/devnet"
 

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -160,7 +160,7 @@ impl TokenManager {
     }
 
     async fn authenticate_keycloak(config: &KeycloakConfig) -> Result<TokenState> {
-        let url = keycloak::login::password_url(&config.url, &config.realm);
+        let url = keycloak::login::token_url(&config.url, &config.realm);
 
         // Choose auth method: client_credentials (M2M) if client_secret is set, otherwise password flow
         let (response, is_m2m) = if let Some(ref client_secret) = config.client_secret {
@@ -236,7 +236,7 @@ impl TokenManager {
             return Ok(());
         };
 
-        let url = keycloak::login::password_url(&config.url, &config.realm);
+        let url = keycloak::login::token_url(&config.url, &config.realm);
 
         match keycloak::login::refresh(RefreshParams {
             client_id: config.client_id.clone(),

--- a/src/server/handlers/auth.rs
+++ b/src/server/handlers/auth.rs
@@ -4,7 +4,7 @@ use canton_proto_rs::com::daml::ledger::api::v2::admin::{
     GrantUserRightsRequest, ListUserRightsRequest, Right,
     right::{CanActAs, CanReadAs, Kind},
 };
-use keycloak::login::{ClientCredentialsParams, client_credentials, password_url};
+use keycloak::login::{ClientCredentialsParams, client_credentials, token_url};
 
 use crate::{
     auth::WorkflowAuth,
@@ -407,13 +407,13 @@ pub async fn grant_rights(
     let member_party_id = party_creds.member_party_id.clone();
     let dec_party_id = party_creds.dec_party_id.clone();
     let user_id = party_creds.user_id.clone();
-    let token_url = password_url(&party_creds.keycloak.url, &party_creds.keycloak.realm);
+    let token_endpoint = token_url(&party_creds.keycloak.url, &party_creds.keycloak.realm);
 
     drop(party_creds_list);
     drop(auth);
 
     let admin_token = match client_credentials(ClientCredentialsParams {
-        url: token_url,
+        url: token_endpoint,
         client_id: admin_client_id,
         client_secret: admin_client_secret,
     })
@@ -516,7 +516,7 @@ fn right_read_as(party: &str) -> Right {
 async fn test_keycloak_auth(
     config: &crate::config::KeycloakConfig,
 ) -> std::result::Result<(), String> {
-    let url = keycloak::login::password_url(&config.url, &config.realm);
+    let url = keycloak::login::token_url(&config.url, &config.realm);
 
     // Use client_credentials if client_secret is set, otherwise password flow
     if let Some(ref client_secret) = config.client_secret {

--- a/src/server/handlers/party_config.rs
+++ b/src/server/handlers/party_config.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use actix_web::{HttpRequest, HttpResponse, Responder, get, post, put, web};
 use canton_proto_rs::com::daml::ledger::api::v2::admin::GetUserRequest;
 use keycloak::login::{
-    ClientCredentialsParams, PasswordParams, client_credentials, password, password_url,
+    ClientCredentialsParams, PasswordParams, client_credentials, password, token_url,
 };
 use tokio::sync::RwLock;
 
@@ -453,7 +453,7 @@ pub async fn discover_member_party(
             });
         }
 
-        let token_url = password_url(&body.keycloak_url, &body.keycloak_realm);
+        let token_endpoint = token_url(&body.keycloak_url, &body.keycloak_realm);
 
         let token_result = if let Some(secret) = body
             .keycloak_client_secret
@@ -461,7 +461,7 @@ pub async fn discover_member_party(
             .filter(|s| !s.is_empty())
         {
             client_credentials(ClientCredentialsParams {
-                url: token_url,
+                url: token_endpoint,
                 client_id: body.keycloak_client_id.clone(),
                 client_secret: secret.clone(),
             })
@@ -471,7 +471,7 @@ pub async fn discover_member_party(
             body.keycloak_password.as_ref().filter(|s| !s.is_empty()),
         ) {
             password(PasswordParams {
-                url: token_url,
+                url: token_endpoint,
                 client_id: body.keycloak_client_id.clone(),
                 username: username.clone(),
                 password: pw.clone(),

--- a/zarf/deployments/devnet/participant1/deployment.yaml
+++ b/zarf/deployments/devnet/participant1/deployment.yaml
@@ -44,7 +44,7 @@ spec:
               mountPath: /app
       containers:
         - name: dec-party-manager
-          image: public.ecr.aws/dlc-link/canton-decparty-manager:0.1.1
+          image: public.ecr.aws/dlc-link/canton-decparty-manager:0.1.2
           imagePullPolicy: Always
           command:
             [

--- a/zarf/deployments/devnet/participant2/deployment.yaml
+++ b/zarf/deployments/devnet/participant2/deployment.yaml
@@ -44,7 +44,7 @@ spec:
               mountPath: /app
       containers:
         - name: dec-party-manager
-          image: public.ecr.aws/dlc-link/canton-decparty-manager:0.1.1
+          image: public.ecr.aws/dlc-link/canton-decparty-manager:0.1.2
           imagePullPolicy: Always
           command:
             [

--- a/zarf/deployments/devnet/participant3/deployment.yaml
+++ b/zarf/deployments/devnet/participant3/deployment.yaml
@@ -44,7 +44,7 @@ spec:
               mountPath: /app
       containers:
         - name: dec-party-manager
-          image: public.ecr.aws/dlc-link/canton-decparty-manager:0.1.1
+          image: public.ecr.aws/dlc-link/canton-decparty-manager:0.1.2
           imagePullPolicy: Always
           command:
             [

--- a/zarf/deployments/testnet/deployment.yaml
+++ b/zarf/deployments/testnet/deployment.yaml
@@ -44,7 +44,7 @@ spec:
               mountPath: /app
       containers:
         - name: dec-party-manager
-          image: public.ecr.aws/dlc-link/canton-decparty-manager:0.1.1
+          image: public.ecr.aws/dlc-link/canton-decparty-manager:0.1.2
           imagePullPolicy: Always
           command:
             [


### PR DESCRIPTION
## Summary

- Swapped `keycloak::login::password_url` (legacy `/auth/realms/...` path) for the new `keycloak::login::token_url` (Keycloak 17+ Quarkus `/realms/...` path) in all five call sites: `src/auth/mod.rs:163,239`, `src/server/handlers/auth.rs:410,519`, `src/server/handlers/party_config.rs:456`.
- Pointed the `keycloak` git dep at the canton-lib branch that introduces `token_url` ([DLC-link/canton-lib#19](https://github.com/DLC-link/canton-lib/pull/19)). Once that merges, follow-up to flip it back to `branch = "main"`.
- Bumped deploy image tag from `0.1.1` → `0.1.2` in `deploy-all.sh` and the four zarf deployment manifests.

## Why

Customers running Keycloak 17+ with default config (no `/auth` context root) got `404 {"error":"Unable to find matching target resource method"}` on `discover-member-party`, because the old helper hard-coded the legacy path. The new helper appends `/realms/.../token` to the host supplied by the operator, leaving the path-shape decision up to them — modern KC users pass the bare host, legacy users include `/auth` in the URL.

This also unblocks our own devnet: the env-driven M2M token init was silently failing under the old code because `DECPM_KEYCLOAK_URL` already ends with `/auth`, so the old helper produced `/auth/auth/realms/...` (doubled). Under the new helper that env value resolves correctly.

## Operator follow-up after merge

Any party stored in SQLite with `keycloak_url` lacking `/auth` (where the target KC is a legacy `--http-relative-path=/auth` deployment) needs the URL updated to include `/auth`. Do this through the Party Configuration popup — no DB access required.

## Test plan

- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib` (111 passed)
- [x] Devnet deploy verified: cluster-internal POST to `…/realms/...` returns the expected ingress 404, confirming the new helper is the code path now in flight; POST to `…/auth/realms/...` returns Keycloak's 400 (path is right, just no `grant_type` in the probe), confirming the fix lands once stored URLs include `/auth`.