### PR TITLE
fix(governance): populated AcceptTransfer choice context from registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -338,7 +338,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -670,7 +670,7 @@ dependencies = [
 [[package]]
 name = "canton-proto-rs"
 version = "3.4.0"
-source = "git+ssh://git@github.com/DLC-link/canton-lib?branch=main#305ad23d92a27450df2c99b93d2123ff952d9a47"
+source = "git+ssh://git@github.com/DLC-link/canton-lib?branch=main#e5b459f62715ee903d9cd8fdd0c4411252356e4e"
 dependencies = [
  "prost",
  "prost-types",
@@ -823,7 +823,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -839,7 +839,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.5.0"
-source = "git+ssh://git@github.com/DLC-link/canton-lib?branch=main#305ad23d92a27450df2c99b93d2123ff952d9a47"
+source = "git+ssh://git@github.com/DLC-link/canton-lib?branch=main#e5b459f62715ee903d9cd8fdd0c4411252356e4e"
 dependencies = [
  "canton-api-client",
  "rust_decimal",
@@ -1094,6 +1094,7 @@ dependencies = [
  "prost",
  "prost-types",
  "rand 0.10.1",
+ "registry",
  "reqwest 0.13.3",
  "rust-embed",
  "secp256k1",
@@ -1296,7 +1297,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1882,7 +1883,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2414,7 +2415,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2854,7 +2855,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror",
  "tokio",
  "tracing",
@@ -2892,7 +2893,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -3072,6 +3073,17 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "registry"
+version = "0.5.0"
+source = "git+ssh://git@github.com/DLC-link/canton-lib?branch=main#e5b459f62715ee903d9cd8fdd0c4411252356e4e"
+dependencies = [
+ "common",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "rend"
@@ -3313,7 +3325,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3371,7 +3383,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3774,7 +3786,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4097,7 +4109,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4864,7 +4876,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -338,7 +338,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -670,7 +670,7 @@ dependencies = [
 [[package]]
 name = "canton-proto-rs"
 version = "3.4.0"
-source = "git+ssh://git@github.com/DLC-link/canton-lib?branch=main#e5b459f62715ee903d9cd8fdd0c4411252356e4e"
+source = "git+ssh://git@github.com/DLC-link/canton-lib?branch=main#305ad23d92a27450df2c99b93d2123ff952d9a47"
 dependencies = [
  "prost",
  "prost-types",
@@ -823,7 +823,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -839,7 +839,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.5.0"
-source = "git+ssh://git@github.com/DLC-link/canton-lib?branch=main#e5b459f62715ee903d9cd8fdd0c4411252356e4e"
+source = "git+ssh://git@github.com/DLC-link/canton-lib?branch=main#305ad23d92a27450df2c99b93d2123ff952d9a47"
 dependencies = [
  "canton-api-client",
  "rust_decimal",
@@ -1297,7 +1297,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1883,7 +1883,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2415,7 +2415,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2855,7 +2855,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror",
  "tokio",
  "tracing",
@@ -2893,7 +2893,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -3077,7 +3077,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 [[package]]
 name = "registry"
 version = "0.5.0"
-source = "git+ssh://git@github.com/DLC-link/canton-lib?branch=main#e5b459f62715ee903d9cd8fdd0c4411252356e4e"
+source = "git+ssh://git@github.com/DLC-link/canton-lib?branch=main#305ad23d92a27450df2c99b93d2123ff952d9a47"
 dependencies = [
  "common",
  "reqwest 0.12.28",
@@ -3325,7 +3325,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3383,7 +3383,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3786,7 +3786,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4109,7 +4109,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4876,7 +4876,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ zeroize = { version = "1.8", features = ["derive"] }
 
 canton-common = { package = "common", git = "ssh://git@github.com/DLC-link/canton-lib", branch = "main" }
 canton-proto-rs = { git = "ssh://git@github.com/DLC-link/canton-lib", branch = "main" }
+canton-registry = { package = "registry", git = "ssh://git@github.com/DLC-link/canton-lib", branch = "main" }
 keycloak = { git = "ssh://git@github.com/DLC-link/canton-lib", branch = "main" }
 
 [dev-dependencies]

--- a/deploy-all.sh
+++ b/deploy-all.sh
@@ -4,7 +4,7 @@ set -e
 
 aws sso login
 
-TAG="0.1.2"
+TAG="0.1.3"
 IMAGE="public.ecr.aws/dlc-link/canton-decparty-manager"
 DEPLOY_DIR="zarf/deployments/devnet"
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -130,6 +130,12 @@ const App = () => {
     [],
   );
 
+  // Jump to the notifications tab after a successful workflow / governance
+  // action so the user lands on the queue showing what they just produced.
+  const goToNotifications = useCallback(() => {
+    navigate(TAB_HASHES.indexOf("notifications"));
+  }, [navigate]);
+
   // Once parties are loaded, resolve pending slug → exact match opens detail
   useEffect(() => {
     if (loading || !pendingSlug.current) return;
@@ -737,6 +743,7 @@ const App = () => {
               onComplete={() => {
                 refreshParties(true);
                 setPackagesRefreshNonce((n) => n + 1);
+                goToNotifications();
               }}
               mode="distribute"
             />
@@ -754,7 +761,10 @@ const App = () => {
             <OnboardingDialog
               open={onboardingDialogOpen}
               onClose={() => setOnboardingDialogOpen(false)}
-              onComplete={() => refreshParties(true)}
+              onComplete={() => {
+                refreshParties(true);
+                goToNotifications();
+              }}
             />
 
           </>
@@ -773,6 +783,7 @@ const App = () => {
                 window.scrollTo(0, savedScrollY.current);
               }}
               onRefresh={() => refreshParties(true)}
+              onNavigateToNotifications={goToNotifications}
               selfParticipantId={nodeConfig?.node.participant_id}
               authStatus={authStatuses.find(
                 (a) => a.dec_party_id === selectedPartyId,

--- a/frontend/src/components/GovernanceActionsDialog.tsx
+++ b/frontend/src/components/GovernanceActionsDialog.tsx
@@ -52,6 +52,7 @@ export const GovernanceActionsDialog = ({
             network={network}
             governanceType={governanceType}
             onAfterAction={onAfterAction}
+            onProposalCreated={onClose}
             view={view}
           />
         </Box>

--- a/frontend/src/components/GovernanceSection.tsx
+++ b/frontend/src/components/GovernanceSection.tsx
@@ -87,6 +87,10 @@ interface GovernanceSectionProps {
   /// execute / revoke / expire / domain confirm / domain execute) so the
   /// parent can refresh sibling views (e.g. the audit trail tab).
   onAfterAction?: () => void;
+  /// Called after a domain proposal is successfully created. The hosting
+  /// dialog wires this to its `onClose` so the modal disappears on success;
+  /// fires after `onAfterAction` so refreshes still run.
+  onProposalCreated?: () => void;
   /// Which half of the section to render:
   /// - "actions"   = governance-action confirmations + new-action form (default)
   /// - "proposals" = domain-proposal list + new-proposal form (core_self only)
@@ -121,6 +125,7 @@ export const GovernanceSection = ({
   network,
   governanceType = "vault",
   onAfterAction,
+  onProposalCreated,
   view,
 }: GovernanceSectionProps) => {
   const showActionsHalf = view !== "proposals";
@@ -1187,11 +1192,13 @@ export const GovernanceSection = ({
         throw new Error(errData.error || "Failed to create proposal");
       }
 
-      // Clear fields, keep the form visible. The created proposal shows up
-      // in the notification queue — no separate success message needed.
+      // Clear fields and let the host close the dialog. The created proposal
+      // shows up in the notification queue — no separate success message
+      // needed.
       resetProposalForm();
       await fetchGovernance();
       onAfterAction?.();
+      onProposalCreated?.();
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to create proposal");
     } finally {

--- a/frontend/src/components/GovernanceSection.tsx
+++ b/frontend/src/components/GovernanceSection.tsx
@@ -69,6 +69,8 @@ import type {
   InstrumentAllowance,
   InstrumentInfo,
   InstrumentsResponse,
+  TransferInstructionInfo,
+  TransferInstructionsResponse,
   TransferPreapprovalsResponse,
 } from "../types";
 
@@ -272,6 +274,12 @@ export const GovernanceSection = ({
   // dropdown without the frontend having to decode contract blobs.
   const [availableInstruments, setAvailableInstruments] = useState<InstrumentInfo[]>([]);
   const [instrumentsLoading, setInstrumentsLoading] = useState(false);
+  // Open TransferInstruction contracts addressed to this dec-party. Powers the
+  // Accept Transfer proposal dropdown.
+  const [openTransferInstructions, setOpenTransferInstructions] = useState<
+    TransferInstructionInfo[]
+  >([]);
+  const [transferInstructionsLoading, setTransferInstructionsLoading] = useState(false);
   // Counts of active TransferPreapproval contracts the gov party already has
   // (CC + Token). Used to warn before issuing a Setup*Preapproval proposal
   // that would be a no-op when executed.
@@ -465,6 +473,32 @@ export const GovernanceSection = ({
       fetchInstruments();
     }
   }, [proposalType, fetchInstruments]);
+
+  // Fetch open `TransferInstruction` contracts for the Accept Transfer
+  // proposal dropdown so operators can pick a transfer offer instead of
+  // pasting a contract id.
+  const fetchOpenTransferInstructions = useCallback(async () => {
+    setTransferInstructionsLoading(true);
+    try {
+      const res = await authenticatedFetch(
+        `${API_BASE}/governance/transfer-instructions?party_id=${encodeURIComponent(partyId)}`,
+      );
+      if (res.ok) {
+        const response: TransferInstructionsResponse = await res.json();
+        setOpenTransferInstructions(response.transfer_instructions);
+      }
+    } catch (e) {
+      console.error("Failed to fetch transfer instructions:", e);
+    } finally {
+      setTransferInstructionsLoading(false);
+    }
+  }, [partyId]);
+
+  useEffect(() => {
+    if (proposalType === "accept_transfer") {
+      fetchOpenTransferInstructions();
+    }
+  }, [proposalType, fetchOpenTransferInstructions]);
 
   // Mint/Burn always use the decparty as the instrument admin — seed the field
   // unconditionally so it's populated even before (or without) an Instrument
@@ -2809,7 +2843,58 @@ export const GovernanceSection = ({
               )}
 
               {proposalType === "accept_transfer" && (
-                <TextField size="small" label="TransferInstruction Contract ID" value={proposalTransferInstructionCid} onChange={(e) => setProposalTransferInstructionCid(e.target.value)} fullWidth required />
+                <Autocomplete
+                  size="small"
+                  freeSolo
+                  options={openTransferInstructions}
+                  value={proposalTransferInstructionCid}
+                  loading={transferInstructionsLoading}
+                  onChange={(_event, value) => {
+                    if (typeof value === "string" || value === null) {
+                      setProposalTransferInstructionCid(value ?? "");
+                    } else {
+                      setProposalTransferInstructionCid(value.contract_id);
+                    }
+                  }}
+                  onInputChange={(_event, value, reason) => {
+                    // Keep the field in sync when the user types a cid by
+                    // hand (freeSolo fallback). `reset` fires when an option
+                    // is selected; we already handled that via `onChange`.
+                    if (reason === "input") {
+                      setProposalTransferInstructionCid(value);
+                    }
+                  }}
+                  getOptionLabel={(option) => {
+                    if (typeof option === "string") return option;
+                    // Strip the `::1220…` fingerprint suffix from the party
+                    // id so the label fits in the dropdown; show a short cid
+                    // tail for disambiguation when multiple transfers share
+                    // a sender/amount.
+                    const senderName = option.sender.split("::")[0];
+                    const amount = option.amount.replace(/\.?0+$/, "");
+                    const cidTail = option.contract_id.slice(-8);
+                    return `${senderName} → ${amount} ${option.instrument_id} (…${cidTail})`;
+                  }}
+                  isOptionEqualToValue={(option, value) =>
+                    typeof value === "string"
+                      ? option.contract_id === value
+                      : option.contract_id === value.contract_id
+                  }
+                  renderInput={(params) => (
+                    <TextField
+                      {...params}
+                      label="TransferInstruction Contract ID"
+                      required
+                      helperText={
+                        transferInstructionsLoading
+                          ? "Loading open transfers…"
+                          : openTransferInstructions.length === 0
+                            ? "No open transfers visible — paste a contract id directly if you have one"
+                            : "Pick an open transfer, or paste a contract id"
+                      }
+                    />
+                  )}
+                />
               )}
 
               {proposalType === "provision_provider_service" && (

--- a/frontend/src/components/PartyDetail.tsx
+++ b/frontend/src/components/PartyDetail.tsx
@@ -80,6 +80,11 @@ interface PartyDetailProps {
   party: DecentralizedParty;
   onBack: () => void;
   onRefresh: () => void;
+  /// Switch the app to the notifications tab. Called after the kick /
+  /// contract-deployment workflows complete and after a governance action or
+  /// proposal is submitted, so the user lands on the queue showing the
+  /// resulting entry.
+  onNavigateToNotifications: () => void;
   selfParticipantId?: string;
   authStatus?: PartyAuthStatus;
   onAuthRefresh?: () => void;
@@ -91,6 +96,7 @@ export const PartyDetail = ({
   party,
   onBack,
   onRefresh,
+  onNavigateToNotifications,
   selfParticipantId,
   authStatus,
   onAuthRefresh,
@@ -509,7 +515,10 @@ export const PartyDetail = ({
       <KickDialog
         open={kickDialogOpen}
         onClose={() => setKickDialogOpen(false)}
-        onKickComplete={onRefresh}
+        onKickComplete={() => {
+          onRefresh();
+          onNavigateToNotifications();
+        }}
         partyId={party.party_id}
         participantUid={selectedParticipant}
         participantOwnerKey={
@@ -524,7 +533,10 @@ export const PartyDetail = ({
       <ContractsDialog
         open={contractsDialogOpen}
         onClose={() => setContractsDialogOpen(false)}
-        onComplete={onRefresh}
+        onComplete={() => {
+          onRefresh();
+          onNavigateToNotifications();
+        }}
         partyId={party.party_id}
         participantIds={party.participants.map((p) => p.participant_uid)}
         defaultOperatorParty={operatorParty}
@@ -553,7 +565,10 @@ export const PartyDetail = ({
           defaultOperatorParty={operatorParty}
           network={network}
           governanceType={governanceTypeFor(editingContract.template_id)}
-          onAfterAction={() => setGovernanceRefreshNonce((n) => n + 1)}
+          onAfterAction={() => {
+            setGovernanceRefreshNonce((n) => n + 1);
+            onNavigateToNotifications();
+          }}
           view={govDialogView}
         />
       )}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -773,6 +773,21 @@ export interface InstrumentsResponse {
   instruments: InstrumentInfo[];
 }
 
+/** An open `TransferInstruction` awaiting receiver acceptance, surfaced for
+ *  the Accept Transfer proposal dropdown. */
+export interface TransferInstructionInfo {
+  contract_id: string;
+  sender: string;
+  receiver: string;
+  amount: string;
+  instrument_admin: string;
+  instrument_id: string;
+}
+
+export interface TransferInstructionsResponse {
+  transfer_instructions: TransferInstructionInfo[];
+}
+
 /** Count of active TransferPreapproval contracts the gov party already has,
  *  split by direction (CC = Canton Coin via Splice; token = via Utility). */
 export interface TransferPreapprovalsResponse {

--- a/src/config.rs
+++ b/src/config.rs
@@ -466,6 +466,22 @@ mod tests {
     }
 
     #[test]
+    fn test_registry_url_per_network() {
+        assert_eq!(
+            Network::Devnet.registry_url(),
+            "https://api.utilities.digitalasset-dev.com",
+        );
+        assert_eq!(
+            Network::Testnet.registry_url(),
+            "https://api.utilities.digitalasset-staging.com",
+        );
+        assert_eq!(
+            Network::Mainnet.registry_url(),
+            "https://api.utilities.digitalasset.com",
+        );
+    }
+
+    #[test]
     fn test_keycloak_defaults_devnet() {
         let defaults = Network::Devnet.keycloak_defaults();
         assert_eq!(defaults.url, "https://keycloak.dev.canton.ibtc.network");

--- a/src/config.rs
+++ b/src/config.rs
@@ -264,7 +264,7 @@ pub struct KeycloakDefaults {
 }
 
 /// Canton Network environment
-#[derive(Clone, Debug, Deserialize, Serialize, utoipa::ToSchema, clap::ValueEnum)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, utoipa::ToSchema, clap::ValueEnum)]
 #[serde(rename_all = "lowercase")]
 pub enum Network {
     Devnet,
@@ -292,6 +292,19 @@ impl Network {
                 "https://api.utilities.digitalasset-staging.com/api/utilities/v0/operator"
             }
             Network::Mainnet => "https://api.utilities.digitalasset.com/api/utilities/v0/operator",
+        }
+    }
+
+    /// Get the DA token-standard registry base URL for this network.
+    ///
+    /// Used to fetch choice contexts and disclosed contracts for token-standard
+    /// transfer flows (e.g. `AcceptTransfer` requires the `transfer-rule`
+    /// context entry, which the registry resolves per `TransferInstruction`).
+    pub fn registry_url(&self) -> &str {
+        match self {
+            Network::Devnet => "https://api.utilities.digitalasset-dev.com",
+            Network::Testnet => "https://api.utilities.digitalasset-staging.com",
+            Network::Mainnet => "https://api.utilities.digitalasset.com",
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,7 +112,7 @@ async fn main() -> Result {
                 config.canton.synchronizer = sync.clone();
             }
             if let Some(net) = canton_network {
-                config.canton.network = net.clone();
+                config.canton.network = *net;
             }
             if keycloak_url.is_some() || keycloak_realm.is_some() || keycloak_client_id.is_some() {
                 let kc = config.keycloak.get_or_insert(KeycloakConfig {

--- a/src/server/action_serializer.rs
+++ b/src/server/action_serializer.rs
@@ -4,9 +4,12 @@
 //! and DAML `Value` representations for use with the Ledger API.
 
 use anyhow::Context;
-use canton_common::decimal::DamlDecimal;
+use canton_common::{
+    decimal::DamlDecimal,
+    transfer_factory::{Context as ChoiceContext, ContextValue},
+};
 use canton_proto_rs::com::daml::ledger::api::v2::{
-    List, Optional, Record, RecordField, Value, Variant, value,
+    List, Optional, Record, RecordField, TextMap, Value, Variant, text_map, value,
 };
 
 use crate::{error::Result, participant_id::CantonId};
@@ -89,10 +92,20 @@ fn make_list(values: Vec<Value>) -> Value {
 }
 
 fn make_empty_text_map() -> Value {
+    make_text_map(vec![])
+}
+
+fn make_text_map(entries: Vec<(String, Value)>) -> Value {
     Value {
-        sum: Some(value::Sum::TextMap(
-            canton_proto_rs::com::daml::ledger::api::v2::TextMap { entries: vec![] },
-        )),
+        sum: Some(value::Sum::TextMap(TextMap {
+            entries: entries
+                .into_iter()
+                .map(|(k, v)| text_map::Entry {
+                    key: k,
+                    value: Some(v),
+                })
+                .collect(),
+        })),
     }
 }
 
@@ -105,13 +118,62 @@ fn make_empty_metadata() -> Value {
 }
 
 fn make_empty_extra_args() -> Value {
+    make_extra_args(make_empty_text_map())
+}
+
+fn make_extra_args(context_values: Value) -> Value {
     make_record(vec![
         field(
             "context",
-            make_record(vec![field("values", make_empty_text_map())]),
+            make_record(vec![field("values", context_values)]),
         ),
         field("meta", make_empty_metadata()),
     ])
+}
+
+/// Serialize a `Splice.Api.Token.MetadataV1.AnyValue` constructor as a Daml
+/// `Variant` Value suitable for the Ledger API.
+fn make_any_value(v: &ContextValue) -> Result<Value> {
+    let (ctor, inner) = match v {
+        ContextValue::Text(s) => ("AV_Text", make_text(s)),
+        ContextValue::Int(n) => ("AV_Int", make_int64(*n)),
+        ContextValue::Decimal(d) => ("AV_Decimal", make_numeric(&d.to_string())),
+        ContextValue::Bool(b) => ("AV_Bool", make_bool(*b)),
+        ContextValue::Party(p) => ("AV_Party", make_party(p)),
+        ContextValue::ContractId(cid) => ("AV_ContractId", make_contract_id(cid)),
+        ContextValue::List(items) => {
+            let elements: Result<Vec<Value>> = items.iter().map(make_any_value).collect();
+            ("AV_List", make_list(elements?))
+        }
+        ContextValue::Map(m) => {
+            let mut entries: Vec<(String, Value)> = m
+                .iter()
+                .map(|(k, v)| make_any_value(v).map(|av| (k.clone(), av)))
+                .collect::<Result<_>>()?;
+            // Stable order so wire bytes are deterministic.
+            entries.sort_by(|a, b| a.0.cmp(&b.0));
+            ("AV_Map", make_text_map(entries))
+        }
+        ContextValue::Date(_) | ContextValue::Time(_) | ContextValue::RelTime(_) => {
+            anyhow::bail!(
+                "AnyValue::{v:?} not supported in choice context: only Text/Int/Decimal/Bool/\
+                 Party/ContractId/List/Map are translated to the Ledger API today",
+            );
+        }
+    };
+    Ok(make_variant(ctor, inner))
+}
+
+/// Build the `extraArgs` record with the choice-context values populated from
+/// a registry response (e.g. `registry::accept_context::get`).
+fn make_extra_args_from_context(ctx: &ChoiceContext) -> Result<Value> {
+    let mut entries: Vec<(String, Value)> = ctx
+        .values
+        .iter()
+        .map(|(k, v)| make_any_value(v).map(|av| (k.clone(), av)))
+        .collect::<Result<_>>()?;
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+    Ok(make_extra_args(make_text_map(entries)))
 }
 
 // ============================================================================
@@ -791,8 +853,9 @@ pub fn build_proposal_create_args(
     governance_party: &str,
     proposer: &str,
     proposal: &ProposalType,
-) -> (ProposalPackage, &'static str, &'static str, Record) {
-    match proposal {
+    accept_transfer_context: Option<&ChoiceContext>,
+) -> Result<(ProposalPackage, &'static str, &'static str, Record)> {
+    Ok(match proposal {
         ProposalType::SetupCcPreapproval {
             provider,
             expected_dso,
@@ -900,23 +963,38 @@ pub fn build_proposal_create_args(
         }
         ProposalType::AcceptTransfer {
             transfer_instruction_cid,
-        } => (
-            ProposalPackage::GovernanceTokenCustody,
-            "Governance.TokenCustody.AcceptTransfer",
-            "AcceptTransferProposal",
-            Record {
-                record_id: None,
-                fields: vec![
-                    field("governanceParty", make_party(governance_party)),
-                    field("proposer", make_party(proposer)),
-                    field(
-                        "transferInstructionCid",
-                        make_contract_id(transfer_instruction_cid),
-                    ),
-                    field("extraArgs", make_empty_extra_args()),
-                ],
-            },
-        ),
+        } => {
+            // The Daml `TransferInstruction_Accept` choice (invoked through
+            // `AcceptTransferProposal`) looks up
+            // `utility.digitalasset.com/transfer-rule` (and friends) in
+            // `extraArgs.context.values` at execution time. An empty context
+            // would fail with `Missing context entry for
+            // utility.digitalasset.com/transfer-rule`. The handler is
+            // expected to fetch the choice context from the token-standard
+            // registry and pass it in; if it didn't, fall back to an empty
+            // record (legacy callers, e.g. tests).
+            let extra_args = match accept_transfer_context {
+                Some(ctx) => make_extra_args_from_context(ctx)?,
+                None => make_empty_extra_args(),
+            };
+            (
+                ProposalPackage::GovernanceTokenCustody,
+                "Governance.TokenCustody.AcceptTransfer",
+                "AcceptTransferProposal",
+                Record {
+                    record_id: None,
+                    fields: vec![
+                        field("governanceParty", make_party(governance_party)),
+                        field("proposer", make_party(proposer)),
+                        field(
+                            "transferInstructionCid",
+                            make_contract_id(transfer_instruction_cid),
+                        ),
+                        field("extraArgs", extra_args),
+                    ],
+                },
+            )
+        }
         ProposalType::GenericVote { description } => (
             ProposalPackage::GovernanceCore,
             "Governance.GenericVote",
@@ -1267,7 +1345,7 @@ pub fn build_proposal_create_args(
                 ],
             },
         ),
-    }
+    })
 }
 
 /// Build the GovernanceRules_ConfirmAction choice argument for domain actions

--- a/src/server/action_serializer.rs
+++ b/src/server/action_serializer.rs
@@ -156,8 +156,8 @@ fn make_any_value(v: &ContextValue) -> Result<Value> {
         }
         ContextValue::Date(_) | ContextValue::Time(_) | ContextValue::RelTime(_) => {
             anyhow::bail!(
-                "AnyValue::{v:?} not supported in choice context: only Text/Int/Decimal/Bool/\
-                 Party/ContractId/List/Map are translated to the Ledger API today",
+                "ContextValue::{v:?} not supported in choice context: only Text, Int, Decimal, \
+                 Bool, Party, ContractId, List, and Map are translated to the Ledger API today",
             );
         }
     };

--- a/src/server/action_serializer.rs
+++ b/src/server/action_serializer.rs
@@ -1818,3 +1818,93 @@ pub fn deserialize_action(value: &Value) -> Result<ActionType> {
         other => anyhow::bail!("Unknown action constructor: {other}"),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    // Locks the AV_* constructor strings against the on-ledger
+    // `Splice.Api.Token.MetadataV1.AnyValue` definition. A typo here would
+    // surface as a runtime interpretation error far from the source, so the
+    // mapping for every supported `ContextValue` variant is asserted explicitly.
+    #[test]
+    fn make_any_value_maps_each_variant_to_expected_ctor() {
+        let cases: Vec<(ContextValue, &str)> = vec![
+            (ContextValue::Text("hi".to_string()), "AV_Text"),
+            (ContextValue::Int(42), "AV_Int"),
+            (
+                ContextValue::Decimal(DamlDecimal::parse("1.5").unwrap()),
+                "AV_Decimal",
+            ),
+            (ContextValue::Bool(true), "AV_Bool"),
+            (ContextValue::Party("alice::pid".to_string()), "AV_Party"),
+            (
+                ContextValue::ContractId("cid-1".to_string()),
+                "AV_ContractId",
+            ),
+            (
+                ContextValue::List(vec![ContextValue::Int(1)]),
+                "AV_List",
+            ),
+            (
+                ContextValue::Map(HashMap::from([(
+                    "k".to_string(),
+                    ContextValue::Text("v".to_string()),
+                )])),
+                "AV_Map",
+            ),
+        ];
+
+        for (input, expected_ctor) in cases {
+            let value = make_any_value(&input).expect("make_any_value succeeded");
+            match value.sum {
+                Some(value::Sum::Variant(v)) => assert_eq!(
+                    v.constructor, expected_ctor,
+                    "wrong constructor for {input:?}",
+                ),
+                other => panic!("expected Variant for {input:?}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn make_any_value_recurses_into_nested_map() {
+        let nested = ContextValue::Map(HashMap::from([
+            ("text".to_string(), ContextValue::Text("hi".to_string())),
+            (
+                "cid".to_string(),
+                ContextValue::ContractId("cid-1".to_string()),
+            ),
+            (
+                "nested".to_string(),
+                ContextValue::Map(HashMap::from([(
+                    "n".to_string(),
+                    ContextValue::Int(7),
+                )])),
+            ),
+        ]));
+
+        let value = make_any_value(&nested).expect("nested map serializes");
+        let Some(value::Sum::Variant(v)) = value.sum else {
+            panic!("expected Variant");
+        };
+        assert_eq!(v.constructor, "AV_Map");
+    }
+
+    #[test]
+    fn make_any_value_rejects_unsupported_time_variants() {
+        for unsupported in [
+            ContextValue::Date("2026-05-19".to_string()),
+            ContextValue::Time("2026-05-19T00:00:00Z".to_string()),
+            ContextValue::RelTime("PT1H".to_string()),
+        ] {
+            let err = make_any_value(&unsupported).expect_err("must reject");
+            assert!(
+                err.to_string().contains("ContextValue::"),
+                "error should reference the Rust type, got: {err}",
+            );
+        }
+    }
+}

--- a/src/server/action_serializer.rs
+++ b/src/server/action_serializer.rs
@@ -1844,10 +1844,7 @@ mod tests {
                 ContextValue::ContractId("cid-1".to_string()),
                 "AV_ContractId",
             ),
-            (
-                ContextValue::List(vec![ContextValue::Int(1)]),
-                "AV_List",
-            ),
+            (ContextValue::List(vec![ContextValue::Int(1)]), "AV_List"),
             (
                 ContextValue::Map(HashMap::from([(
                     "k".to_string(),
@@ -1879,10 +1876,7 @@ mod tests {
             ),
             (
                 "nested".to_string(),
-                ContextValue::Map(HashMap::from([(
-                    "n".to_string(),
-                    ContextValue::Int(7),
-                )])),
+                ContextValue::Map(HashMap::from([("n".to_string(), ContextValue::Int(7))])),
             ),
         ]));
 

--- a/src/server/handlers/governance.rs
+++ b/src/server/handlers/governance.rs
@@ -1891,9 +1891,16 @@ async fn execute_confirmed_action(
         )
         .await
         {
-            Ok(Some(ctx)) => {
-                registry_disclosed = to_proto_disclosed_contracts(&ctx.disclosed_contracts)?;
-            }
+            Ok(Some(ctx)) => match to_proto_disclosed_contracts(&ctx.disclosed_contracts) {
+                Ok(dcs) => registry_disclosed = dcs,
+                Err(e) => {
+                    // A malformed blob from the registry shouldn't 500 the
+                    // execute call — mirror the non-fatal handling below.
+                    tracing::warn!(
+                        "Failed to decode registry disclosed contracts for proposal {proposal_cid}: {e:#}"
+                    );
+                }
+            },
             Ok(None) => {}
             Err(e) => {
                 // Don't hard-fail on registry hiccups for non-transfer

--- a/src/server/handlers/governance.rs
+++ b/src/server/handlers/governance.rs
@@ -31,8 +31,9 @@ use crate::{
         middleware::require_admin,
         queries::{
             ContractQueryParams as QueryContractParams, get_governance_confirmations,
-            get_governance_state as query_governance_state, get_instruments, get_provider_services,
-            get_registrar_services, get_user_services, get_vaults, query_contracts_by_template,
+            get_governance_state as query_governance_state, get_instruments,
+            get_open_transfer_instructions, get_provider_services, get_registrar_services,
+            get_user_services, get_vaults, query_contracts_by_template,
         },
         transfer_context::{
             fetch as fetch_accept_transfer_context, maybe_fetch_for_proposal,
@@ -45,8 +46,8 @@ use crate::{
             GovernanceResponse, GovernanceStateResponse, GovernanceType, InstrumentsResponse,
             KnownMember, KnownMembersResponse, MessageResponse, NetworkInfo, OperatorInfo,
             ProposalType, ProposeActionRequest, ProviderServicesResponse,
-            RegistrarServicesResponse, TransferPreapprovalsResponse, UserServicesResponse,
-            VaultsResponse,
+            RegistrarServicesResponse, TransferInstructionsResponse, TransferPreapprovalsResponse,
+            UserServicesResponse, VaultsResponse,
         },
     },
     utils,
@@ -410,6 +411,44 @@ pub async fn get_registrar_services_handler(
             tracing::error!("Failed to fetch registrar services: {e}");
             HttpResponse::InternalServerError().json(ErrorResponse {
                 error: format!("Failed to fetch registrar services: {e}"),
+            })
+        }
+    }
+}
+
+/// List open `TransferInstruction` contracts (status
+/// `TransferPendingReceiverAcceptance`) addressed to this dec-party. Used by
+/// the Accept Transfer proposal form to populate a dropdown of acceptable
+/// transfers — operators pick from this list instead of pasting the contract
+/// id.
+#[utoipa::path(
+    tag = "Services",
+    params(GovernanceQuery),
+    responses(
+        (
+            status = 200,
+            description = "Open transfer instructions",
+            body = TransferInstructionsResponse,
+        ),
+        (status = 500, description = "Internal server error", body = ErrorResponse),
+    )
+)]
+#[get("/governance/transfer-instructions")]
+pub async fn get_transfer_instructions_handler(
+    data: web::Data<AppState>,
+    query: web::Query<GovernanceQuery>,
+) -> impl Responder {
+    let party_id = &query.party_id;
+    let token = get_party_token(&data, party_id).await;
+
+    match get_open_transfer_instructions(&data.config, party_id, token).await {
+        Ok(transfer_instructions) => HttpResponse::Ok().json(TransferInstructionsResponse {
+            transfer_instructions,
+        }),
+        Err(e) => {
+            tracing::error!("Failed to fetch transfer instructions: {e}");
+            HttpResponse::InternalServerError().json(ErrorResponse {
+                error: format!("Failed to fetch transfer instructions: {e}"),
             })
         }
     }

--- a/src/server/handlers/governance.rs
+++ b/src/server/handlers/governance.rs
@@ -1877,12 +1877,12 @@ async fn execute_confirmed_action(
 
     // For `AcceptTransferProposal` execution the executor's submission must
     // include the registry-supplied disclosed contracts (transfer rule + its
-    // dependencies). Detect that by template id of the on-chain proposal and
-    // fetch the choice context now. Other proposal types pass through.
+    // dependencies). `maybe_fetch_for_proposal` template-id-checks the
+    // on-chain proposal and returns `Ok(None)` for anything else, so we don't
+    // gate on `governance_type` here — that would silently drop the fetch on
+    // any non-CoreDomain path that happens to carry an AcceptTransferProposal.
     let mut registry_disclosed: Vec<DisclosedContract> = Vec::new();
-    if matches!(request.governance_type, GovernanceType::CoreDomain)
-        && let Some(proposal_cid) = request.proposal_cid.as_deref()
-    {
+    if let Some(proposal_cid) = request.proposal_cid.as_deref() {
         match maybe_fetch_for_proposal(
             config,
             Some(token.to_string()),

--- a/src/server/handlers/governance.rs
+++ b/src/server/handlers/governance.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use actix_web::{HttpRequest, HttpResponse, Responder, get, post, web};
 use anyhow::Context;
 use base64::Engine;
@@ -32,14 +34,19 @@ use crate::{
             get_governance_state as query_governance_state, get_instruments, get_provider_services,
             get_registrar_services, get_user_services, get_vaults, query_contracts_by_template,
         },
+        transfer_context::{
+            fetch as fetch_accept_transfer_context, maybe_fetch_for_proposal,
+            to_proto_disclosed_contracts,
+        },
         types::{
             AuditLogEntry, AuditLogQuery, AuditLogResponse, CancelConfirmationRequest,
             ChainAuditEntry, ChainAuditQuery, ChainAuditResponse, ConfirmActionRequest,
             ContractQueryResponse, ErrorResponse, ExecuteActionRequest, ExpireConfirmationRequest,
             GovernanceResponse, GovernanceStateResponse, GovernanceType, InstrumentsResponse,
             KnownMember, KnownMembersResponse, MessageResponse, NetworkInfo, OperatorInfo,
-            ProposeActionRequest, ProviderServicesResponse, RegistrarServicesResponse,
-            TransferPreapprovalsResponse, UserServicesResponse, VaultsResponse,
+            ProposalType, ProposeActionRequest, ProviderServicesResponse,
+            RegistrarServicesResponse, TransferPreapprovalsResponse, UserServicesResponse,
+            VaultsResponse,
         },
     },
     utils,
@@ -768,12 +775,48 @@ pub async fn propose_action(
 
     let packages = packages();
 
+    // For `AcceptTransfer`, the underlying `TransferInstruction_Accept` choice
+    // requires the token-standard `transfer-rule` choice-context entry. Fetch
+    // the context from the registry now so the on-chain proposal carries the
+    // right `extraArgs.context.values`; without it, execute time fails with
+    // `Missing context entry for utility.digitalasset.com/transfer-rule`.
+    let accept_transfer_context = match &body.proposal {
+        ProposalType::AcceptTransfer {
+            transfer_instruction_cid,
+        } => match fetch_accept_transfer_context(
+            data.config.canton.network,
+            &party_id.to_string(),
+            transfer_instruction_cid,
+        )
+        .await
+        {
+            Ok(ctx) => Some(ctx),
+            Err(e) => {
+                tracing::warn!(
+                    "Failed to fetch AcceptTransfer choice context from registry: {e:#}"
+                );
+                return HttpResponse::BadGateway().json(ErrorResponse {
+                    error: format!("Failed to fetch transfer choice context: {e}"),
+                });
+            }
+        },
+        _ => None,
+    };
+
     let (package_source, module_name, entity_name, create_args) =
-        action_serializer::build_proposal_create_args(
+        match action_serializer::build_proposal_create_args(
             &party_id.to_string(),
             &member_party_id.to_string(),
             &body.proposal,
-        );
+            accept_transfer_context.as_ref().map(|r| &r.context),
+        ) {
+            Ok(args) => args,
+            Err(e) => {
+                return HttpResponse::BadRequest().json(ErrorResponse {
+                    error: format!("Failed to build proposal create arguments: {e}"),
+                });
+            }
+        };
 
     let package_id = match package_source {
         action_serializer::ProposalPackage::GovernanceCore => {
@@ -1793,6 +1836,37 @@ async fn execute_confirmed_action(
         }
     };
 
+    // For `AcceptTransferProposal` execution the executor's submission must
+    // include the registry-supplied disclosed contracts (transfer rule + its
+    // dependencies). Detect that by template id of the on-chain proposal and
+    // fetch the choice context now. Other proposal types pass through.
+    let mut registry_disclosed: Vec<DisclosedContract> = Vec::new();
+    if matches!(request.governance_type, GovernanceType::CoreDomain)
+        && let Some(proposal_cid) = request.proposal_cid.as_deref()
+    {
+        match maybe_fetch_for_proposal(
+            config,
+            Some(token.to_string()),
+            &request.party_id,
+            proposal_cid,
+        )
+        .await
+        {
+            Ok(Some(ctx)) => {
+                registry_disclosed = to_proto_disclosed_contracts(&ctx.disclosed_contracts)?;
+            }
+            Ok(None) => {}
+            Err(e) => {
+                // Don't hard-fail on registry hiccups for non-transfer
+                // proposals; for transfer proposals the Daml choice will
+                // surface a clear `Missing context entry` error.
+                tracing::warn!(
+                    "Failed to fetch transfer choice context for proposal {proposal_cid}: {e:#}"
+                );
+            }
+        }
+    }
+
     let channel = tonic::transport::Channel::from_shared(config.ledger_api_url())?
         .connect()
         .await?;
@@ -1809,6 +1883,32 @@ async fn execute_confirmed_action(
         })),
     };
 
+    let mut disclosed_contracts: Vec<DisclosedContract> = request
+        .disclosed_contracts
+        .iter()
+        .map(|dc| {
+            Ok(DisclosedContract {
+                template_id: None,
+                contract_id: dc.contract_id.clone(),
+                created_event_blob: base64::engine::general_purpose::STANDARD
+                    .decode(&dc.blob)
+                    .context("Invalid base64 in disclosed contract blob")?,
+                synchronizer_id: String::new(),
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    // De-dup by contract id — the FE may forward something the registry also
+    // returned; keep the first occurrence (FE-supplied).
+    let seen: HashSet<String> = disclosed_contracts
+        .iter()
+        .map(|d| d.contract_id.clone())
+        .collect();
+    disclosed_contracts.extend(
+        registry_disclosed
+            .into_iter()
+            .filter(|d| !seen.contains(&d.contract_id)),
+    );
+
     let commands = Commands {
         workflow_id: String::new(),
         user_id: String::new(),
@@ -1820,20 +1920,7 @@ async fn execute_confirmed_action(
         act_as: vec![member_party_id.to_string()],
         read_as: vec![request.party_id.to_string()],
         submission_id: String::new(),
-        disclosed_contracts: request
-            .disclosed_contracts
-            .iter()
-            .map(|dc| {
-                Ok(DisclosedContract {
-                    template_id: None,
-                    contract_id: dc.contract_id.clone(),
-                    created_event_blob: base64::engine::general_purpose::STANDARD
-                        .decode(&dc.blob)
-                        .context("Invalid base64 in disclosed contract blob")?,
-                    synchronizer_id: String::new(),
-                })
-            })
-            .collect::<Result<Vec<_>>>()?,
+        disclosed_contracts,
         synchronizer_id: String::new(),
         package_id_selection_preference: vec![],
         prefetch_contract_keys: vec![],

--- a/src/server/handlers/mod.rs
+++ b/src/server/handlers/mod.rs
@@ -14,8 +14,8 @@ pub use governance::{
     get_governance_audit, get_governance_chain_audit, get_governance_state,
     get_instruments_handler, get_known_members, get_network_info, get_operator_info, get_packages,
     get_provider_services_handler, get_registrar_services_handler, get_token_standard_contracts,
-    get_transfer_preapprovals_handler, get_user_services_handler, get_vaults_handler,
-    propose_action, query_contracts_handler,
+    get_transfer_instructions_handler, get_transfer_preapprovals_handler,
+    get_user_services_handler, get_vaults_handler, propose_action, query_contracts_handler,
 };
 pub use invitations::{accept_invitation, decline_invitation, get_invitations};
 pub use keys::get_key_status;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1300,6 +1300,7 @@ pub async fn start_server(
             .service(handlers::get_user_services_handler)
             .service(handlers::get_registrar_services_handler)
             .service(handlers::get_instruments_handler)
+            .service(handlers::get_transfer_instructions_handler)
             .service(handlers::get_transfer_preapprovals_handler)
             .service(handlers::query_contracts_handler)
             .service(handlers::get_packages)

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -5,6 +5,7 @@ mod chain_audit;
 mod handlers;
 mod middleware;
 mod queries;
+mod transfer_context;
 mod types;
 
 pub mod peer_status;

--- a/src/server/queries.rs
+++ b/src/server/queries.rs
@@ -1,10 +1,11 @@
 use std::collections::HashMap;
 
+use canton_common::decimal::DamlDecimal;
 use canton_proto_rs::com::{
     daml::ledger::api::v2::{
         CreatedEvent, CumulativeFilter, EventFormat, Filters, GetActiveContractsRequest,
-        GetLedgerEndRequest, Identifier, InterfaceFilter, TemplateFilter, Value, WildcardFilter,
-        admin::ListKnownPartiesRequest, cumulative_filter,
+        GetLedgerEndRequest, Identifier, InterfaceFilter, Record, TemplateFilter, Value,
+        WildcardFilter, admin::ListKnownPartiesRequest, cumulative_filter,
         get_active_contracts_response::ContractEntry, value,
     },
     digitalasset::canton::admin::participant::v30::{
@@ -24,7 +25,8 @@ use super::{
     types::{
         ActionType, ContractInfo, ContractWithBlob, DomainGovernanceAction, GovernanceAction,
         GovernanceConfirmation, GovernanceState, InstrumentInfo, PartyMetadata,
-        ProviderServiceInfo, RegistrarServiceInfo, UserServiceInfo, VaultInfo,
+        ProviderServiceInfo, RegistrarServiceInfo, TransferInstructionInfo, UserServiceInfo,
+        VaultInfo,
     },
 };
 
@@ -2494,6 +2496,182 @@ pub async fn query_contracts_by_template(
     }
 
     Ok(contracts)
+}
+
+// ============================================================================
+// Token-standard TransferInstruction Query (for Accept Transfer dropdown)
+// ============================================================================
+
+/// Fetch open `TransferInstruction` contracts (status
+/// `TransferPendingReceiverAcceptance`) whose `receiver` is `party_id`.
+///
+/// The token-standard registry models `TransferInstruction` as an interface
+/// (`Splice.Api.Token.TransferInstructionV1:TransferInstruction`), so this
+/// uses an `InterfaceFilter` and reads the computed `TransferInstructionView`
+/// to surface sender / receiver / amount / instrument for the UI dropdown.
+pub async fn get_open_transfer_instructions(
+    config: &NodeConfig,
+    party_id: &CantonId,
+    token: Option<String>,
+) -> Result<Vec<TransferInstructionInfo>> {
+    let mut state_client = utils::create_state_client(config, token).await?;
+
+    let ledger_end = state_client
+        .get_ledger_end(tonic::Request::new(GetLedgerEndRequest {}))
+        .await?
+        .into_inner()
+        .offset;
+
+    let mut filters_by_party = HashMap::new();
+    filters_by_party.insert(
+        party_id.to_string(),
+        Filters {
+            cumulative: vec![CumulativeFilter {
+                identifier_filter: Some(cumulative_filter::IdentifierFilter::InterfaceFilter(
+                    InterfaceFilter {
+                        interface_id: Some(Identifier {
+                            package_id: "#splice-api-token-transfer-instruction-v1".to_string(),
+                            module_name: "Splice.Api.Token.TransferInstructionV1".to_string(),
+                            entity_name: "TransferInstruction".to_string(),
+                        }),
+                        include_interface_view: true,
+                        include_created_event_blob: false,
+                    },
+                )),
+            }],
+        },
+    );
+
+    let acs_request = GetActiveContractsRequest {
+        active_at_offset: ledger_end,
+        event_format: Some(EventFormat {
+            filters_by_party,
+            filters_for_any_party: None,
+            verbose: true,
+        }),
+    };
+
+    let mut stream = state_client
+        .get_active_contracts(tonic::Request::new(acs_request))
+        .await?
+        .into_inner();
+
+    let receiver_str = party_id.to_string();
+    let mut instructions = Vec::new();
+    while let Some(response) = stream.message().await? {
+        if let Some(ContractEntry::ActiveContract(active)) = response.contract_entry
+            && let Some(created) = active.created_event
+            && let Some(info) = extract_transfer_instruction_info(&created)
+            && info.receiver.to_string() == receiver_str
+        {
+            instructions.push(info);
+        }
+    }
+
+    Ok(instructions)
+}
+
+/// Pull sender / receiver / amount / instrument out of a `TransferInstruction`
+/// interface view. Returns `None` if the view is missing, the status is not
+/// `TransferPendingReceiverAcceptance`, or any expected field is absent.
+fn extract_transfer_instruction_info(created: &CreatedEvent) -> Option<TransferInstructionInfo> {
+    // The view is delivered under `interface_views` (not `create_arguments`).
+    // Pick the first one matching the TransferInstruction interface; there's
+    // typically only one for this filter shape.
+    let view = created.interface_views.iter().find(|v| {
+        v.interface_id.as_ref().is_some_and(|id| {
+            id.module_name == "Splice.Api.Token.TransferInstructionV1"
+                && id.entity_name == "TransferInstruction"
+        })
+    })?;
+    let view_record = view.view_value.as_ref()?;
+
+    // Filter out already-progressing instructions; only pending-acceptance
+    // ones can be Accepted.
+    let status = view_record
+        .fields
+        .iter()
+        .find(|f| f.label == "status")
+        .and_then(|f| f.value.as_ref())?;
+    let is_pending_acceptance = matches!(
+        &status.sum,
+        Some(value::Sum::Variant(v)) if v.constructor == "TransferPendingReceiverAcceptance"
+    );
+    if !is_pending_acceptance {
+        return None;
+    }
+
+    let transfer_record = view_record
+        .fields
+        .iter()
+        .find(|f| f.label == "transfer")
+        .and_then(|f| f.value.as_ref())
+        .and_then(|v| match &v.sum {
+            Some(value::Sum::Record(r)) => Some(r),
+            _ => None,
+        })?;
+
+    let sender: CantonId = field_party(transfer_record, "sender")?.parse().ok()?;
+    let receiver: CantonId = field_party(transfer_record, "receiver")?.parse().ok()?;
+    let amount =
+        field_numeric(transfer_record, "amount").and_then(|s| DamlDecimal::parse(&s).ok())?;
+
+    let instrument_record = transfer_record
+        .fields
+        .iter()
+        .find(|f| f.label == "instrumentId")
+        .and_then(|f| f.value.as_ref())
+        .and_then(|v| match &v.sum {
+            Some(value::Sum::Record(r)) => Some(r),
+            _ => None,
+        })?;
+    let instrument_admin: CantonId = field_party(instrument_record, "admin")?.parse().ok()?;
+    let instrument_id = field_text(instrument_record, "id")?;
+
+    Some(TransferInstructionInfo {
+        contract_id: created.contract_id.clone(),
+        sender,
+        receiver,
+        amount,
+        instrument_admin,
+        instrument_id,
+    })
+}
+
+fn field_party(record: &Record, label: &str) -> Option<String> {
+    record
+        .fields
+        .iter()
+        .find(|f| f.label == label)
+        .and_then(|f| f.value.as_ref())
+        .and_then(|v| match &v.sum {
+            Some(value::Sum::Party(p)) => Some(p.clone()),
+            _ => None,
+        })
+}
+
+fn field_text(record: &Record, label: &str) -> Option<String> {
+    record
+        .fields
+        .iter()
+        .find(|f| f.label == label)
+        .and_then(|f| f.value.as_ref())
+        .and_then(|v| match &v.sum {
+            Some(value::Sum::Text(t)) => Some(t.clone()),
+            _ => None,
+        })
+}
+
+fn field_numeric(record: &Record, label: &str) -> Option<String> {
+    record
+        .fields
+        .iter()
+        .find(|f| f.label == label)
+        .and_then(|f| f.value.as_ref())
+        .and_then(|v| match &v.sum {
+            Some(value::Sum::Numeric(n)) => Some(n.clone()),
+            _ => None,
+        })
 }
 
 #[cfg(test)]

--- a/src/server/queries.rs
+++ b/src/server/queries.rs
@@ -1,4 +1,7 @@
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 use canton_common::decimal::DamlDecimal;
 use canton_proto_rs::com::{
@@ -2611,6 +2614,18 @@ fn extract_transfer_instruction_info(created: &CreatedEvent) -> Option<TransferI
             _ => None,
         })?;
 
+    // Drop instructions whose `executeBefore` deadline has already passed —
+    // accepting them would fail at interpretation with `deadline-exceeded`,
+    // so they have no business in the dropdown.
+    let execute_before_micros = field_timestamp(transfer_record, "executeBefore")?;
+    let now_micros = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()?
+        .as_micros() as i64;
+    if execute_before_micros <= now_micros {
+        return None;
+    }
+
     let sender: CantonId = field_party(transfer_record, "sender")?.parse().ok()?;
     let receiver: CantonId = field_party(transfer_record, "receiver")?.parse().ok()?;
     let amount =
@@ -2670,6 +2685,18 @@ fn field_numeric(record: &Record, label: &str) -> Option<String> {
         .and_then(|f| f.value.as_ref())
         .and_then(|v| match &v.sum {
             Some(value::Sum::Numeric(n)) => Some(n.clone()),
+            _ => None,
+        })
+}
+
+fn field_timestamp(record: &Record, label: &str) -> Option<i64> {
+    record
+        .fields
+        .iter()
+        .find(|f| f.label == label)
+        .and_then(|f| f.value.as_ref())
+        .and_then(|v| match &v.sum {
+            Some(value::Sum::Timestamp(t)) => Some(*t),
             _ => None,
         })
 }

--- a/src/server/queries.rs
+++ b/src/server/queries.rs
@@ -2925,11 +2925,8 @@ mod tests {
     fn extract_transfer_instruction_info_drops_expired() {
         // Epoch is comfortably in the past.
         assert!(
-            extract_transfer_instruction_info(&make_event(
-                TRANSFER_PENDING_RECEIVER_ACCEPTANCE,
-                0
-            ))
-            .is_none(),
+            extract_transfer_instruction_info(&make_event(TRANSFER_PENDING_RECEIVER_ACCEPTANCE, 0))
+                .is_none(),
         );
     }
 }

--- a/src/server/queries.rs
+++ b/src/server/queries.rs
@@ -2505,6 +2505,11 @@ pub async fn query_contracts_by_template(
 // Token-standard TransferInstruction Query (for Accept Transfer dropdown)
 // ============================================================================
 
+/// The only `TransferInstructionStatus` constructor that can be Accepted —
+/// see `Splice.Api.Token.TransferInstructionV1` in the token-standard package.
+/// Lifted here so a grep surfaces every place that depends on the spelling.
+const TRANSFER_PENDING_RECEIVER_ACCEPTANCE: &str = "TransferPendingReceiverAcceptance";
+
 /// Fetch open `TransferInstruction` contracts (status
 /// `TransferPendingReceiverAcceptance`) whose `receiver` is `party_id`.
 ///
@@ -2562,6 +2567,10 @@ pub async fn get_open_transfer_instructions(
     let receiver_str = party_id.to_string();
     let mut instructions = Vec::new();
     while let Some(response) = stream.message().await? {
+        // The InterfaceFilter only enforces party visibility — this party can
+        // see the contract as sender, receiver, or an instrument-admin
+        // stakeholder. Keep only the ones where it's the *receiver*, since
+        // those are the only ones it can Accept.
         if let Some(ContractEntry::ActiveContract(active)) = response.contract_entry
             && let Some(created) = active.created_event
             && let Some(info) = extract_transfer_instruction_info(&created)
@@ -2598,7 +2607,7 @@ fn extract_transfer_instruction_info(created: &CreatedEvent) -> Option<TransferI
         .and_then(|f| f.value.as_ref())?;
     let is_pending_acceptance = matches!(
         &status.sum,
-        Some(value::Sum::Variant(v)) if v.constructor == "TransferPendingReceiverAcceptance"
+        Some(value::Sum::Variant(v)) if v.constructor == TRANSFER_PENDING_RECEIVER_ACCEPTANCE
     );
     if !is_pending_acceptance {
         return None;
@@ -2770,5 +2779,157 @@ mod tests {
         assert_eq!(compare_versions("1.0.0", "0.99.99"), Ordering::Greater);
         assert_eq!(compare_versions("1.0.0", "1.0.0"), Ordering::Equal);
         assert_eq!(compare_versions("1.0", "1.0.0"), Ordering::Less);
+    }
+
+    // ------------------------------------------------------------------------
+    // extract_transfer_instruction_info
+    //
+    // Locks the two filters that are easy to break by accident: the status
+    // constructor match and the `executeBefore` deadline check.
+    // ------------------------------------------------------------------------
+
+    use canton_proto_rs::com::daml::ledger::api::v2::{InterfaceView, RecordField, Variant};
+
+    fn field(label: &str, value: Value) -> RecordField {
+        RecordField {
+            label: label.to_string(),
+            value: Some(value),
+        }
+    }
+
+    fn text_value(s: &str) -> Value {
+        Value {
+            sum: Some(value::Sum::Text(s.to_string())),
+        }
+    }
+
+    fn party_value(p: &str) -> Value {
+        Value {
+            sum: Some(value::Sum::Party(p.to_string())),
+        }
+    }
+
+    fn numeric_value(n: &str) -> Value {
+        Value {
+            sum: Some(value::Sum::Numeric(n.to_string())),
+        }
+    }
+
+    fn timestamp_value(micros: i64) -> Value {
+        Value {
+            sum: Some(value::Sum::Timestamp(micros)),
+        }
+    }
+
+    fn variant_value(constructor: &str, inner: Value) -> Value {
+        Value {
+            sum: Some(value::Sum::Variant(Box::new(Variant {
+                variant_id: None,
+                constructor: constructor.to_string(),
+                value: Some(Box::new(inner)),
+            }))),
+        }
+    }
+
+    fn record_value(fields: Vec<RecordField>) -> Value {
+        Value {
+            sum: Some(value::Sum::Record(Record {
+                record_id: None,
+                fields,
+            })),
+        }
+    }
+
+    fn unit_value() -> Value {
+        record_value(vec![])
+    }
+
+    /// Build a `CreatedEvent` carrying a `TransferInstructionView` interface
+    /// view. `status_ctor` is the variant constructor on the status field;
+    /// `execute_before_micros` populates the transfer record's
+    /// `executeBefore` field.
+    fn make_event(status_ctor: &str, execute_before_micros: i64) -> CreatedEvent {
+        // Canton party id format: `<prefix>::<34-byte-multihash-hex>`.
+        // `CantonId::parse` rejects anything else, so use a real-shaped fingerprint.
+        const FP: &str = "1220c4010d6883f367c7f45d55b2449501620130f9b21e96379f17dea455ac7a5892";
+        let transfer = record_value(vec![
+            field("sender", party_value(&format!("alice::{FP}"))),
+            field("receiver", party_value(&format!("bob::{FP}"))),
+            field("amount", numeric_value("10.0")),
+            field(
+                "instrumentId",
+                record_value(vec![
+                    field("admin", party_value(&format!("admin::{FP}"))),
+                    field("id", text_value("CBTC")),
+                ]),
+            ),
+            field("executeBefore", timestamp_value(execute_before_micros)),
+        ]);
+        let view = InterfaceView {
+            interface_id: Some(Identifier {
+                package_id: "#splice-api-token-transfer-instruction-v1".to_string(),
+                module_name: "Splice.Api.Token.TransferInstructionV1".to_string(),
+                entity_name: "TransferInstruction".to_string(),
+            }),
+            view_status: None,
+            view_value: Some(Record {
+                record_id: None,
+                fields: vec![
+                    field("status", variant_value(status_ctor, unit_value())),
+                    field("transfer", transfer),
+                ],
+            }),
+        };
+        CreatedEvent {
+            offset: 0,
+            node_id: 0,
+            contract_id: "cid-1".to_string(),
+            template_id: None,
+            contract_key: None,
+            create_arguments: None,
+            created_event_blob: vec![],
+            interface_views: vec![view],
+            witness_parties: vec![],
+            signatories: vec![],
+            observers: vec![],
+            created_at: None,
+            package_name: String::new(),
+            representative_package_id: String::new(),
+            acs_delta: false,
+        }
+    }
+
+    #[test]
+    fn extract_transfer_instruction_info_accepts_pending_in_future() {
+        let future_micros = i64::MAX / 4;
+        let info = extract_transfer_instruction_info(&make_event(
+            TRANSFER_PENDING_RECEIVER_ACCEPTANCE,
+            future_micros,
+        ))
+        .expect("pending + in-future should yield info");
+        assert_eq!(info.contract_id, "cid-1");
+        assert!(info.sender.to_string().starts_with("alice::"));
+        assert!(info.receiver.to_string().starts_with("bob::"));
+    }
+
+    #[test]
+    fn extract_transfer_instruction_info_drops_non_pending_status() {
+        let future_micros = i64::MAX / 4;
+        assert!(
+            extract_transfer_instruction_info(&make_event("TransferInProgress", future_micros))
+                .is_none(),
+        );
+    }
+
+    #[test]
+    fn extract_transfer_instruction_info_drops_expired() {
+        // Epoch is comfortably in the past.
+        assert!(
+            extract_transfer_instruction_info(&make_event(
+                TRANSFER_PENDING_RECEIVER_ACCEPTANCE,
+                0
+            ))
+            .is_none(),
+        );
     }
 }

--- a/src/server/transfer_context.rs
+++ b/src/server/transfer_context.rs
@@ -54,6 +54,9 @@ pub async fn fetch(
     let response = canton_registry::accept_context::get(canton_registry::accept_context::Params {
         registry_url: network.registry_url().to_string(),
         decentralized_party_id: decentralized_party_id.to_string(),
+        // Upstream field is named `transfer_offer_contract_id` but the
+        // registry endpoint actually keys on the TransferInstruction cid.
+        // Naming mismatch is in canton-lib, not here.
         transfer_offer_contract_id: transfer_instruction_cid.to_string(),
         request: canton_registry::accept_context::Request {
             meta: canton_registry::accept_context::Meta {

--- a/src/server/transfer_context.rs
+++ b/src/server/transfer_context.rs
@@ -15,7 +15,8 @@ use std::collections::HashMap;
 use anyhow::Context as _;
 use base64::Engine as _;
 use canton_common::{
-    transfer::DisclosedContract as RegistryDisclosedContract, transfer_factory::Context,
+    transfer::DisclosedContract as RegistryDisclosedContract,
+    transfer_factory::{Context, ContextValue},
 };
 use canton_proto_rs::com::daml::ledger::api::v2::{
     CumulativeFilter, DisclosedContract, EventFormat, Filters, GetEventsByContractIdRequest,
@@ -63,11 +64,16 @@ pub async fn fetch(
     .await
     .map_err(|e| anyhow::anyhow!("registry accept-context request failed: {e}"))?;
 
-    let context: Context = serde_json::from_value(response.choice_context_data.values)
-        .context("Failed to deserialize registry choice_context_data.values as Context")?;
+    // The registry's `choiceContextData` JSON is `{"values": {<key>: <AnyValue>, ...}}`.
+    // `canton_registry::accept_context::Response` already strips the outer wrapper into
+    // `ChoiceContextData { values: serde_json::Value }`, so `response.choice_context_data.values`
+    // is the inner key→AnyValue map. Deserialize it directly into the map type and wrap.
+    let values: HashMap<String, ContextValue> =
+        serde_json::from_value(response.choice_context_data.values)
+            .context("Failed to deserialize registry choice_context_data.values")?;
 
     Ok(AcceptTransferContext {
-        context,
+        context: Context { values },
         disclosed_contracts: response.disclosed_contracts,
     })
 }

--- a/src/server/transfer_context.rs
+++ b/src/server/transfer_context.rs
@@ -1,0 +1,190 @@
+//! Token-standard registry lookups for transfer flows.
+//!
+//! `AcceptTransferProposal` execution invokes
+//! `TransferInstruction_Accept`, which reads `utility.digitalasset.com/transfer-rule`
+//! (and friends) from `extraArgs.context.values` and references the contracts
+//! through `disclosed_contracts` on the submission. The registry's
+//! `…/choice-contexts/accept` endpoint returns both pieces in one call.
+//!
+//! This module wraps `canton_registry::accept_context::get` and surfaces a
+//! type the propose/execute handlers can pass into the action serializer and
+//! the submission builder respectively.
+
+use std::collections::HashMap;
+
+use anyhow::Context as _;
+use base64::Engine as _;
+use canton_common::{
+    transfer::DisclosedContract as RegistryDisclosedContract, transfer_factory::Context,
+};
+use canton_proto_rs::com::daml::ledger::api::v2::{
+    CumulativeFilter, DisclosedContract, EventFormat, Filters, GetEventsByContractIdRequest,
+    WildcardFilter, cumulative_filter, value,
+};
+
+use crate::{
+    config::{Network, NodeConfig},
+    error::Result,
+    participant_id::CantonId,
+    utils,
+};
+
+/// The data needed to submit an `AcceptTransfer` flow against the ledger.
+///
+/// `context` lands inside the proposal's `extraArgs.context.values` at
+/// proposal-creation time. `disclosed_contracts` must be attached to the
+/// `Commands` submission at execute-confirmed-action time (the contracts are
+/// not stored on the ledger so the executor needs them on the wire).
+#[derive(Debug, Clone)]
+pub struct AcceptTransferContext {
+    pub context: Context,
+    pub disclosed_contracts: Vec<RegistryDisclosedContract>,
+}
+
+/// Fetch the accept choice context from the token-standard registry for a
+/// given `TransferInstruction`. Used by the propose handler (to bake the
+/// context into the proposal) and the execute handler (to attach disclosed
+/// contracts to the submission).
+pub async fn fetch(
+    network: Network,
+    decentralized_party_id: &str,
+    transfer_instruction_cid: &str,
+) -> Result<AcceptTransferContext> {
+    let response = canton_registry::accept_context::get(canton_registry::accept_context::Params {
+        registry_url: network.registry_url().to_string(),
+        decentralized_party_id: decentralized_party_id.to_string(),
+        transfer_offer_contract_id: transfer_instruction_cid.to_string(),
+        request: canton_registry::accept_context::Request {
+            meta: canton_registry::accept_context::Meta {
+                values: String::new(),
+            },
+        },
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("registry accept-context request failed: {e}"))?;
+
+    let context: Context = serde_json::from_value(response.choice_context_data.values)
+        .context("Failed to deserialize registry choice_context_data.values as Context")?;
+
+    Ok(AcceptTransferContext {
+        context,
+        disclosed_contracts: response.disclosed_contracts,
+    })
+}
+
+/// Inspect a governance proposal contract by cid; if it's an
+/// `AcceptTransferProposal`, fetch the choice context from the registry and
+/// return it so the executor can attach disclosed contracts. Returns `Ok(None)`
+/// for any other proposal type so the caller can pass through.
+///
+/// The lookup uses `EventQueryService.GetEventsByContractId`, which returns
+/// the create event for an exact contract id (cheap, single round-trip).
+pub async fn maybe_fetch_for_proposal(
+    config: &NodeConfig,
+    token: Option<String>,
+    party_id: &CantonId,
+    proposal_cid: &str,
+) -> Result<Option<AcceptTransferContext>> {
+    let mut client = utils::create_event_query_client(config, token).await?;
+
+    // `GetEventsByContractId` filters by party-visibility so the requester
+    // must be authorized to read the proposal. Use the party that's executing
+    // the action — they're a stakeholder on the governance proposal.
+    let mut filters_by_party = HashMap::new();
+    filters_by_party.insert(
+        party_id.to_string(),
+        Filters {
+            cumulative: vec![CumulativeFilter {
+                identifier_filter: Some(cumulative_filter::IdentifierFilter::WildcardFilter(
+                    WildcardFilter {
+                        include_created_event_blob: false,
+                    },
+                )),
+            }],
+        },
+    );
+
+    let request = GetEventsByContractIdRequest {
+        contract_id: proposal_cid.to_string(),
+        event_format: Some(EventFormat {
+            filters_by_party,
+            filters_for_any_party: None,
+            verbose: true,
+        }),
+    };
+
+    let response = client
+        .get_events_by_contract_id(tonic::Request::new(request))
+        .await
+        .context("Failed to query event for proposal contract id")?
+        .into_inner();
+
+    let Some(created) = response.created else {
+        // Proposal not visible or already archived — caller's submission will
+        // surface the right error, no need to second-guess it here.
+        return Ok(None);
+    };
+    let Some(created_event) = created.created_event else {
+        return Ok(None);
+    };
+
+    // Identify `AcceptTransferProposal` by template id. The package id is
+    // package-name-resolved (e.g. `#governance-token-custody-v0`) so match
+    // on the module + entity tuple alone.
+    let is_accept_transfer = created_event
+        .template_id
+        .as_ref()
+        .map(|t| {
+            t.module_name == "Governance.TokenCustody.AcceptTransfer"
+                && t.entity_name == "AcceptTransferProposal"
+        })
+        .unwrap_or(false);
+    if !is_accept_transfer {
+        return Ok(None);
+    }
+
+    let Some(create_args) = created_event.create_arguments else {
+        anyhow::bail!("AcceptTransferProposal create_arguments missing in event response");
+    };
+
+    let transfer_instruction_cid = create_args
+        .fields
+        .iter()
+        .find(|f| f.label == "transferInstructionCid")
+        .and_then(|f| f.value.as_ref())
+        .and_then(|v| match &v.sum {
+            Some(value::Sum::ContractId(cid)) => Some(cid.clone()),
+            _ => None,
+        })
+        .context("AcceptTransferProposal missing transferInstructionCid field")?;
+
+    let ctx = fetch(
+        config.canton.network,
+        &party_id.to_string(),
+        &transfer_instruction_cid,
+    )
+    .await?;
+
+    Ok(Some(ctx))
+}
+
+/// Translate the registry's JSON `DisclosedContract` view into the Ledger
+/// API's proto form, base64-decoding the created-event blob.
+pub fn to_proto_disclosed_contracts(
+    contracts: &[RegistryDisclosedContract],
+) -> Result<Vec<DisclosedContract>> {
+    contracts
+        .iter()
+        .map(|dc| {
+            let created_event_blob = base64::engine::general_purpose::STANDARD
+                .decode(&dc.created_event_blob)
+                .context("Invalid base64 in registry-provided disclosed contract blob")?;
+            Ok(DisclosedContract {
+                template_id: None,
+                contract_id: dc.contract_id.clone(),
+                created_event_blob,
+                synchronizer_id: dc.synchronizer_id.clone(),
+            })
+        })
+        .collect()
+}

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -1417,6 +1417,26 @@ pub struct UserServiceInfo {
     pub user: CantonId,
 }
 
+/// An open `TransferInstruction` awaiting receiver acceptance. Populates the
+/// Accept Transfer proposal form's dropdown so operators don't have to paste
+/// the contract id by hand.
+#[derive(Clone, Debug, Serialize, utoipa::ToSchema)]
+pub struct TransferInstructionInfo {
+    pub contract_id: String,
+    pub sender: CantonId,
+    pub receiver: CantonId,
+    #[schema(value_type = String)]
+    pub amount: DamlDecimal,
+    pub instrument_admin: CantonId,
+    pub instrument_id: String,
+}
+
+/// Response for the transfer instructions endpoint.
+#[derive(Serialize, utoipa::ToSchema)]
+pub struct TransferInstructionsResponse {
+    pub transfer_instructions: Vec<TransferInstructionInfo>,
+}
+
 /// Information about an InstrumentConfiguration contract (one "token" the
 /// governance party can mint/burn against). `instrument_admin` and
 /// `instrument_id` are read off the contract's `defaultIdentifier` field and

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -11,6 +11,7 @@ use canton_proto_rs::com::{
             party_management_service_client::PartyManagementServiceClient,
             user_management_service_client::UserManagementServiceClient,
         },
+        event_query_service_client::EventQueryServiceClient,
         interactive::interactive_submission_service_client::InteractiveSubmissionServiceClient,
         state_service_client::StateServiceClient,
         update_service_client::UpdateServiceClient,
@@ -446,6 +447,7 @@ define_client_creator!(create_user_client, UserManagementServiceClient);
 define_client_creator!(create_submission_client, InteractiveSubmissionServiceClient);
 define_client_creator!(create_state_client, StateServiceClient);
 define_client_creator!(create_update_client, UpdateServiceClient);
+define_client_creator!(create_event_query_client, EventQueryServiceClient);
 
 /// Create a directory with context for error messages
 pub async fn create_directory(path: &Path) -> Result {

--- a/zarf/deployments/devnet/participant1/deployment.yaml
+++ b/zarf/deployments/devnet/participant1/deployment.yaml
@@ -44,7 +44,7 @@ spec:
               mountPath: /app
       containers:
         - name: dec-party-manager
-          image: public.ecr.aws/dlc-link/canton-decparty-manager:0.1.2
+          image: public.ecr.aws/dlc-link/canton-decparty-manager:0.1.3
           imagePullPolicy: Always
           command:
             [

--- a/zarf/deployments/devnet/participant2/deployment.yaml
+++ b/zarf/deployments/devnet/participant2/deployment.yaml
@@ -44,7 +44,7 @@ spec:
               mountPath: /app
       containers:
         - name: dec-party-manager
-          image: public.ecr.aws/dlc-link/canton-decparty-manager:0.1.2
+          image: public.ecr.aws/dlc-link/canton-decparty-manager:0.1.3
           imagePullPolicy: Always
           command:
             [

--- a/zarf/deployments/devnet/participant3/deployment.yaml
+++ b/zarf/deployments/devnet/participant3/deployment.yaml
@@ -44,7 +44,7 @@ spec:
               mountPath: /app
       containers:
         - name: dec-party-manager
-          image: public.ecr.aws/dlc-link/canton-decparty-manager:0.1.2
+          image: public.ecr.aws/dlc-link/canton-decparty-manager:0.1.3
           imagePullPolicy: Always
           command:
             [

--- a/zarf/deployments/testnet/deployment.yaml
+++ b/zarf/deployments/testnet/deployment.yaml
@@ -44,7 +44,7 @@ spec:
               mountPath: /app
       containers:
         - name: dec-party-manager
-          image: public.ecr.aws/dlc-link/canton-decparty-manager:0.1.2
+          image: public.ecr.aws/dlc-link/canton-decparty-manager:0.1.3
           imagePullPolicy: Always
           command:
             [


### PR DESCRIPTION
## Summary

`AcceptTransferProposal` execution was failing with `Missing context entry for utility.digitalasset.com/transfer-rule` because the proposal was created with an empty `extraArgs.context`. The propose handler now fetches the choice context (and disclosed contracts) from the token-standard registry, bakes the context into the on-chain proposal at create time, and re-fetches disclosed contracts at execute time to attach them to the submission.

- New module `src/server/transfer_context.rs` wraps `canton_registry::accept_context::get` and the `EventQueryService` lookup for the per-proposal disclosed-contract fetch.
- `Network::registry_url()` added next to `operator_url()` (devnet/testnet/mainnet hosts of the token-standard registry).
- `action_serializer::build_proposal_create_args` now takes an `Option<&ChoiceContext>` and translates the registry's `AnyValue` map into a `TextMap AnyValue` of `Variant`s for the `AcceptTransfer` branch. Other proposal types unaffected.
- `execute_confirmed_action` detects `AcceptTransferProposal` via `EventQueryService.GetEventsByContractId` on the `proposal_cid` (CoreDomain path), extracts `transferInstructionCid`, refetches the registry context, and merges the returned `disclosed_contracts` into the submission's `disclosed_contracts` (de-duped by contract id).
- Tag bump `0.1.2 → 0.1.3` in `deploy-all.sh` and the four zarf deployment manifests (devnet × 3 + testnet).

## Caveats

- Builds on `fix/auth/keycloak-token-url` (canton-lib dep flipped to the `feat/keycloak/added-quarkus-token-url` branch). PR base is set accordingly; merge that one first.
- Pre-existing AcceptTransfer proposals on the ledger have empty `extraArgs.context` baked in and can't be fixed by code — dismiss + recreate.
- The fix relies on registry hostnames matching `operator_url()` (e.g. `api.utilities.digitalasset-dev.com`). Verified the `…/choice-contexts/accept` endpoint exists on devnet.

## Test plan

- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib` (111 pass)
- [x] Devnet end-to-end: create fresh AcceptTransfer proposal on `0.1.3` and execute; confirm Daml advances past the `transfer-rule` check.