### PR TITLE
feat(ui): readable accept mint & burn request dropdowns

### DIFF
--- a/frontend/src/components/GovernanceSection.tsx
+++ b/frontend/src/components/GovernanceSection.tsx
@@ -41,8 +41,6 @@ import {
   TEMPLATE_ALLOCATION_FACTORY,
   INTERFACE_FEATURED_APP_RIGHT,
   TEMPLATE_REGISTRAR_SERVICE,
-  TEMPLATE_MINT_REQUEST,
-  TEMPLATE_BURN_REQUEST,
 } from "../constants";
 import { authenticatedFetch } from "../api";
 import { getActionTypeOptions } from "../governanceFormat";
@@ -73,6 +71,9 @@ import type {
   InstrumentsResponse,
   TransferInstructionInfo,
   TransferInstructionsResponse,
+  TokenRequestInfo,
+  MintRequestsResponse,
+  BurnRequestsResponse,
   TransferPreapprovalsResponse,
   TransferFactoryInfo,
   TransferFactoriesResponse,
@@ -301,8 +302,13 @@ export const GovernanceSection = ({
   >([]);
   const [userServices, setUserServices] = useState<UserServiceInfo[]>([]);
   const [registrarServiceContracts, setRegistrarServiceContracts] = useState<ContractWithBlob[]>([]);
-  const [mintRequestContracts, setMintRequestContracts] = useState<ContractWithBlob[]>([]);
-  const [burnRequestContracts, setBurnRequestContracts] = useState<ContractWithBlob[]>([]);
+  // Typed `MintRequest`/`BurnRequest` rows so the Accept dropdowns can show
+  // holder → amount instrument (…cid) — mirroring the Accept Transfer UX —
+  // instead of just the contract id slug.
+  const [mintRequestContracts, setMintRequestContracts] = useState<TokenRequestInfo[]>([]);
+  const [burnRequestContracts, setBurnRequestContracts] = useState<TokenRequestInfo[]>([]);
+  const [mintRequestsLoading, setMintRequestsLoading] = useState(false);
+  const [burnRequestsLoading, setBurnRequestsLoading] = useState(false);
   // InstrumentConfiguration contracts fetched from /instruments. Each one
   // represents a token the governance party can mint/burn against and exposes
   // its parsed instrument_admin + instrument_id, so we can drive a real
@@ -595,6 +601,43 @@ export const GovernanceSection = ({
     }
   }, [proposalType, fetchOpenTransferInstructions]);
 
+  // Pull typed open mint/burn requests for the Accept dropdowns. Mirrors the
+  // Accept Transfer flow above — the backend extracts holder/amount/instrument
+  // from the contract payload so we can render a useful label.
+  const fetchOpenMintRequests = useCallback(async () => {
+    setMintRequestsLoading(true);
+    try {
+      const res = await authenticatedFetch(
+        `${API_BASE}/governance/mint-requests?party_id=${encodeURIComponent(partyId)}`,
+      );
+      if (res.ok) {
+        const response: MintRequestsResponse = await res.json();
+        setMintRequestContracts(response.mint_requests);
+      }
+    } catch (e) {
+      console.error("Failed to fetch mint requests:", e);
+    } finally {
+      setMintRequestsLoading(false);
+    }
+  }, [partyId]);
+
+  const fetchOpenBurnRequests = useCallback(async () => {
+    setBurnRequestsLoading(true);
+    try {
+      const res = await authenticatedFetch(
+        `${API_BASE}/governance/burn-requests?party_id=${encodeURIComponent(partyId)}`,
+      );
+      if (res.ok) {
+        const response: BurnRequestsResponse = await res.json();
+        setBurnRequestContracts(response.burn_requests);
+      }
+    } catch (e) {
+      console.error("Failed to fetch burn requests:", e);
+    } finally {
+      setBurnRequestsLoading(false);
+    }
+  }, [partyId]);
+
   // Fetch holdings + transfer factories for the Transfer Proposal dropdown.
   // Both endpoints are cheap (one ACS query each) and we need them together
   // to render the dropdown + prefill, so fetch them in parallel.
@@ -716,16 +759,12 @@ export const GovernanceSection = ({
       fetchContractsByTemplate(TEMPLATE_REGISTRAR_SERVICE).then(setRegistrarServiceContracts);
     }
     if (proposalType === "accept_mint_request") {
-      fetchContractsByTemplate(TEMPLATE_MINT_REQUEST, { activeOnly: true }).then(
-        setMintRequestContracts,
-      );
+      fetchOpenMintRequests();
     }
     if (proposalType === "accept_burn_request") {
-      fetchContractsByTemplate(TEMPLATE_BURN_REQUEST, { activeOnly: true }).then(
-        setBurnRequestContracts,
-      );
+      fetchOpenBurnRequests();
     }
-  }, [proposalType, fetchContractsByTemplate]);
+  }, [proposalType, fetchContractsByTemplate, fetchOpenMintRequests, fetchOpenBurnRequests]);
 
   // Fetch all deployment-related contracts for vault_deployment
   const fetchDeployContracts = useCallback(async () => {
@@ -4448,42 +4487,122 @@ export const GovernanceSection = ({
                 const requestCid = isMint ? proposalMintRequestCid : proposalBurnRequestCid;
                 const setRequestCid = isMint ? setProposalMintRequestCid : setProposalBurnRequestCid;
                 const requestLabel = isMint ? "MintRequest" : "BurnRequest";
+                const requestsLoading = isMint ? mintRequestsLoading : burnRequestsLoading;
+                // Mint = tokens created (green), burn = tokens destroyed (red).
+                const accentColor = isMint ? "success.main" : "error.main";
+                // Selecting a request prefills the matching InstrumentConfiguration
+                // so the user doesn't have to re-pick the token by hand.
+                const prefillInstrument = (req: TokenRequestInfo) => {
+                  const inst = availableInstruments.find(
+                    (i) =>
+                      i.instrument_admin === req.instrument_admin &&
+                      i.instrument_id === req.instrument_id,
+                  );
+                  if (inst) setProposalInstrumentConfigurationCid(inst.contract_id);
+                };
                 return (
                   <>
-                    <FormControl size="small" fullWidth required>
-                      <InputLabel>
-                        <TextHelp
-                          text={
-                            isMint
-                              ? "MintRequest contract created by the holder that this proposal will accept."
-                              : "BurnRequest contract created by the holder that this proposal will accept."
+                    <Autocomplete
+                      size="small"
+                      freeSolo
+                      options={requestContracts}
+                      value={requestCid}
+                      loading={requestsLoading}
+                      onChange={(_event, value) => {
+                        if (typeof value === "string" || value === null) {
+                          setRequestCid(value ?? "");
+                        } else {
+                          setRequestCid(value.contract_id);
+                          prefillInstrument(value);
+                        }
+                      }}
+                      onInputChange={(_event, value, reason) => {
+                        if (reason === "input") setRequestCid(value);
+                      }}
+                      getOptionLabel={(option) => {
+                        if (typeof option === "string") return option;
+                        const holderName = option.holder.split("::")[0];
+                        const amount = option.amount.replace(/\.?0+$/, "");
+                        const cidTail = option.contract_id.slice(-8);
+                        return `${holderName} → ${amount} ${option.instrument_id} (…${cidTail})`;
+                      }}
+                      getOptionDisabled={(option) => {
+                        if (typeof option === "string") return false;
+                        const exp = option.expires_at ?? 0;
+                        return exp > 0 && exp <= Math.floor(Date.now() / 1000);
+                      }}
+                      isOptionEqualToValue={(option, value) =>
+                        typeof value === "string"
+                          ? option.contract_id === value
+                          : option.contract_id === value.contract_id
+                      }
+                      renderOption={(props, option) => {
+                        if (typeof option === "string") {
+                          return <li {...props}>{option}</li>;
+                        }
+                        const holderName = option.holder.split("::")[0];
+                        const amount = option.amount.replace(/\.?0+$/, "");
+                        const cidTail = option.contract_id.slice(-8);
+                        const exp = option.expires_at ?? 0;
+                        const isExpired =
+                          exp > 0 && exp <= Math.floor(Date.now() / 1000);
+                        return (
+                          <li {...props} key={option.contract_id}>
+                            <Box
+                              sx={{
+                                display: "flex",
+                                flexDirection: "column",
+                                gap: 0.25,
+                                opacity: isExpired ? 0.6 : 1,
+                              }}
+                            >
+                              <Typography variant="body2">
+                                {holderName} →{" "}
+                                <Box
+                                  component="span"
+                                  sx={{ color: accentColor, fontWeight: 600 }}
+                                >
+                                  {amount} {option.instrument_id}
+                                </Box>{" "}
+                                (…{cidTail})
+                              </Typography>
+                              {isExpired && (
+                                <Typography variant="caption" color="warning.main">
+                                  Expired {new Date(exp * 1000).toLocaleString()}
+                                </Typography>
+                              )}
+                            </Box>
+                          </li>
+                        );
+                      }}
+                      renderInput={(params) => (
+                        <TextField
+                          {...params}
+                          label={
+                            <TextHelp
+                              text={
+                                isMint
+                                  ? "MintRequest contract created by the holder that this proposal will accept."
+                                  : "BurnRequest contract created by the holder that this proposal will accept."
+                              }
+                            >
+                              {requestLabel}
+                            </TextHelp>
                           }
-                        >
-                          {requestLabel}
-                        </TextHelp>
-                      </InputLabel>
-                      <Select
-                        label={requestLabel}
-                        value={requestCid}
-                        onChange={(e) => setRequestCid(e.target.value)}
-                        MenuProps={{ disableScrollLock: true }}
-                      >
-                        {requestContracts.length > 0 ? (
-                          requestContracts.map((c) => (
-                            <MenuItem key={c.contract_id} value={c.contract_id}>
-                              {c.contract_id.slice(0, 16)}…
-                            </MenuItem>
-                          ))
-                        ) : (
-                          <MenuItem disabled>
-                            No {requestLabel} contracts found — holder must create one first
-                          </MenuItem>
-                        )}
-                      </Select>
-                    </FormControl>
-                    <FormControl size="small" fullWidth required>
+                          required
+                          helperText={
+                            requestsLoading
+                              ? `Loading open ${isMint ? "mint" : "burn"} requests…`
+                              : requestContracts.length === 0
+                                ? `No ${requestLabel} contracts found — holder must create one first`
+                                : "Pick an open request, or paste a contract id"
+                          }
+                        />
+                      )}
+                    />
+                    <FormControl size="small" fullWidth required disabled>
                       <InputLabel>
-                        <TextHelp text="Instrument the request was made against. Usually the one referenced by the selected request.">
+                        <TextHelp text="Instrument the request was made against. Derived automatically from the selected request.">
                           Instrument
                         </TextHelp>
                       </InputLabel>

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -40,17 +40,6 @@ export const TEMPLATE_REGISTRAR_SERVICE = {
   module: "Utility.Registry.App.V0.Service.Registrar",
   entity: "RegistrarService",
 };
-export const TEMPLATE_MINT_REQUEST = {
-  package_ref: "#utility-registry-app-v0",
-  module: "Utility.Registry.App.V0.Model.Mint",
-  entity: "MintRequest",
-};
-export const TEMPLATE_BURN_REQUEST = {
-  package_ref: "#utility-registry-app-v0",
-  module: "Utility.Registry.App.V0.Model.Burn",
-  entity: "BurnRequest",
-};
-
 export const DEVNET_VAULT_RULES: DisclosedContract = {
   contract_id:
     "006002aa16790251b09f9332e1d57a1a554ad266cb88cc0d382f82a6afa159d66fca1212202bb3e307bd42ea38da22ba40df796d3febdf761572da0dea03c1388e5250241b",

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -843,6 +843,26 @@ export interface TransferInstructionsResponse {
   transfer_instructions: TransferInstructionInfo[];
 }
 
+/** An open `MintRequest` / `BurnRequest` the governance party can accept.
+ *  Shape is shared between mint and burn — the containing endpoint
+ *  disambiguates. `expires_at` is unix seconds of `executeBefore`. */
+export interface TokenRequestInfo {
+  contract_id: string;
+  holder: string;
+  amount: string;
+  instrument_admin: string;
+  instrument_id: string;
+  expires_at: number;
+}
+
+export interface MintRequestsResponse {
+  mint_requests: TokenRequestInfo[];
+}
+
+export interface BurnRequestsResponse {
+  burn_requests: TokenRequestInfo[];
+}
+
 /** Count of active TransferPreapproval contracts the gov party already has,
  *  split by direction (CC = Canton Coin via Splice; token = via Utility). */
 export interface TransferPreapprovalsResponse {

--- a/src/server/handlers/governance.rs
+++ b/src/server/handlers/governance.rs
@@ -32,23 +32,24 @@ use crate::{
         queries::{
             ContractQueryParams as QueryContractParams, get_governance_confirmations,
             get_governance_state as query_governance_state, get_holdings, get_instruments,
-            get_open_transfer_instructions, get_provider_services, get_registrar_services,
-            get_transfer_factories, get_user_services, get_vaults, query_contracts_by_template,
+            get_open_burn_requests, get_open_mint_requests, get_open_transfer_instructions,
+            get_provider_services, get_registrar_services, get_transfer_factories,
+            get_user_services, get_vaults, query_contracts_by_template,
         },
         transfer_context::{
             AcceptTransferContext, ProposeTransferArgs, fetch as fetch_accept_transfer_context,
             fetch_factory_for_propose, maybe_fetch_for_proposal, to_proto_disclosed_contracts,
         },
         types::{
-            AuditLogEntry, AuditLogQuery, AuditLogResponse, CancelConfirmationRequest,
-            ChainAuditEntry, ChainAuditQuery, ChainAuditResponse, ConfirmActionRequest,
-            ContractQueryResponse, ErrorResponse, ExecuteActionRequest, ExpireConfirmationRequest,
-            GovernanceResponse, GovernanceStateResponse, GovernanceType, HoldingsResponse,
-            InstrumentsResponse, KnownMember, KnownMembersResponse, MessageResponse, NetworkInfo,
-            OperatorInfo, ProposalType, ProposeActionRequest, ProviderServicesResponse,
-            RegistrarServicesResponse, TransferFactoriesResponse, TransferFactoryInfo,
-            TransferInstructionsResponse, TransferPreapprovalsResponse, UserServicesResponse,
-            VaultsResponse,
+            AuditLogEntry, AuditLogQuery, AuditLogResponse, BurnRequestsResponse,
+            CancelConfirmationRequest, ChainAuditEntry, ChainAuditQuery, ChainAuditResponse,
+            ConfirmActionRequest, ContractQueryResponse, ErrorResponse, ExecuteActionRequest,
+            ExpireConfirmationRequest, GovernanceResponse, GovernanceStateResponse, GovernanceType,
+            HoldingsResponse, InstrumentsResponse, KnownMember, KnownMembersResponse,
+            MessageResponse, MintRequestsResponse, NetworkInfo, OperatorInfo, ProposalType,
+            ProposeActionRequest, ProviderServicesResponse, RegistrarServicesResponse,
+            TransferFactoriesResponse, TransferFactoryInfo, TransferInstructionsResponse,
+            TransferPreapprovalsResponse, UserServicesResponse, VaultsResponse,
         },
     },
     utils,
@@ -465,6 +466,66 @@ pub async fn get_transfer_instructions_handler(
             tracing::error!("Failed to fetch transfer instructions: {e}");
             HttpResponse::InternalServerError().json(ErrorResponse {
                 error: format!("Failed to fetch transfer instructions: {e}"),
+            })
+        }
+    }
+}
+
+/// Open `MintRequest` contracts the governance party can accept. Returns
+/// typed fields (holder, amount, instrument) so the Accept Mint Request
+/// dropdown can surface a human-readable label instead of just the cid.
+#[utoipa::path(
+    tag = "Services",
+    params(GovernanceQuery),
+    responses(
+        (status = 200, description = "Open mint requests", body = MintRequestsResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse),
+    )
+)]
+#[get("/governance/mint-requests")]
+pub async fn get_mint_requests_handler(
+    data: web::Data<AppState>,
+    query: web::Query<GovernanceQuery>,
+) -> impl Responder {
+    let party_id = &query.party_id;
+    let token = get_party_token(&data, party_id).await;
+    let packages = packages();
+
+    match get_open_mint_requests(&data.config, party_id, token, &packages).await {
+        Ok(mint_requests) => HttpResponse::Ok().json(MintRequestsResponse { mint_requests }),
+        Err(e) => {
+            tracing::error!("Failed to fetch mint requests: {e}");
+            HttpResponse::InternalServerError().json(ErrorResponse {
+                error: format!("Failed to fetch mint requests: {e}"),
+            })
+        }
+    }
+}
+
+/// Open `BurnRequest` contracts. Mirrors `/governance/mint-requests`.
+#[utoipa::path(
+    tag = "Services",
+    params(GovernanceQuery),
+    responses(
+        (status = 200, description = "Open burn requests", body = BurnRequestsResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse),
+    )
+)]
+#[get("/governance/burn-requests")]
+pub async fn get_burn_requests_handler(
+    data: web::Data<AppState>,
+    query: web::Query<GovernanceQuery>,
+) -> impl Responder {
+    let party_id = &query.party_id;
+    let token = get_party_token(&data, party_id).await;
+    let packages = packages();
+
+    match get_open_burn_requests(&data.config, party_id, token, &packages).await {
+        Ok(burn_requests) => HttpResponse::Ok().json(BurnRequestsResponse { burn_requests }),
+        Err(e) => {
+            tracing::error!("Failed to fetch burn requests: {e}");
+            HttpResponse::InternalServerError().json(ErrorResponse {
+                error: format!("Failed to fetch burn requests: {e}"),
             })
         }
     }

--- a/src/server/handlers/mod.rs
+++ b/src/server/handlers/mod.rs
@@ -10,9 +10,10 @@ mod workflows;
 pub use auth::{get_auth_config, get_auth_status, grant_rights, test_auth};
 pub use config::{get_network_config, get_node_config, save_network_config};
 pub use governance::{
-    cancel_confirmation, confirm_action, execute_action, expire_confirmation, get_governance,
-    get_governance_audit, get_governance_chain_audit, get_governance_state, get_holdings_handler,
-    get_instruments_handler, get_known_members, get_network_info, get_operator_info, get_packages,
+    cancel_confirmation, confirm_action, execute_action, expire_confirmation,
+    get_burn_requests_handler, get_governance, get_governance_audit, get_governance_chain_audit,
+    get_governance_state, get_holdings_handler, get_instruments_handler, get_known_members,
+    get_mint_requests_handler, get_network_info, get_operator_info, get_packages,
     get_provider_services_handler, get_registrar_services_handler, get_token_standard_contracts,
     get_transfer_factories_handler, get_transfer_instructions_handler,
     get_transfer_preapprovals_handler, get_user_services_handler, get_vaults_handler,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1319,6 +1319,8 @@ pub async fn start_server(
             .service(handlers::get_registrar_services_handler)
             .service(handlers::get_instruments_handler)
             .service(handlers::get_transfer_instructions_handler)
+            .service(handlers::get_mint_requests_handler)
+            .service(handlers::get_burn_requests_handler)
             .service(handlers::get_transfer_preapprovals_handler)
             .service(handlers::get_transfer_factories_handler)
             .service(handlers::get_holdings_handler)

--- a/src/server/queries.rs
+++ b/src/server/queries.rs
@@ -29,7 +29,7 @@ use super::{
     types::{
         AcceptTransferDetails, ActionType, ContractInfo, ContractWithBlob, DomainGovernanceAction,
         GovernanceAction, GovernanceConfirmation, GovernanceState, HoldingInfo, InstrumentInfo,
-        PartyMetadata, PendingAction, ProviderServiceInfo, RegistrarServiceInfo,
+        PartyMetadata, PendingAction, ProviderServiceInfo, RegistrarServiceInfo, TokenRequestInfo,
         TransferFactoryInfo, TransferInstructionInfo, TransferInstructionStatus,
         TransferProposalDetails, UserServiceInfo, VaultInfo,
     },
@@ -2927,6 +2927,191 @@ fn extract_transfer_instruction_info(created: &CreatedEvent) -> Option<TransferI
         pending_actions,
         expires_at,
     })
+}
+
+/// Fetch active `MintRequest` contracts (`Utility.Registry.App.V0.Model.Mint`)
+/// visible to `party_id`. Past-deadline contracts are dropped so the Accept
+/// dropdown only offers requests that would still succeed at interpretation.
+pub async fn get_open_mint_requests(
+    config: &NodeConfig,
+    party_id: &CantonId,
+    token: Option<String>,
+    packages: &PackageConfig,
+) -> Result<Vec<TokenRequestInfo>> {
+    let Some(pkg) = packages.utility_registry.as_ref() else {
+        return Ok(Vec::new());
+    };
+    fetch_token_requests_for_template(
+        config,
+        party_id,
+        token,
+        &TemplateId {
+            package_id: pkg.clone(),
+            module_name: "Utility.Registry.App.V0.Model.Mint",
+            entity_name: "MintRequest",
+        },
+        "mint",
+    )
+    .await
+}
+
+/// Fetch active `BurnRequest` contracts. Mirrors `get_open_mint_requests`.
+pub async fn get_open_burn_requests(
+    config: &NodeConfig,
+    party_id: &CantonId,
+    token: Option<String>,
+    packages: &PackageConfig,
+) -> Result<Vec<TokenRequestInfo>> {
+    let Some(pkg) = packages.utility_registry.as_ref() else {
+        return Ok(Vec::new());
+    };
+    fetch_token_requests_for_template(
+        config,
+        party_id,
+        token,
+        &TemplateId {
+            package_id: pkg.clone(),
+            module_name: "Utility.Registry.App.V0.Model.Burn",
+            entity_name: "BurnRequest",
+        },
+        "burn",
+    )
+    .await
+}
+
+async fn fetch_token_requests_for_template(
+    config: &NodeConfig,
+    party_id: &CantonId,
+    token: Option<String>,
+    template: &TemplateId,
+    payload_field: &str,
+) -> Result<Vec<TokenRequestInfo>> {
+    let mut state_client = utils::create_state_client(config, token).await?;
+
+    let ledger_end = state_client
+        .get_ledger_end(tonic::Request::new(GetLedgerEndRequest {}))
+        .await?
+        .into_inner()
+        .offset;
+
+    let mut filters_by_party = HashMap::new();
+    filters_by_party.insert(
+        party_id.to_string(),
+        Filters {
+            cumulative: vec![CumulativeFilter {
+                identifier_filter: Some(cumulative_filter::IdentifierFilter::TemplateFilter(
+                    TemplateFilter {
+                        template_id: Some(Identifier {
+                            package_id: template.package_id.clone(),
+                            module_name: template.module_name.to_string(),
+                            entity_name: template.entity_name.to_string(),
+                        }),
+                        include_created_event_blob: false,
+                    },
+                )),
+            }],
+        },
+    );
+
+    let acs_request = GetActiveContractsRequest {
+        active_at_offset: ledger_end,
+        event_format: Some(EventFormat {
+            filters_by_party,
+            filters_for_any_party: None,
+            verbose: true,
+        }),
+    };
+
+    let mut stream = state_client
+        .get_active_contracts(tonic::Request::new(acs_request))
+        .await?
+        .into_inner();
+
+    let mut requests = Vec::new();
+    while let Some(response) = stream.message().await? {
+        if let Some(ContractEntry::ActiveContract(active)) = response.contract_entry
+            && let Some(created) = active.created_event
+            && !is_execute_before_expired_in_payload(&created, payload_field)
+            && let Some(info) = extract_token_request_info(&created, payload_field)
+        {
+            requests.push(info);
+        }
+    }
+
+    Ok(requests)
+}
+
+/// Extract `{holder, amount, instrumentId.{admin,id}, executeBefore}` from a
+/// MintRequest/BurnRequest created event. `payload_field` is `"mint"` or
+/// `"burn"` — the nested record wrapping the shared `Mint`/`Burn` payload.
+fn extract_token_request_info(
+    created: &CreatedEvent,
+    payload_field: &str,
+) -> Option<TokenRequestInfo> {
+    let record = created.create_arguments.as_ref()?;
+    let payload = record
+        .fields
+        .iter()
+        .find(|f| f.label == payload_field)
+        .and_then(|f| f.value.as_ref())
+        .and_then(|v| match &v.sum {
+            Some(value::Sum::Record(r)) => Some(r),
+            _ => None,
+        })?;
+
+    let holder: CantonId = field_party(payload, "holder")?.parse().ok()?;
+    let amount = field_numeric(payload, "amount").and_then(|s| DamlDecimal::parse(&s).ok())?;
+
+    let instrument_record = payload
+        .fields
+        .iter()
+        .find(|f| f.label == "instrumentId")
+        .and_then(|f| f.value.as_ref())
+        .and_then(|v| match &v.sum {
+            Some(value::Sum::Record(r)) => Some(r),
+            _ => None,
+        })?;
+    let instrument_admin: CantonId = field_party(instrument_record, "admin")?.parse().ok()?;
+    let instrument_id = field_text(instrument_record, "id")?;
+
+    let expires_at = field_timestamp(payload, "executeBefore")? / 1_000_000;
+
+    Some(TokenRequestInfo {
+        contract_id: created.contract_id.clone(),
+        holder,
+        amount,
+        instrument_admin,
+        instrument_id,
+        expires_at,
+    })
+}
+
+/// Same as `is_execute_before_expired`, but looks inside the nested `mint`/
+/// `burn` payload record where MintRequest/BurnRequest carry their deadline.
+fn is_execute_before_expired_in_payload(created: &CreatedEvent, payload_field: &str) -> bool {
+    let Some(record) = created.create_arguments.as_ref() else {
+        return false;
+    };
+    let Some(payload) = record
+        .fields
+        .iter()
+        .find(|f| f.label == payload_field)
+        .and_then(|f| f.value.as_ref())
+        .and_then(|v| match &v.sum {
+            Some(value::Sum::Record(r)) => Some(r),
+            _ => None,
+        })
+    else {
+        return false;
+    };
+    let Some(execute_before_micros) = field_timestamp(payload, "executeBefore") else {
+        return false;
+    };
+    let now_micros = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_micros() as i64)
+        .unwrap_or(0);
+    execute_before_micros <= now_micros
 }
 
 /// Decode the `pendingActions :: Map Party Text` payload of

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -1567,6 +1567,35 @@ pub struct TransferInstructionsResponse {
     pub transfer_instructions: Vec<TransferInstructionInfo>,
 }
 
+/// An open `MintRequest`/`BurnRequest` (`Utility.Registry.App.V0.Model.{Mint,Burn}`)
+/// the governance party can accept. The shape is identical for both kinds; the
+/// containing endpoint disambiguates. `expires_at` is read off the inner
+/// `mint`/`burn` payload's `executeBefore` field so the dropdown can disable
+/// past-deadline rows.
+#[derive(Clone, Debug, Serialize, utoipa::ToSchema)]
+pub struct TokenRequestInfo {
+    pub contract_id: String,
+    pub holder: CantonId,
+    #[schema(value_type = String)]
+    pub amount: DamlDecimal,
+    pub instrument_admin: CantonId,
+    pub instrument_id: String,
+    /// Unix seconds of the request's `executeBefore` deadline.
+    pub expires_at: i64,
+}
+
+/// Response for the mint-requests endpoint.
+#[derive(Serialize, utoipa::ToSchema)]
+pub struct MintRequestsResponse {
+    pub mint_requests: Vec<TokenRequestInfo>,
+}
+
+/// Response for the burn-requests endpoint.
+#[derive(Serialize, utoipa::ToSchema)]
+pub struct BurnRequestsResponse {
+    pub burn_requests: Vec<TokenRequestInfo>,
+}
+
 /// A token-standard Holding owned by a decentralized party, aggregated across
 /// every active `Splice.Api.Token.HoldingV1:Holding` contract that shares the
 /// same `(instrument_admin, instrument_id)` pair.


### PR DESCRIPTION
## Summary

Makes the **Accept Mint Request** / **Accept Burn Request** proposal dropdowns readable, mirroring the existing Accept Transfer UX. Previously they listed only a truncated contract id (`0016761d83b8f764…`), so it was unclear which token, amount, and holder a request was for.

## Changes

**Backend**
- New `/governance/mint-requests` and `/governance/burn-requests` endpoints returning typed `TokenRequestInfo` rows (`holder`, `amount`, `instrument_admin`, `instrument_id`, `expires_at`) parsed from the `MintRequest`/`BurnRequest` payloads (`Utility.Registry.App.V0.Model.{Mint,Burn}`).
- Past-deadline requests (`executeBefore`) are dropped server-side.

**Frontend**
- Mint/burn request fields are now Autocompletes showing `holder → amount instrument (…cid)` instead of a raw cid.
- Selecting a request **auto-fills** the matching Instrument; the Instrument field is now read-only (derived from the request).
- Dropdown options color the amount + token name — green for mint, red for burn.

## Notes
- `frontend/dist/` is gitignored; rebuild the frontend so the embedded bundle (rust-embed) picks up the changes.