### PR TITLE
chore(repo): prepare repository for open source

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,58 @@
+name: Bug report
+description: Report a problem with dec-party-manager
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report. Please do not report
+        security vulnerabilities here — see the Security Policy instead.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, including what you expected to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps that reproduce the behaviour.
+      placeholder: |
+        1. Start the node with ...
+        2. Call endpoint ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version / commit
+      description: Release version or git commit SHA.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, Rust version, deployment method (binary / Docker / Kubernetes), and Canton network (devnet / testnet / mainnet).
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Paste any relevant log output. Redact secrets and tokens first.
+      render: shell
+    validations:
+      required: false
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Confirmation
+      options:
+        - label: I searched existing issues and this is not a duplicate.
+          required: true
+        - label: This is not a security vulnerability (those are reported privately).
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/DLC-link/dec-party-manager/security/advisories/new
+    about: Please report vulnerabilities privately — do not open a public issue.
+  - name: Documentation
+    url: https://github.com/DLC-link/dec-party-manager/tree/main/docs
+    about: Architecture, integration, use-case, and contributing guides.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,39 @@
+name: Feature request
+description: Suggest an idea or enhancement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What problem does this solve? What are you trying to do?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe the change or feature you'd like.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you've thought about, if any.
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Any other context, references, or screenshots.
+    validations:
+      required: false
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Confirmation
+      options:
+        - label: I searched existing issues and this is not a duplicate.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+<!-- Thanks for contributing! Please fill out the sections below. -->
+
+## Summary
+
+<!-- What does this PR do and why? -->
+
+## Related issues
+
+<!-- e.g. Closes #123 -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor
+- [ ] Documentation
+- [ ] Build / CI / chore
+
+## Checklist
+
+- [ ] `cargo fmt -- --check` passes
+- [ ] `cargo clippy --all-targets --all-features -- -D warnings` is clean
+- [ ] `cargo test` passes
+- [ ] Added/updated tests where appropriate
+- [ ] Updated documentation where appropriate
+- [ ] Commits follow the `<type>(<scope>): <subject>` convention
+
+## Notes for reviewers
+
+<!-- Anything reviewers should focus on, trade-offs, follow-ups, etc. -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -410,7 +410,7 @@ For tests that require database access, use the `#[sqlx::test]` macro with a mig
 
 ```toml
 [dependencies]
-sqlx = { version = "0.8", features = ["any", "chrono", "postgres", "runtime-tokio-rustls", "uuid"] }
+sqlx = { version = "0.8", default-features = false, features = ["macros", "migrate", "runtime-tokio-rustls", "sqlite"] }
 ```
 
 2. Create a migrations directory with numbered SQL files:
@@ -438,14 +438,14 @@ mod tests {
     use super::*;
 
     #[sqlx::test(migrator = "MIGRATOR")]
-    async fn test_insert_user(pool: PgPool) -> Result {
+    async fn test_insert_user(pool: SqlitePool) -> Result {
         // Arrange
         let username = "alice";
         let email = "alice@example.com";
 
         // Act
         sqlx::query!(
-            "INSERT INTO users (username, email) VALUES ($1, $2)",
+            "INSERT INTO users (username, email) VALUES (?, ?)",
             username,
             email
         )
@@ -453,7 +453,7 @@ mod tests {
         .await?;
 
         // Assert
-        let user = sqlx::query!("SELECT username, email FROM users WHERE username = $1", username)
+        let user = sqlx::query!("SELECT username, email FROM users WHERE username = ?", username)
             .fetch_one(&pool)
             .await?;
 
@@ -480,7 +480,7 @@ static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./migrations");
 
 // In your module (e.g., src/storage/tables/contracts.rs)
 use anyhow::Context;
-use sqlx::PgPool;
+use sqlx::SqlitePool;
 
 use crate::error::Result;
 
@@ -492,9 +492,9 @@ pub struct Contract {
 }
 
 impl Contract {
-    pub async fn insert(&self, pool: &PgPool) -> Result {
+    pub async fn insert(&self, pool: &SqlitePool) -> Result {
         sqlx::query!(
-            "INSERT INTO contracts (contract_id, template_id, created_at) VALUES ($1, $2, $3)",
+            "INSERT INTO contracts (contract_id, template_id, created_at) VALUES (?, ?, ?)",
             self.contract_id,
             self.template_id,
             self.created_at
@@ -506,10 +506,10 @@ impl Contract {
         Ok(())
     }
 
-    pub async fn get_all(pool: &PgPool, limit: i64, offset: i64) -> Result<Vec<Self>> {
+    pub async fn get_all(pool: &SqlitePool, limit: i64, offset: i64) -> Result<Vec<Self>> {
         sqlx::query_as!(
             Self,
-            "SELECT contract_id, template_id, created_at FROM contracts LIMIT $1 OFFSET $2",
+            "SELECT contract_id, template_id, created_at FROM contracts LIMIT ? OFFSET ?",
             limit,
             offset
         )
@@ -526,7 +526,7 @@ mod tests {
     use super::*;
 
     #[sqlx::test(migrator = "MIGRATOR")]
-    async fn test_get_all(pool: PgPool) -> Result {
+    async fn test_get_all(pool: SqlitePool) -> Result {
         // Test with empty database (migrations have run)
         let contracts = Contract::get_all(&pool, 100, 0).await?;
         assert_eq!(contracts.len(), 0);
@@ -535,7 +535,7 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
-    async fn test_insert_and_retrieve(pool: PgPool) -> Result {
+    async fn test_insert_and_retrieve(pool: SqlitePool) -> Result {
         // Insert test data
         let contract = Contract {
             contract_id: "test-123".to_string(),

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "dec-party-manager"
 version = "0.1.7"
 edition = "2024"
+license = "Apache-2.0"
 
 [profile.release]
 opt-level = 3

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,6 @@
+Canton Decentralized Party Manager
+Copyright 2026 BitSafe Finance
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this software except in compliance with the License.
+A copy of the License is provided in the LICENSE file in this repository.

--- a/README.md
+++ b/README.md
@@ -595,4 +595,4 @@ docker push public.ecr.aws/your-repo/dec-party-manager:v1.0.0
 
 ## License
 
-Proprietary - All rights reserved.
+Licensed under the [Apache License 2.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ A web application for managing decentralized parties in Canton blockchain networ
 
 - [Architecture Overview](docs/ARCHITECTURE.md) -- System architecture, core concepts, communication protocol, and technical constraints
 - [Integration Guide](docs/INTEGRATION_GUIDE.md) -- Deployment, configuration, authentication setup, and full API reference
+- [User Guide](USER_GUIDE.md) -- Walkthrough of the web UI for day-to-day party and governance operations
+- [Custom DAML Templates](docs/CUSTOM_DAML_TEMPLATES.md) -- Authoring and deploying your own DAML governance templates
+- [Migration Guide](docs/MIGRATION_GUIDE.md) -- Upgrading between versions and migrating existing deployments
 - [Use Cases](docs/USE_CASES.md) -- Vault governance, FAR rewards, multi-sig wallet, and utility service walkthroughs
 - [Contributing Guide](docs/CONTRIBUTING.md) -- Development setup, coding standards, commit conventions, and the PR process
 
@@ -117,8 +120,7 @@ participant-dir/
 └── data/
     ├── noise.key      # Auto-generated Noise keypair
     ├── decpm.db       # SQLite database (peers, party credentials)
-    ├── dars/          # DAR files for contract deployment
-    └── workflow-data/ # Workflow data (proposals, signatures, etc.)
+    └── dars/          # DAR files for contract deployment
 ```
 
 The database file path can be overridden with the `--db` CLI flag.
@@ -127,6 +129,13 @@ The database file path can be overridden with the `--db` CLI flag.
 
 | Variable | Description | Default |
 |----------|-------------|---------|
+| `DECPM_DIR` | Root directory for persistent data (`--dir`/`-d`) | `.` |
+| `DECPM_HOST` | Host address to bind the HTTP/UI server to | `0.0.0.0` |
+| `DECPM_PORT` | Port for the HTTP/UI server | `8080` |
+| `DECPM_DB_PATH` | SQLite database path override (CLI flag `--db`) | _(defaults to `{dir}/data/decpm.db`)_ |
+| `DECPM_DB_ENCRYPTION_KEY` | Encryption key for secrets stored in the database | _(none)_ |
+| `DECPM_ADMIN_ROLE` | Role name that gates sensitive endpoints (unset skips the role check) | _(none)_ |
+| `DECPM_ALLOWED_ORIGIN` | Origin permitted by CORS (e.g. `https://dpm.example.com`) | _(none, same-origin only)_ |
 | `DECPM_LISTEN_ADDRESS` | Address to listen on for Noise protocol connections | `0.0.0.0` |
 | `DECPM_NOISE_PORT` | Port for Noise protocol connections | `9000` |
 | `DECPM_PUBLIC_ADDRESS` | Public address that peers use to connect to this node | _(falls back to listen address)_ |
@@ -146,6 +155,9 @@ The database file path can be overridden with the `--db` CLI flag.
 | `DECPM_TIMEOUT_MESSAGE` | Noise message timeout in seconds | `120` |
 | `DECPM_TIMEOUT_RETRY_ATTEMPTS` | Connection retry attempts | `3` |
 | `DECPM_TIMEOUT_RETRY_DELAY` | Connection retry delay in seconds | `5` |
+| `DECPM_NOISE_RETRY_TIMEOUT_SEC` | Per-attempt timeout for the bounded peer-Noise retry wrapper, in seconds | `5` |
+| `DECPM_NOISE_RETRY_MAX_ATTEMPTS` | Total attempts (initial + retries) for the bounded peer-Noise retry wrapper | `2` |
+| `DECPM_NOISE_RETRY_BACKOFF_MS` | Backoff between attempts of the bounded peer-Noise retry wrapper, in milliseconds | `250` |
 
 All environment variables can also be passed as CLI arguments (e.g., `--canton-admin-host`).
 
@@ -271,10 +283,15 @@ curl http://localhost:8081/party-config/decparty::1220abc...
 
 ## API Endpoints
 
+The table below is a curated subset. The authoritative, complete API reference is the live **Swagger UI at `/swagger-ui/`** (OpenAPI document at `/api-docs/openapi.json`).
+
 | Endpoint | Method | Description |
 |----------|--------|-------------|
 | `/` | GET | Serves the React frontend |
+| `/auth-config` | GET | Returns frontend auth configuration (Keycloak or Auth0) |
 | `/node-config` | GET | Returns node configuration |
+| `/network-info` | GET | Returns network info (DSO party, AmuletRules contract) |
+| `/operator-info` | GET | Returns DA Utility operator info |
 | `/network-config` | GET | Returns network peer list (from SQLite) |
 | `/network-config` | POST | Updates network peer list (saved to SQLite) |
 | `/party-config/{dec_party_id}` | GET | Returns party credentials (secrets masked) |
@@ -288,6 +305,13 @@ curl http://localhost:8081/party-config/decparty::1220abc...
 | `/contracts/status` | GET | Returns contracts progress |
 | `/kick` | POST | Starts kick workflow |
 | `/kick/status` | GET | Returns kick progress |
+| `/workflows` | GET | Lists workflow instances and their lifecycle state |
+| `/workflows/{instance_name}/dismiss` | POST | Dismisses a workflow instance |
+| `/workflows/{instance_name}/retry` | POST | Retries a failed workflow instance |
+| `/onboarding/cancel` | POST | Cancels the onboarding workflow |
+| `/contracts/cancel` | POST | Cancels the contracts workflow |
+| `/kick/cancel` | POST | Cancels the kick workflow |
+| `/dars/cancel` | POST | Cancels the DARs distribution workflow |
 | `/invitations` | GET | Returns pending workflow invitations |
 | `/invitations/accept` | POST | Accepts a pending invitation |
 | `/invitations/decline` | POST | Declines a pending invitation |
@@ -305,7 +329,6 @@ curl http://localhost:8081/party-config/decparty::1220abc...
 | `/services/registrar` | GET | Returns RegistrarService contracts |
 | `/contracts/query` | GET | Queries active contracts by template |
 | `/packages` | GET | Returns configured package IDs for a party |
-| `/amulet-rules` | GET | Returns AmuletRules contract |
 | `/token-standard-contracts` | POST | Queries token standard contracts |
 | `/dars/upload` | POST | Uploads DARs to the current node only |
 | `/dars/distribute` | POST | Distributes DARs across all participants |
@@ -588,11 +611,13 @@ Build and push to ECR:
 docker build -t dec-party-manager .
 
 # Tag for ECR
-docker tag dec-party-manager:latest public.ecr.aws/your-repo/dec-party-manager:v1.0.0
+docker tag dec-party-manager:latest public.ecr.aws/dlc-link/canton-decparty-manager:<version>
 
 # Push
-docker push public.ecr.aws/your-repo/dec-party-manager:v1.0.0
+docker push public.ecr.aws/dlc-link/canton-decparty-manager:<version>
 ```
+
+Replace the registry/org (`public.ecr.aws/dlc-link`) and `<version>` with your own.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A web application for managing decentralized parties in Canton blockchain networ
 - [Architecture Overview](docs/ARCHITECTURE.md) -- System architecture, core concepts, communication protocol, and technical constraints
 - [Integration Guide](docs/INTEGRATION_GUIDE.md) -- Deployment, configuration, authentication setup, and full API reference
 - [Use Cases](docs/USE_CASES.md) -- Vault governance, FAR rewards, multi-sig wallet, and utility service walkthroughs
+- [Contributing Guide](docs/CONTRIBUTING.md) -- Development setup, coding standards, commit conventions, and the PR process
 
 ## Architecture
 
@@ -592,6 +593,13 @@ docker tag dec-party-manager:latest public.ecr.aws/your-repo/dec-party-manager:v
 # Push
 docker push public.ecr.aws/your-repo/dec-party-manager:v1.0.0
 ```
+
+## Contributing
+
+Contributions are welcome! See the [Contributing Guide](docs/CONTRIBUTING.md) for
+development setup, coding standards, commit conventions, and the pull request
+process. Please also review our [Code of Conduct](docs/CODE_OF_CONDUCT.md) and,
+for vulnerabilities, our [Security Policy](docs/SECURITY.md).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ curl http://localhost:8081/party-config/decparty::1220abc...
 
 ## API Endpoints
 
-The table below is a curated subset. The authoritative, complete API reference is the live **Swagger UI at `/swagger-ui/`** (OpenAPI document at `/api-docs/openapi.json`).
+The table below is a curated subset. A complete, interactive API reference is available via the **Swagger UI at `/swagger-ui/`** (OpenAPI document at `/api-docs/openapi.json`) — but note these endpoints are only mounted in development/test builds (`--features test-mode`); the shipped release image does not expose them.
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1,202 +1,85 @@
 # Canton Decentralized Party Manager - User Guide
 
+This is an operator quick-start. The application is configured entirely through
+`DECPM_*` environment variables (or a `.env` file placed in the data directory).
+There is **no TOML config file** — every setting is an env var / CLI flag.
+
+For full configuration, authentication (Keycloak / Auth0) setup, and Kubernetes
+deployment, see the [Integration Guide](docs/INTEGRATION_GUIDE.md). For end-to-end
+workflow walkthroughs (onboarding a party, deploying contracts, kicking a
+participant), see the [Use Cases](docs/USE_CASES.md).
+
 ## Quick Start with Docker
 
+Build the image locally, then run a single instance:
+
 ```bash
-docker run -d \
-  --name dec-party-manager \
-  -p 8080:8080 \
-  -p 9000:9000 \
-  -v $(pwd)/config:/config \
-  -v $(pwd)/data:/data \
-  public.ecr.aws/dlc-link/canton-decparty-manager:mainnet-demo
+# Build the image
+docker build -t dec-party-manager .
+
+# Run
+docker run -p 8080:8080 -p 9000:9000 -v ./data:/data \
+  -e DECPM_PORT=8080 \
+  -e DECPM_NOISE_PORT=9000 \
+  -e DECPM_CANTON_ADMIN_HOST=canton-node \
+  -e DECPM_CANTON_ADMIN_PORT=5002 \
+  -e DECPM_CANTON_LEDGER_HOST=canton-node \
+  -e DECPM_CANTON_LEDGER_PORT=5001 \
+  -e DECPM_CANTON_SYNCHRONIZER=global \
+  -e DECPM_CANTON_NETWORK=devnet \
+  dec-party-manager
 ```
 
-Access the web UI at `http://localhost:8080`
+Then open the web UI at `http://localhost:8080`.
+
+The `-v ./data:/data` mount persists the SQLite database (peers, party
+credentials) and the auto-generated Noise keypair across restarts.
 
 ## Configuration
 
-Before running, create a `config/node.toml` file:
+All configuration is supplied via `DECPM_*` environment variables. The key ones:
 
-```toml
-[node]
-# participant_id is auto-resolved from Canton if omitted
-listen_address = "0.0.0.0"
-public_address = "your-public-ip-or-hostname"  # Address other peers will use to connect
-port = 9000
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `DECPM_PORT` | Port for the HTTP / web UI server | `8080` |
+| `DECPM_NOISE_PORT` | Port for the Noise P2P transport | `9000` |
+| `DECPM_CANTON_ADMIN_HOST` | Canton Admin API host | `127.0.0.1` |
+| `DECPM_CANTON_ADMIN_PORT` | Canton Admin API port | `5002` |
+| `DECPM_CANTON_LEDGER_HOST` | Canton Ledger API host | `127.0.0.1` |
+| `DECPM_CANTON_LEDGER_PORT` | Canton Ledger API port | `5001` |
+| `DECPM_CANTON_SYNCHRONIZER` | Canton synchronizer name | `global` |
+| `DECPM_CANTON_NETWORK` | Canton network (`devnet`, `testnet`, `mainnet`) | `devnet` |
 
-[canton]
-admin_api_host = "your-canton-node"
-admin_api_port = 5002
-ledger_api_host = "your-canton-node"
-ledger_api_port = 5001
-synchronizer = "global"
+Instead of `-e` flags, you can place a `.env` file in the data directory. It is
+loaded automatically on startup (before CLI parsing), so any `DECPM_*` key set
+there takes effect:
 
-[timeouts]
-handshake_timeout_secs = 30
-message_timeout_secs = 120
-connection_retry_attempts = 3
-connection_retry_delay_secs = 5
+```env
+DECPM_PORT=8080
+DECPM_NOISE_PORT=9000
+DECPM_CANTON_ADMIN_HOST=canton-node
+DECPM_CANTON_ADMIN_PORT=5002
+DECPM_CANTON_LEDGER_HOST=canton-node
+DECPM_CANTON_LEDGER_PORT=5001
+DECPM_CANTON_SYNCHRONIZER=global
+DECPM_CANTON_NETWORK=devnet
 ```
 
-**Note:** The `public_address` is used when sharing your peer info with others. Set it to your actual reachable IP address or hostname. The `listen_address` should remain `0.0.0.0` to listen on all interfaces. The `participant_id` field is optional and will be auto-resolved from Canton on first startup.
+See the [Integration Guide](docs/INTEGRATION_GUIDE.md) for the complete variable
+reference, authentication configuration, and Kubernetes manifests.
 
 ## Port Requirements
 
 | Port | Purpose |
 |------|---------|
-| 8080 | Web UI and API |
-| 9000 | P2P communication between participants |
+| 8080 | HTTP / web UI (default, `DECPM_PORT`) |
+| 9000 | Noise P2P communication between participants (default, `DECPM_NOISE_PORT`) |
 
-Ensure both ports are accessible. For P2P to work, port 9000 must be reachable by other participants.
+For P2P to work, the Noise port must be reachable by the other participants.
 
-## Kubernetes Deployment
+## Next Steps
 
-```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: dec-party-manager-config
-data:
-  node.toml: |
-    [node]
-    listen_address = "0.0.0.0"
-    public_address = "dec-party-manager.your-namespace.svc.cluster.local"
-    port = 9000
-
-    [canton]
-    admin_api_host = "canton-node"
-    admin_api_port = 5002
-    ledger_api_host = "canton-node"
-    ledger_api_port = 5001
-    synchronizer = "global"
-
-    [timeouts]
-    handshake_timeout_secs = 30
-    message_timeout_secs = 120
-    connection_retry_attempts = 3
-    connection_retry_delay_secs = 5
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: dec-party-manager-data
-spec:
-  accessModes: [ReadWriteOnce]
-  resources:
-    requests:
-      storage: 1Gi
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: dec-party-manager
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: dec-party-manager
-  template:
-    metadata:
-      labels:
-        app: dec-party-manager
-    spec:
-      initContainers:
-        - name: copy-config
-          image: busybox:latest
-          command: ['sh', '-c', 'cp /config-source/* /config/']
-          volumeMounts:
-            - name: config-source
-              mountPath: /config-source
-            - name: data
-              mountPath: /config
-              subPath: config
-      containers:
-        - name: dec-party-manager
-          image: public.ecr.aws/dlc-link/canton-decparty-manager:mainnet-demo
-          ports:
-            - containerPort: 8080
-            - containerPort: 9000
-          volumeMounts:
-            - name: data
-              mountPath: /config
-              subPath: config
-            - name: data
-              mountPath: /data
-              subPath: data
-      volumes:
-        - name: config-source
-          configMap:
-            name: dec-party-manager-config
-        - name: data
-          persistentVolumeClaim:
-            claimName: dec-party-manager-data
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: dec-party-manager
-spec:
-  type: ClusterIP
-  ports:
-    - port: 80
-      targetPort: 8080
-      name: http
-    - port: 9000
-      targetPort: 9000
-      name: p2p
-  selector:
-    app: dec-party-manager
-```
-
-Apply with:
-
-```bash
-kubectl apply -f dec-party-manager.yaml
-```
-
-## Adding Peers
-
-1. Open the web UI
-2. Expand **Network Configuration**
-3. Click **Add Peer**
-4. Paste a CSV row shared by the other participant - the fields will auto-fill:
-   ```
-   participant::1220def...,Participant 2,10.0.0.2,9000,03ab12cd...,
-   ```
-5. Alternatively, fill in the fields manually:
-   - **Participant ID**: Canton participant UID (e.g., `participant::1220...`)
-   - **Name**: Display name
-   - **Address**: IP or hostname
-   - **Port**: P2P port (usually 9000)
-   - **Public Key**: Peer's public key (found in their UI under Node Configuration)
-6. Click **Save**
-
-## Removing a Participant (Kick)
-
-1. Open the web UI
-2. Select the party
-3. Click **Remove Participant**
-4. Select the participant to remove
-5. Confirm
-
-Requires majority approval from remaining participants.
-
-## Troubleshooting
-
-**Peer not connecting:**
-- Verify the peer's address, port, and public key are correct
-- Ensure port 9000 is open on both sides
-
-**Canton connection failed:**
-- Check `admin_api_host` and `ledger_api_host` in `node.toml`
-- Verify Canton node is running and accessible
-
-**View logs:**
-```bash
-# Docker
-docker logs dec-party-manager
-
-# Kubernetes
-kubectl logs deployment/dec-party-manager
-```
+- **Configure peers, authentication, and deploy to Kubernetes** —
+  [Integration Guide](docs/INTEGRATION_GUIDE.md)
+- **Walk through onboarding, deploying contracts, and kicking a participant** —
+  [Use Cases](docs/USE_CASES.md)

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1,7 +1,8 @@
 # Canton Decentralized Party Manager - User Guide
 
 This is an operator quick-start. The application is configured entirely through
-`DECPM_*` environment variables (or a `.env` file placed in the data directory).
+`DECPM_*` environment variables (or a `.env` file placed in the directory given
+by `--dir` / `DECPM_DIR`).
 There is **no TOML config file** — every setting is an env var / CLI flag.
 
 For full configuration, authentication (Keycloak / Auth0) setup, and Kubernetes
@@ -50,9 +51,10 @@ All configuration is supplied via `DECPM_*` environment variables. The key ones:
 | `DECPM_CANTON_SYNCHRONIZER` | Canton synchronizer name | `global` |
 | `DECPM_CANTON_NETWORK` | Canton network (`devnet`, `testnet`, `mainnet`) | `devnet` |
 
-Instead of `-e` flags, you can place a `.env` file in the data directory. It is
-loaded automatically on startup (before CLI parsing), so any `DECPM_*` key set
-there takes effect:
+Instead of `-e` flags, you can place a `.env` file in the directory given by
+`--dir` / `DECPM_DIR` (its root — not the `data/` subfolder). It is loaded
+automatically on startup (before CLI parsing), so any `DECPM_*` key set there
+takes effect:
 
 ```env
 DECPM_PORT=8080

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -691,10 +691,10 @@ The system depends on the following Daml packages:
 
 | Package ID | Purpose |
 |------------|---------|
-| `#governance-core-v1-rc1` | GovernanceRules, GovernableAction interface, GenericVoteProposal |
-| `#governance-token-custody-v1-rc1` | TransferProposal, AcceptTransferProposal, preapproval proposals |
-| `#governance-utility-onboarding-v1-rc1` | SetupUtility, six granular onboarding proposals, MintProposal, BurnProposal |
-| `#governance-utility-credential-v1-rc1` | Credential domain: offer/accept free and paid credentials |
+| `#governance-core-<version>` | GovernanceRules, GovernableAction interface, GenericVoteProposal |
+| `#governance-token-custody-<version>` | TransferProposal, AcceptTransferProposal, preapproval proposals |
+| `#governance-utility-onboarding-<version>` | SetupUtility, six granular onboarding proposals, MintProposal, BurnProposal |
+| `#governance-utility-credential-<version>` | Credential domain: offer/accept free and paid credentials |
 | `#bitsafe-vault-governance-v0-rc8` | Legacy VaultGovernanceRules contract templates |
 | `#bitsafe-vault-v0-rc8` | VaultRules and Vault contract templates |
 | `#utility-registry-app-v0` | ProviderService, UserService, AllocationFactory |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -24,7 +24,7 @@ result = "1220" + hex(hash)   // Multihash SHA-256 prefix
 Key properties:
 - The hash is **immutable** -- it is computed once from the initial set of owners and never changes
 - Owners are sorted lexicographically before hashing for determinism
-- The threshold (minimum signers required) is `floor(n/2) + 1` (strict majority) by default
+- The threshold (minimum signers required) is `ceil(n/2)` by default; for even `n` this is a bare majority
 - Adding or removing members updates the `DecentralizedNamespaceDefinition` mapping but does not change the namespace hash itself
 
 ### PartyToParticipant (P2P)
@@ -41,7 +41,7 @@ The system uses a majority threshold for both topology changes and governance ac
 
 | Operation | Threshold |
 |-----------|-----------|
-| Topology changes (DNS/P2P) | `floor(n/2) + 1` (strict majority) of namespace owners must sign |
+| Topology changes (DNS/P2P) | `ceil(n/2)` of namespace owners must sign (bare majority for even `n`) |
 | Governance actions | Configurable per `GovernanceRules` or `VaultGovernanceRules` contract |
 
 ### Key Types
@@ -204,6 +204,11 @@ Minimum message size: 6 bytes (type + length with zero payload).
 | 0x0008 | GetNextCommand | (empty) | Peer polls for next command |
 | 0x0009 | SignKick | Config + kick proposals | Sign kick topology proposals |
 | 0x000A | Ping | (empty) | Heartbeat ping |
+| 0x000B | ListPackages | (empty) | Request peer's uploaded package list |
+| 0x000C | RequestOwnerKeys | (empty) | Request a peer's namespace owner keys |
+| 0x000D | ListPeers | (empty) | Request a peer's known-peer list |
+| 0x000E | RequestMemberParty | (empty) | Request a peer's member party |
+| 0x000F | Health | (empty) | Health probe |
 
 **Invites (0x0010 - 0x001F):** Sent during heartbeat to invite peers.
 
@@ -213,6 +218,9 @@ Minimum message size: 6 bytes (type + length with zero payload).
 | 0x0011 | InviteKick | Invite to kick workflow |
 | 0x0012 | InviteContracts | Invite to contracts workflow |
 | 0x0013 | InviteDars | Invite to DARs upload workflow |
+| 0x0014 | CancelInvite | Cancel a previously sent invitation |
+| 0x0015 | RetryWorkflow | Coordinator tells peers to retry a failed run |
+| 0x0016 | DeclineInvitation | Peer declines an invitation (frees coordinator's run) |
 
 **Responses (0x0100 - 0x01FF):** Replies from coordinator or peer.
 
@@ -224,6 +232,11 @@ Minimum message size: 6 bytes (type + length with zero payload).
 | 0x0104 | Ready | Peer is ready |
 | 0x0105 | Wait | No command ready, poll again |
 | 0x0106 | Pong | Heartbeat response |
+| 0x0107 | OwnerKeys | Namespace owner keys (reply to RequestOwnerKeys) |
+| 0x0108 | PeerList | Known-peer list (reply to ListPeers) |
+| 0x0109 | MemberPartyResponse | Member party (reply to RequestMemberParty) |
+| 0x010A | HealthResponse | Health status (reply to Health) |
+| 0x010B | Busy | Node is busy with another workflow |
 
 **Data Transfers (0x0200 - 0x02FF):** Peer data uploads to coordinator.
 
@@ -344,13 +357,14 @@ Uploads DAR packages to all participants without deploying contracts.
 
 The governance system provides multi-party approval workflows built on Daml smart contracts. It uses a **modular, interface-based architecture** where a single `GovernanceRules` contract handles consensus logic (threshold validation, confirmation lifecycle) while domain-specific actions are defined as separate templates implementing the `GovernableAction` interface.
 
-The system is split into two Daml packages:
+The system is split into the following Daml packages:
 
 | Package | Purpose |
 |---------|---------|
 | `governance-core` | Core governance engine, interfaces, confirmation lifecycle, generic voting |
 | `governance-token-custody` | Token transfer and preapproval actions |
 | `governance-utility-onboarding` | Utility-registry onboarding actions and token mint / burn |
+| `governance-utility-credential` | Credential domain: offer/accept free and paid credentials |
 
 A legacy `VaultGovernanceRules` contract (from the `bitsafe-vault-governance` package) is also supported for backward compatibility with existing vault deployments.
 
@@ -368,6 +382,8 @@ interface GovernableAction where
     controller (view this).governanceParty
   choice GovernableAction_Cancel : ()
     controller (view this).governanceParty
+  choice GovernableAction_ProposerCancel : ()
+    controller (view this).proposer
 
 data GovernableActionView = GovernableActionView with
     governanceParty : Party    -- The party whose authority is required
@@ -395,7 +411,7 @@ GovernanceRules {
 }
 ```
 
-The `additionalProposers` field (added in `v0-rc4`) lets a committee grant propose-only rights to parties that are not full voting members — for example, an admin console, a monitoring script, or a regulatory officer. The authoritative on-chain proposer set is `members ∪ fromOptional Set.empty additionalProposers`. `GovernanceRules_ConfirmAction` enforces that every proposal's `proposer` is in this set; outsider proposals are rejected at confirm time even if a member tries to confirm them. The two `SelfAction_*AdditionalProposer` variants below mutate this allowlist under the same threshold consensus as committee changes.
+The `additionalProposers` field (added in `v1-rc1`) lets a committee grant propose-only rights to parties that are not full voting members — for example, an admin console, a monitoring script, or a regulatory officer. The authoritative on-chain proposer set is `members ∪ fromOptional Set.empty additionalProposers`. `GovernanceRules_ConfirmAction` enforces that every proposal's `proposer` is in this set; outsider proposals are rejected at confirm time even if a member tries to confirm them. The two `SelfAction_*AdditionalProposer` variants below mutate this allowlist under the same threshold consensus as committee changes.
 
 The contract provides two distinct paths for governance actions:
 
@@ -494,6 +510,8 @@ GovernanceExecutionResult {
 |----------|-------------|-------------|
 | `GenericVoteProposal` | `GenericVote` | Free-text governance vote with no on-chain side effect -- the vote outcome is recorded solely via the `GovernanceExecutionResult` |
 
+The `GenericVoteProposal` template lives in module `Governance.GenericVote` (`daml/governance-core/daml/Governance/GenericVote.daml`), while the `GovernableAction` interface it implements is defined in module `Governance.Action`.
+
 #### governance-token-custody Actions
 
 | Template | Action Label | Description |
@@ -557,9 +575,9 @@ Choices on `VaultGovernanceRules`:
 
 #### Vault Action Types
 
-The vault governance system supports 19 action types across 7 categories:
+The vault governance system supports 21 action types across 7 categories:
 
-**Governance (4 actions):**
+**Governance (6 actions):**
 
 | Action | Parameters | Description |
 |--------|------------|-------------|
@@ -567,6 +585,8 @@ The vault governance system supports 19 action types across 7 categories:
 | `GovernanceRemoveMember` | member, new_threshold | Remove a governance member |
 | `GovernanceSetThreshold` | new_threshold | Change the approval threshold |
 | `GovernanceSetTimeout` | new_timeout_microseconds | Set confirmation expiry timeout |
+| `GovernanceAddAdditionalProposer` | additional_proposer | Grant propose-only rights to a non-member party |
+| `GovernanceRemoveAdditionalProposer` | additional_proposer | Revoke propose-only rights from a party |
 
 **Vault Deployment (2 actions):**
 
@@ -671,9 +691,10 @@ The system depends on the following Daml packages:
 
 | Package ID | Purpose |
 |------------|---------|
-| `#governance-core-v0-rc4` | GovernanceRules, GovernableAction interface, GenericVoteProposal |
-| `#governance-token-custody-v0-rc4` | TransferProposal, AcceptTransferProposal, preapproval proposals |
-| `#governance-utility-onboarding-v0-rc4` | SetupUtility, six granular onboarding proposals, MintProposal, BurnProposal |
+| `#governance-core-v1-rc1` | GovernanceRules, GovernableAction interface, GenericVoteProposal |
+| `#governance-token-custody-v1-rc1` | TransferProposal, AcceptTransferProposal, preapproval proposals |
+| `#governance-utility-onboarding-v1-rc1` | SetupUtility, six granular onboarding proposals, MintProposal, BurnProposal |
+| `#governance-utility-credential-v1-rc1` | Credential domain: offer/accept free and paid credentials |
 | `#bitsafe-vault-governance-v0-rc8` | Legacy VaultGovernanceRules contract templates |
 | `#bitsafe-vault-v0-rc8` | VaultRules and Vault contract templates |
 | `#utility-registry-app-v0` | ProviderService, UserService, AllocationFactory |

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -1,0 +1,61 @@
+# Code of Conduct
+
+## Our pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- Demonstrating empathy and kindness toward other people.
+- Being respectful of differing opinions, viewpoints, and experiences.
+- Giving and gracefully accepting constructive feedback.
+- Accepting responsibility, apologizing to those affected by our mistakes, and
+  learning from the experience.
+- Focusing on what is best for the overall community.
+
+Examples of unacceptable behavior include:
+
+- Harassment of any kind, whether public or private.
+- Personal attacks, insults, or derogatory comments.
+- Demeaning, discriminatory, or otherwise inappropriate conduct.
+- Publishing others' private information without their explicit permission.
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting.
+
+## Enforcement responsibilities
+
+Project maintainers are responsible for clarifying and enforcing these standards
+and will take appropriate and fair corrective action in response to any behavior
+they deem inappropriate, threatening, offensive, or harmful. Maintainers may
+remove, edit, or reject contributions that are not aligned with this Code of
+Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainers at
+`conduct@bitsafe.finance` <!-- TODO: confirm this is a monitored address -->.
+All complaints will be reviewed and investigated promptly and fairly. Maintainers
+are obligated to respect the privacy and security of the reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org), version 2.1,
+available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -49,7 +49,7 @@ an individual is officially representing the community in public spaces.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the project maintainers at
-`conduct@bitsafe.finance` <!-- TODO: confirm this is a monitored address -->.
+`conduct@bitsafe.finance`.
 All complaints will be reviewed and investigated promptly and fairly. Maintainers
 are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -49,7 +49,7 @@ an individual is officially representing the community in public spaces.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the project maintainers at
-`conduct@bitsafe.finance`.
+`eng@bitsafe.finance`.
 All complaints will be reviewed and investigated promptly and fairly. Maintainers
 are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,140 @@
+# Contributing to Canton Decentralized Party Manager
+
+Thanks for your interest in contributing! This document explains how to get set
+up, the conventions we follow, and how to get your change merged.
+
+By participating in this project you agree to abide by our
+[Code of Conduct](CODE_OF_CONDUCT.md). Contributions are accepted under the
+project's [Apache License 2.0](../LICENSE).
+
+## Table of contents
+
+- [Reporting bugs & requesting features](#reporting-bugs--requesting-features)
+- [Reporting security issues](#reporting-security-issues)
+- [Development setup](#development-setup)
+- [Building, testing, and linting](#building-testing-and-linting)
+- [Coding standards](#coding-standards)
+- [Commit & branch conventions](#commit--branch-conventions)
+- [Submitting a pull request](#submitting-a-pull-request)
+
+## Reporting bugs & requesting features
+
+Use the GitHub [issue templates](../.github/ISSUE_TEMPLATE) — they prompt for the
+details we need (reproduction steps, environment, logs). Before opening a new
+issue, please search existing issues to avoid duplicates.
+
+## Reporting security issues
+
+**Do not open a public issue for security vulnerabilities.** Please follow the
+process in [SECURITY.md](SECURITY.md).
+
+## Development setup
+
+### Prerequisites
+
+- **Rust** — recent stable toolchain (the crate uses edition 2024, Rust ≥ 1.85).
+- **Node.js** — `^20.19.0 || >=22.12.0` (the React frontend is built automatically by `build.rs`).
+- **Docker** — required to run the full integration test (boots a Splice localnet).
+- **Daml** — the `dpm` CLI (Daml SDK `3.4.11`); **Java 17+** is required for Daml tests.
+- Access to the Canton ledger/admin APIs of a participant node for running the app against a live network (optional for most code changes).
+
+> **Note:** some Rust dependencies (`canton-common`, `canton-proto-rs`,
+> `canton-registry`, `keycloak`) are currently consumed from a separate
+> repository. See the README for the dependency source and access requirements.
+
+### Repository layout
+
+- `src/` — Rust application (HTTP server, Noise P2P, Canton gRPC, workflows).
+- `frontend/` — React + Vite UI (embedded into the binary at build time).
+- `daml/` — Daml governance packages and tests.
+- `migrations/` — SQLx database migrations.
+- `integration-tests/` — end-to-end test harness and scripts.
+- `docs/` — architecture, integration, and use-case documentation.
+
+## Building, testing, and linting
+
+```bash
+# Debug / release build (the frontend is built automatically via build.rs)
+cargo build
+cargo build --release
+
+# Run unit tests (includes the integration harness helpers; the e2e test
+# itself is #[ignore]'d and runs via the script below)
+cargo test
+
+# Lint — must be clean with no warnings
+cargo clippy --all-targets --all-features -- -D warnings
+
+# Format
+cargo fmt
+```
+
+### Integration tests
+
+The full suite boots a Splice localnet in Docker, spawns three
+`dec-party-manager` instances, and runs an end-to-end governance workflow:
+
+```bash
+./integration-tests/run.sh            # quiet mode (Given-When-Then trace)
+./integration-tests/run.sh --verbose  # full logs
+./integration-tests/run.sh --help
+```
+
+## Coding standards
+
+All Rust changes must pass CI before review:
+
+- `cargo fmt -- --check`
+- `cargo clippy --all-targets --all-features -- -D warnings`
+- `cargo test`
+- No compiler warnings.
+
+Key conventions (see [`CLAUDE.md`](../CLAUDE.md) for the full set):
+
+- **Imports:** `mod` declarations first, then `use` groups ordered std →
+  third-party → local, separated by blank lines; merge multiple imports from the
+  same module with braces.
+- **Format strings:** prefer inline captures — `format!("{path}")` — over
+  positional args, but don't introduce a variable just to inline it.
+- **Error handling:** use `anyhow::Result` for application errors and
+  `thiserror` for custom error types. **Avoid `unwrap()` / `expect()`** —
+  including in tests; return `Result` and use `?`.
+- **Logging:** use `tracing` (`info!`/`warn!`/`error!`), never `println!`/`eprintln!`.
+- **Cargo.toml:** dependencies and their features are kept in strict
+  alphabetical order.
+- **Comments:** only where the logic isn't self-evident; remove dead code rather
+  than commenting it out.
+
+## Commit & branch conventions
+
+Commit messages (past tense) and branch names follow:
+
+```
+<type>(<scope>): <subject>      # commit
+<type>/<scope>/<subject>        # branch
+```
+
+- **type:** `feat`, `fix`, `docs`, `style`, `refact`, `perf`, `test`, `chore`
+- **scope:** the area touched, e.g. `api`, `ui`, `core`, `server`, `workflow`
+
+Examples:
+
+```
+feat(ui): added peer version column to the peers table
+fix(workflow): handled durable cancel during topology retry
+```
+
+Keep commits small, focused, and atomic. Stage files intentionally
+(`git add <file>`), not `git add .`.
+
+## Submitting a pull request
+
+1. Fork the repo and create a branch following the naming convention above.
+2. Make your change with tests, and ensure `fmt`, `clippy`, and `test` all pass
+   locally.
+3. Keep the PR focused; large unrelated changes are harder to review.
+4. Fill out the [pull request template](../.github/PULL_REQUEST_TEMPLATE.md) and
+   link any related issues (e.g. `Closes #123`).
+5. A maintainer will review; please be responsive to feedback.
+
+Thank you for contributing! 🎉

--- a/docs/CUSTOM_DAML_TEMPLATES.md
+++ b/docs/CUSTOM_DAML_TEMPLATES.md
@@ -240,7 +240,7 @@ curl -X POST http://coordinator:8080/contracts \
     "contracts": [{
       "id":           "governance-rules",
       "name":         "GovernanceRules",
-      "package_id":   "#governance-core-v1-rc1",
+      "package_id":   "#governance-core-<version>",
       "module_name":  "Governance.Rules",
       "entity_name":  "GovernanceRules",
       "fields": [
@@ -456,7 +456,7 @@ curl 'http://localhost:8080/contracts/query?party_id=my-vault-network::1220abc..
 Set `interface=true` to query by interface id instead — useful for listing every active `GovernableAction` regardless of underlying template:
 
 ```
-package_id=#governance-action-v1-rc1
+package_id=#governance-action-<version>
 module_name=Governance.Action
 entity_name=GovernableAction
 interface=true
@@ -556,7 +556,7 @@ curl -X POST http://node:8080/governance/execute \
   }"
 
 # 4. Audit: a GovernanceExecutionResult contract now records the executed action.
-curl "http://node:8080/contracts/query?party_id=${DEC_PARTY}&package_id=%23governance-core-v1-rc1&module_name=Governance.ExecutionResult&entity_name=GovernanceExecutionResult&interface=false"
+curl "http://node:8080/contracts/query?party_id=${DEC_PARTY}&package_id=%23governance-core-<version>&module_name=Governance.ExecutionResult&entity_name=GovernanceExecutionResult&interface=false"
 ```
 
 That is the entire contract between a custom DAML template and DecMan: implement `GovernableAction`, ship the DAR, and drive the lifecycle through the existing API.

--- a/docs/INTEGRATION_GUIDE.md
+++ b/docs/INTEGRATION_GUIDE.md
@@ -50,7 +50,7 @@ Both ports must be reachable between all participants. The Noise port (9000) car
 ### Software
 
 - **Docker** (recommended) or Rust toolchain for building from source
-- `cargo` 1.75+ if building from source
+- Rust ≥ 1.85 if building from source (the crate uses edition 2024)
 
 ## Deployment
 
@@ -62,6 +62,7 @@ docker run -d \
   -p 8080:8080 \
   -p 9000:9000 \
   -v $(pwd)/data:/app/data \
+  -e DECPM_DIR=/app \
   -e DECPM_CANTON_ADMIN_HOST=canton-participant \
   -e DECPM_CANTON_ADMIN_PORT=5002 \
   -e DECPM_CANTON_LEDGER_HOST=canton-participant \
@@ -87,8 +88,14 @@ docker run -d \
   -p 9000:9000 \
   -v $(pwd)/data:/app/data \
   -v $(pwd)/.env:/app/.env:ro \
+  -e DECPM_DIR=/app \
   public.ecr.aws/dlc-link/canton-decparty-manager:latest
 ```
+
+The `-e DECPM_DIR=/app` above matches the `/app/...` mount paths and the
+Kubernetes manifest below. The shipped image defaults `DECPM_DIR=/`, so without
+it the data dir and auto-loaded `.env` would be resolved under `/` instead of
+`/app`.
 
 ### Kubernetes
 
@@ -251,11 +258,11 @@ CLI options (every flag has a matching `DECPM_*` env var; flags override env):
 
 | Flag | Env Var | Default | Description |
 |------|---------|---------|-------------|
-| `-d`, `--dir` | `DECPM_DIR` | `.` | Root directory for persistent data; loads `.env` from this dir if present |
+| `-d`, `--dir` | `DECPM_DIR` | `.` (the shipped Docker image sets `/`) | Root directory for persistent data; loads `.env` from this dir if present |
 | `--host` | `DECPM_HOST` | `0.0.0.0` | HTTP server bind address |
 | `--port` | `DECPM_PORT` | `8080` | HTTP server port |
-| `--test` | -- | `false` | Enable test mode with mock authentication |
 | `--db` | `DECPM_DB_PATH` | `{dir}/data/decpm.db` | Path to SQLite database file |
+| `--db-encryption-key` | `DECPM_DB_ENCRYPTION_KEY` | (none) | Key used to encrypt secrets stored in the database |
 | `--listen-address` | `DECPM_LISTEN_ADDRESS` | `0.0.0.0` | Noise server bind address |
 | `--noise-port` | `DECPM_NOISE_PORT` | `9000` | Noise server port |
 | `--public-address` | `DECPM_PUBLIC_ADDRESS` | (none) | External address for peers |
@@ -271,6 +278,8 @@ CLI options (every flag has a matching `DECPM_*` env var; flags override env):
 | `--auth0-domain` | `DECPM_AUTH0_DOMAIN` | (none) | Auth0 tenant domain (frontend auth gating; mutually exclusive with `--keycloak-*`) |
 | `--auth0-client-id` | `DECPM_AUTH0_CLIENT_ID` | (none) | Auth0 SPA client ID (frontend auth gating) |
 | `--auth0-audience` | `DECPM_AUTH0_AUDIENCE` | (none) | Auth0 API audience (target for SPA access tokens) |
+| `--admin-role` | `DECPM_ADMIN_ROLE` | (none) | Role that gates sensitive endpoints (`PUT /party-config`, `POST /kick`, etc.); unset treats every authenticated caller as admin |
+| `--allowed-origin` | `DECPM_ALLOWED_ORIGIN` | (none) | Origin permitted by CORS; defaults to same-origin only |
 | `--timeout-handshake` | `DECPM_TIMEOUT_HANDSHAKE` | `30` | Noise handshake timeout (seconds) |
 | `--timeout-message` | `DECPM_TIMEOUT_MESSAGE` | `120` | Noise message timeout (seconds) |
 | `--timeout-retry-attempts` | `DECPM_TIMEOUT_RETRY_ATTEMPTS` | `3` | Connection retry count |
@@ -317,6 +326,13 @@ All node configuration is provided through environment variables (or their equiv
 | `DECPM_AUTH0_DOMAIN` | `--auth0-domain` | string | (none) | Auth0 tenant domain for frontend auth gating (mutually exclusive with `DECPM_KEYCLOAK_*`) |
 | `DECPM_AUTH0_CLIENT_ID` | `--auth0-client-id` | string | (none) | Auth0 SPA client ID for frontend auth gating |
 | `DECPM_AUTH0_AUDIENCE` | `--auth0-audience` | string | (none) | Auth0 API audience targeted by SPA access tokens |
+| `DECPM_ADMIN_ROLE` | `--admin-role` | string | (none) | Role that gates sensitive endpoints (`PUT /party-config`, `POST /kick`, etc.). Unset treats every authenticated caller as admin |
+| `DECPM_ALLOWED_ORIGIN` | `--allowed-origin` | string | (none) | Origin permitted by CORS (e.g. `https://dpm.example.com`). Defaults to same-origin only |
+| `DECPM_DB_ENCRYPTION_KEY` | `--db-encryption-key` | string | (none) | Key used to encrypt secrets (client secrets, passwords) stored in the database |
+| `DECPM_DB_PATH` | `--db` | string | `{dir}/data/decpm.db` | Path to the SQLite database file |
+| `DECPM_DIR` | `-d`, `--dir` | string | `.` (the shipped Docker image sets `/`) | Root directory for persistent data; loads `.env` from this dir if present |
+| `DECPM_HOST` | `--host` | string | `0.0.0.0` | HTTP server bind address |
+| `DECPM_PORT` | `--port` | u16 | `8080` | HTTP server port |
 | `DECPM_TIMEOUT_HANDSHAKE` | `--timeout-handshake` | u64 | `30` | Noise handshake timeout in seconds |
 | `DECPM_TIMEOUT_MESSAGE` | `--timeout-message` | u64 | `120` | Noise message timeout in seconds |
 | `DECPM_TIMEOUT_RETRY_ATTEMPTS` | `--timeout-retry-attempts` | u32 | `3` | Max connection retries |
@@ -445,8 +461,8 @@ Response — Keycloak example:
   "has_password": false,
   "has_auth0_client_secret": false,
   "packages": {
-    "governance_core": "#governance-core-v0-rc4",
-    "governance_token_custody": "#governance-token-custody-v0-rc4",
+    "governance_core": "#governance-core-v1-rc1",
+    "governance_token_custody": "#governance-token-custody-v1-rc1",
     "utility_credential": "#utility-credential-app-v0",
     "utility_registry": "#utility-registry-app-v0",
     "vault": "#bitsafe-vault-v0-rc8",
@@ -489,13 +505,25 @@ For safety, changing the token endpoint URL (`keycloak_url` or `auth0_domain`) i
 
 ### Test Mode
 
-For development and testing without any IdP:
+Test mode is a **compile-time** option, not a runtime flag. It is active only when
+the binary is built with the `test-mode` Cargo feature or under `cargo test` —
+internally the server gates it on `cfg!(any(test, feature = "test-mode"))`. A
+released production binary cannot enable it at runtime; there is no `--test`
+flag, and `serve --test` errors out.
+
+To build and run with test mode for development without any IdP:
 
 ```bash
-dec-party-manager -d ./my-dir serve --test
+# Build with the test-mode feature enabled
+cargo build --features test-mode
+
+# Run normally — test mode is baked into the binary
+./target/debug/dec-party-manager -d ./my-dir serve
 ```
 
-Test mode uses a mock authentication provider that returns static tokens. All governance and ledger operations will use mock credentials.
+When active, test mode uses a mock authentication provider that returns static
+tokens (and enables the Swagger UI). All governance and ledger operations use
+mock credentials.
 
 ### Verification
 
@@ -834,7 +862,7 @@ curl -X POST http://localhost:8080/contracts \
       {
         "id": "governance-rules",
         "name": "GovernanceRules",
-        "package_id": "#governance-core-v0-rc4",
+        "package_id": "#governance-core-v1-rc1",
         "module_name": "Governance.Rules",
         "entity_name": "GovernanceRules",
         "fields": [
@@ -966,7 +994,7 @@ Each participant's Ledger API user needs:
 |--------|----------|-------------|--------------|
 | POST | `/onboarding` | Start onboarding | `{ "party_id_prefix": "...", "peer_ids": [...] }` |
 | GET | `/onboarding/status` | Get onboarding progress | -- |
-| POST | `/kick` | Start kick workflow | `{ "decentralized_party_id": "...", "participant_id": "...", "namespace_fingerprint": "...", "new_threshold": N }` |
+| POST | `/kick` | Start kick workflow | `{ "decentralized_party_id": "...", "participant_id": "...", "new_threshold": N, "previous_threshold": N }` (the request rejects unknown fields; `previous_threshold` is optional and display-only) |
 | GET | `/kick/status` | Get kick progress | -- |
 | POST | `/contracts` | Start contracts workflow | `{ "decentralized_party_id": "...", "participant_ids": [...], ... }` |
 | GET | `/contracts/status` | Get contracts progress | -- |
@@ -987,10 +1015,50 @@ Each participant's Ledger API user needs:
 
 | Method | Endpoint | Description | Response |
 |--------|----------|-------------|----------|
-| GET | `/auth-config` | Get the configured auth provider (mock or keycloak) | `{ "provider": "..." }` |
+| GET | `/auth-config` | Get the frontend auth configuration | `AuthConfigResponse` (see below) |
 | GET | `/auth/status` | Get auth status for all parties | `{ "parties": [...] }` |
 | POST | `/auth/test` | Test authentication | `{ "results": [...] }` |
 | POST | `/auth/grant-rights` | Grant Canton actAs/readAs rights to a party (admin-only) | `{ "rights": { ... } }` |
+
+#### `/auth-config` Response (`AuthConfigResponse`)
+
+The frontend reads this to decide which login flow to render. Auth0 and Keycloak
+are both first-class providers — each node configures at most one. Provider
+fields are omitted from the JSON when not set.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `auth_required` | bool | `false` in test mode or when no provider is configured; `true` otherwise |
+| `keycloak_host` | string? | Keycloak server URL (Keycloak nodes only) |
+| `keycloak_realm` | string? | Keycloak realm (Keycloak nodes only) |
+| `keycloak_client_id` | string? | Keycloak client ID (Keycloak nodes only) |
+| `auth0_domain` | string? | Auth0 tenant domain (Auth0 nodes only) |
+| `auth0_client_id` | string? | Auth0 SPA client ID (Auth0 nodes only) |
+| `auth0_audience` | string? | Auth0 API audience (Auth0 nodes only) |
+
+When Auth0 is configured it takes precedence over Keycloak. When no provider is
+configured, the server returns `{ "auth_required": false }` with all provider
+fields omitted.
+
+Keycloak example:
+```json
+{
+  "auth_required": true,
+  "keycloak_host": "https://keycloak.example.com",
+  "keycloak_realm": "canton",
+  "keycloak_client_id": "dpm-ui"
+}
+```
+
+Auth0 example:
+```json
+{
+  "auth_required": true,
+  "auth0_domain": "tenant.us.auth0.com",
+  "auth0_client_id": "spa-client-id",
+  "auth0_audience": "https://your-canton-api"
+}
+```
 
 ### Governance
 
@@ -1029,17 +1097,34 @@ All governance mutation endpoints accept a `governance_type` field that selects 
 }
 ```
 
-The server populates the `proposer` field on the proposal contract automatically (using the calling party's identity). As of `v0-rc4`, that proposer must be a member of the targeted `GovernanceRules` or appear in its `additionalProposers` allowlist; otherwise the auto-confirmation step rejects the proposal at confirm time.
+The server populates the `proposer` field on the proposal contract automatically (using the calling party's identity). As of `v1-rc1`, that proposer must be a member of the targeted `GovernanceRules` or appear in its `additionalProposers` allowlist; otherwise the auto-confirmation step rejects the proposal at confirm time.
 
-Available proposal types:
+Available proposal types (the `type` discriminator is `snake_case`). These map
+1:1 to the `ProposalType` enum in `src/server/types.rs`, which is the source of
+truth for the exact field shapes; see also the domain-action catalog in
+ARCHITECTURE.md and the serializers in `src/server/action_serializer.rs`.
 
 | Type | Fields | Description |
 |------|--------|-------------|
-| `generic_vote` | `description` | Free-text governance vote |
+| `generic_vote` | `description` | Free-text governance vote (no on-chain effect beyond recording the result) |
 | `setup_cc_preapproval` | `provider`, `expected_dso` | Set up Canton Coin transfer preapproval |
 | `setup_token_preapproval` | `operator`, `instrument_admin`, `instrument_allowances` (optional) | Set up utility token transfer preapproval |
 | `transfer` | `transfer_factory_cid`, `expected_admin`, `receiver`, `amount`, `instrument_id`, `input_holding_cids` (optional) | Transfer tokens from governance party |
 | `accept_transfer` | `transfer_instruction_cid` | Accept an incoming token transfer |
+| `mint` | `allocation_factory_cid`, `instrument_id`, `instrument_configuration_cid`, `recipient`, `amount`, `description` | Offer a mint to a recipient via `AllocationFactory_OfferMint` |
+| `burn` | `allocation_factory_cid`, `instrument_id`, `instrument_configuration_cid`, `holder`, `amount`, `description` | Offer a burn of a holder's tokens via `AllocationFactory_OfferBurn` |
+| `accept_mint_request` | `mint_request_cid`, `instrument_configuration_cid`, `description` | Accept a holder-initiated `MintRequest` |
+| `accept_burn_request` | `burn_request_cid`, `instrument_configuration_cid`, `description` | Accept a holder-initiated `BurnRequest` |
+| `offer_free_credential` | `user_service_cid`, `holder`, `id`, `description`, `claims` | Offer a free credential via the governance party's `UserService` |
+| `offer_paid_credential` | `user_service_cid`, `holder`, `id`, `description`, `claims`, `billing_params`, `deposit_initial_amount_usd` (optional) | Offer a paid credential via the governance party's `UserService` |
+| `accept_free_credential` | `user_service_cid`, `credential_offer_cid` | Accept a free credential offered to the governance party |
+| `provision_provider_service` | (none) | Provision a Utility-Registry `ProviderService` (operator = proposer) |
+| `setup_utility` | `provider_service_cid`, `operator`, `instrument_id_text`, `additional_identifiers` (optional), `create_transfer_rule`, `create_allocation_factory` | Run the full Utility-Registry onboarding in one vote |
+| `create_provider_service_request` | `operator`, `provider` | Create a `ProviderServiceRequest` |
+| `create_user_service_request` | `operator`, `user` | Create a `UserServiceRequest` |
+| `set_provider_app_reward_beneficiaries` | `instrument_configuration_cid`, `provider_app_reward_beneficiaries` (optional; `null` clears) | Set provider-app reward beneficiaries on an `InstrumentConfiguration` |
+| `set_enable_result_contracts` | `registrar_service_cid`, `enable_result_contracts` (optional) | Toggle result-contract emission on a `RegistrarService` |
+| `create_delegated_batched_markers_proxy` | `operator` | Authorize an operator to create batched activity markers via a `DelegatedBatchedMarkersProxy` |
 
 #### Confirm
 
@@ -1077,7 +1162,7 @@ Available `core_self` action types (DAML `GovernanceSelfAction` variants):
 | `governance_add_additional_proposer` | `additional_proposer` (party id) | `SelfAction_AddAdditionalProposer` |
 | `governance_remove_additional_proposer` | `additional_proposer` (party id) | `SelfAction_RemoveAdditionalProposer` |
 
-The two `*_additional_proposer` variants (added in `v0-rc4`) mutate the `additionalProposers` allowlist on `GovernanceRules`. See ARCHITECTURE.md for the proposer-authorization model.
+The two `*_additional_proposer` variants (added in `v1-rc1`) mutate the `additionalProposers` allowlist on `GovernanceRules`. See ARCHITECTURE.md for the proposer-authorization model.
 
 **For domain actions (`governance_type: "core_domain"`):**
 

--- a/docs/INTEGRATION_GUIDE.md
+++ b/docs/INTEGRATION_GUIDE.md
@@ -160,7 +160,7 @@ spec:
               mountPath: /app
       containers:
         - name: dec-party-manager
-          image: public.ecr.aws/dlc-link/canton-decparty-manager:latest
+          image: public.ecr.aws/dlc-link/canton-decparty-manager:0.1.7 # pin a release; avoid :latest
           command: ["dec-party-manager", "serve"]
           ports:
             - name: http
@@ -461,8 +461,8 @@ Response — Keycloak example:
   "has_password": false,
   "has_auth0_client_secret": false,
   "packages": {
-    "governance_core": "#governance-core-v1-rc1",
-    "governance_token_custody": "#governance-token-custody-v1-rc1",
+    "governance_core": "#governance-core-<version>",
+    "governance_token_custody": "#governance-token-custody-<version>",
     "utility_credential": "#utility-credential-app-v0",
     "utility_registry": "#utility-registry-app-v0",
     "vault": "#bitsafe-vault-v0-rc8",
@@ -862,7 +862,7 @@ curl -X POST http://localhost:8080/contracts \
       {
         "id": "governance-rules",
         "name": "GovernanceRules",
-        "package_id": "#governance-core-v1-rc1",
+        "package_id": "#governance-core-<version>",
         "module_name": "Governance.Rules",
         "entity_name": "GovernanceRules",
         "fields": [

--- a/docs/INTEGRATION_GUIDE.md
+++ b/docs/INTEGRATION_GUIDE.md
@@ -72,7 +72,7 @@ docker run -d \
   -e DECPM_LISTEN_ADDRESS=0.0.0.0 \
   -e DECPM_NOISE_PORT=9000 \
   -e DECPM_PUBLIC_ADDRESS=your-external-address \
-  public.ecr.aws/dlc-link/canton-decparty-manager:latest
+  public.ecr.aws/dlc-link/canton-decparty-manager:0.1.7   # pin a release; avoid :latest
 ```
 
 The container expects:
@@ -89,7 +89,7 @@ docker run -d \
   -v $(pwd)/data:/app/data \
   -v $(pwd)/.env:/app/.env:ro \
   -e DECPM_DIR=/app \
-  public.ecr.aws/dlc-link/canton-decparty-manager:latest
+  public.ecr.aws/dlc-link/canton-decparty-manager:0.1.7   # pin a release; avoid :latest
 ```
 
 The `-e DECPM_DIR=/app` above matches the `/app/...` mount paths and the

--- a/docs/MIGRATION_GUIDE.md
+++ b/docs/MIGRATION_GUIDE.md
@@ -43,7 +43,7 @@ The Dec Party Manager is published as a public container image:
 public.ecr.aws/dlc-link/canton-decparty-manager:<tag>
 ```
 
-Use the latest tagged release (for example `0.0.30`). Pin the version explicitly — do not use `latest`. If your cluster cannot pull from Public ECR directly, mirror the image into your own registry first.
+Use the latest tagged release (for example `0.1.7`). Pin the version explicitly — do not use `latest`. If your cluster cannot pull from Public ECR directly, mirror the image into your own registry first.
 
 To check the version of a running pod:
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,41 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.**
+
+Instead, use one of the following private channels:
+
+- **GitHub private vulnerability reporting** (preferred): open the repository's
+  **Security** tab and choose **Report a vulnerability**.
+- **Email:** `security@bitsafe.finance` <!-- TODO: confirm this is a monitored address -->
+
+Please include as much of the following as you can:
+
+- A description of the vulnerability and its potential impact.
+- Steps to reproduce, or a proof-of-concept.
+- Affected version(s) or commit SHA, and the deployment context
+  (binary / Docker / Kubernetes; devnet / testnet / mainnet).
+- Any suggested remediation, if you have one.
+
+## What to expect
+
+- We will acknowledge your report as soon as we can.
+- We will investigate and keep you informed of progress.
+- We will credit reporters in the release notes unless you prefer to remain
+  anonymous.
+
+Please give us a reasonable opportunity to address the issue before any public
+disclosure.
+
+## Supported versions
+
+This project is under active development. Security fixes are applied to the
+latest release and the `main` branch.
+
+## Audits
+
+The governance Daml contracts have undergone third-party security review
+(Quantstamp). See [`docs/audit-acknowledgements.md`](audit-acknowledgements.md)
+for design decisions made in response to audit findings.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -9,7 +9,7 @@ Instead, use one of the following private channels:
 
 - **GitHub private vulnerability reporting** (preferred): open the repository's
   **Security** tab and choose **Report a vulnerability**.
-- **Email:** `security@bitsafe.finance`
+- **Email:** `eng@bitsafe.finance`
 
 Please include as much of the following as you can:
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -9,7 +9,7 @@ Instead, use one of the following private channels:
 
 - **GitHub private vulnerability reporting** (preferred): open the repository's
   **Security** tab and choose **Report a vulnerability**.
-- **Email:** `security@bitsafe.finance` <!-- TODO: confirm this is a monitored address -->
+- **Email:** `security@bitsafe.finance`
 
 Please include as much of the following as you can:
 

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -6,6 +6,8 @@ Practical walkthroughs for the primary applications of the Decentralized Party M
 
 The primary use case: multiple custodians jointly managing BitsafeVault contracts through a shared decentralized party identity.
 
+> **Note:** The `#bitsafe-vault-*` DARs are external/proprietary and are not included in this repository — the repo ships only the splice, utility, and governance DARs — so this example requires those vault packages to be supplied separately.
+
 ### Scenario
 
 Three custodial organizations (Custodian A, B, C) want to jointly manage a digital asset vault. No single custodian should be able to unilaterally deploy, pause, or modify the vault. All critical operations require a 2-of-3 majority.
@@ -64,7 +66,7 @@ curl -X POST http://custodian-a:8080/contracts \
 
 This deploys a `VaultGovernanceRules` contract with all 3 members, threshold 2, and a 24-hour confirmation timeout.
 
-> **Note:** New deployments should use `GovernanceRules` (from `#governance-core-v0-rc4`) instead. See the [Integration Guide](INTEGRATION_GUIDE.md#deploying-governance-contracts) for the recommended contract deployment payload.
+> **Note:** New deployments should use `GovernanceRules` (from `#governance-core-v1-rc1`) instead. See the [Integration Guide](INTEGRATION_GUIDE.md#deploying-governance-contracts) for the recommended contract deployment payload.
 
 ### Full Deployment Flow
 
@@ -76,7 +78,7 @@ The complete end-to-end deployment of a vault system follows these steps. Each g
 | 2 | Configure party credentials | DPM (`PUT /party-config` API) | Configure OAuth credentials (Keycloak or Auth0) and package IDs for each party |
 | 3 | Grant Ledger API rights | External (Canton admin) | Grant `actAs`/`readAs` rights for member parties on the decentralized party |
 | 4 | Upload DARs | DPM (DARs workflow) | Upload DAR packages to all participant nodes |
-| 5a | Deploy GovernanceRules | DPM (contracts workflow) | Deploy `GovernanceRules` contract with package `#governance-core-v0-rc4` (recommended) |
+| 5a | Deploy GovernanceRules | DPM (contracts workflow) | Deploy `GovernanceRules` contract with package `#governance-core-v1-rc1` (recommended) |
 | 5b | Deploy VaultGovernance | DPM (contracts workflow) | Deploy `VaultGovernanceRules` contract with package `#bitsafe-vault-governance-v0-rc8` (legacy) |
 | 6 | Create ProviderService | Governance action | `utility_create_provider_request` |
 | 7 | Create UserService | Governance action | `utility_create_user_request` |
@@ -300,8 +302,8 @@ Adding a 4th custodian involves both governance and topology:
       -d '{
         "decentralized_party_id": "joint-vault::1220...",
         "participant_id": "custodian-c::1220...",
-        "namespace_fingerprint": "1220...",
-        "new_threshold": 2
+        "new_threshold": 2,
+        "previous_threshold": 3
       }'
     ```
 
@@ -702,8 +704,8 @@ The `governance-token-custody` package enables governance-controlled token opera
 
 ### Prerequisites
 
-- `GovernanceRules` contract deployed (from `#governance-core-v0-rc4`)
-- `governance-token-custody` DAR uploaded to all participants (from `#governance-token-custody-v0-rc4`)
+- `GovernanceRules` contract deployed (from `#governance-core-v1-rc1`)
+- `governance-token-custody` DAR uploaded to all participants (from `#governance-token-custody-v1-rc1`)
 - Token infrastructure deployed (transfer factories, instruments, etc.)
 
 ### Set Up Canton Coin Preapproval
@@ -841,7 +843,7 @@ curl -X POST http://custodian-a:8080/governance/confirm \
   }'
 ```
 
-**Grant propose-only rights to a non-member (`v0-rc4`+):**
+**Grant propose-only rights to a non-member (`v1-rc1`+):**
 
 ```bash
 curl -X POST http://custodian-a:8080/governance/confirm \

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -66,11 +66,13 @@ curl -X POST http://custodian-a:8080/contracts \
 
 This deploys a `VaultGovernanceRules` contract with all 3 members, threshold 2, and a 24-hour confirmation timeout.
 
-> **Note:** New deployments should use `GovernanceRules` (from `#governance-core-v1-rc1`) instead. See the [Integration Guide](INTEGRATION_GUIDE.md#deploying-governance-contracts) for the recommended contract deployment payload.
+> **Note:** New deployments should use `GovernanceRules` (from `#governance-core-<version>`) instead. See the [Integration Guide](INTEGRATION_GUIDE.md#deploying-governance-contracts) for the recommended contract deployment payload.
 
 ### Full Deployment Flow
 
 The complete end-to-end deployment of a vault system follows these steps. Each governance action (steps 6-15) requires threshold confirmations before execution. Steps 5a/5b show the two governance contract options.
+
+> **Note:** `#governance-*-<version>` package IDs use `<version>` as a placeholder — substitute the version of the governance packages you deployed (these are configured per party via `PUT /party-config`).
 
 | # | Step | Actor | Description |
 |---|------|-------|-------------|
@@ -78,7 +80,7 @@ The complete end-to-end deployment of a vault system follows these steps. Each g
 | 2 | Configure party credentials | DPM (`PUT /party-config` API) | Configure OAuth credentials (Keycloak or Auth0) and package IDs for each party |
 | 3 | Grant Ledger API rights | External (Canton admin) | Grant `actAs`/`readAs` rights for member parties on the decentralized party |
 | 4 | Upload DARs | DPM (DARs workflow) | Upload DAR packages to all participant nodes |
-| 5a | Deploy GovernanceRules | DPM (contracts workflow) | Deploy `GovernanceRules` contract with package `#governance-core-v1-rc1` (recommended) |
+| 5a | Deploy GovernanceRules | DPM (contracts workflow) | Deploy `GovernanceRules` contract with package `#governance-core-<version>` (recommended) |
 | 5b | Deploy VaultGovernance | DPM (contracts workflow) | Deploy `VaultGovernanceRules` contract with package `#bitsafe-vault-governance-v0-rc8` (legacy) |
 | 6 | Create ProviderService | Governance action | `utility_create_provider_request` |
 | 7 | Create UserService | Governance action | `utility_create_user_request` |
@@ -704,8 +706,8 @@ The `governance-token-custody` package enables governance-controlled token opera
 
 ### Prerequisites
 
-- `GovernanceRules` contract deployed (from `#governance-core-v1-rc1`)
-- `governance-token-custody` DAR uploaded to all participants (from `#governance-token-custody-v1-rc1`)
+- `GovernanceRules` contract deployed (from `#governance-core-<version>`)
+- `governance-token-custody` DAR uploaded to all participants (from `#governance-token-custody-<version>`)
 - Token infrastructure deployed (transfer factories, instruments, etc.)
 
 ### Set Up Canton Coin Preapproval

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "frontend",
   "private": true,
   "version": "0.0.0",
+  "license": "Apache-2.0",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -390,8 +390,9 @@ impl AuthRegistry {
     }
 }
 
-/// Unified auth provider that works with workflows
-/// Supports both real Keycloak auth and mock auth for testing
+/// Unified auth provider that works with workflows.
+/// Supports real OAuth2 auth (Keycloak or Auth0 M2M, via the auth registry) and
+/// mock auth for testing.
 #[derive(Clone)]
 pub enum WorkflowAuth {
     Keycloak(Arc<AuthRegistry>),

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -78,61 +78,8 @@ pub const CANTON_PROTOCOL_VERSION: i32 = 34;
 /// rejected with LOCAL_VERDICT_TIMEOUT.
 pub const TOPOLOGY_PROPAGATION_DELAY_SECS: u64 = 30;
 
-// File name prefixes
-/// Prefix for peer public key files
-pub const PEER_KEYS_PREFIX: &str = "peer-public-keys";
-
-/// Prefix for participant ID files
-pub const PARTICIPANT_ID_PREFIX: &str = "participant-id";
-
-/// Prefix for signed DNS proposal files
-pub const SIGNED_DNS_PROPOSAL_PREFIX: &str = "signed-dns-proposal";
-
-/// Prefix for signed P2P proposal files
-pub const SIGNED_P2P_PROPOSALS_PREFIX: &str = "signed-p2p-proposals";
-
-/// Prefix for submission signature files
-pub const SUBMISSION_SIGNATURES_PREFIX: &str = "submission-signatures";
-
-/// Prefix for signed kick proposal files
-pub const SIGNED_KICK_PROPOSALS_PREFIX: &str = "signed-kick-proposals";
-
-// File names
-/// Namespace definition file name
-pub const NAMESPACE_DEF_FILENAME: &str = "namespace_def.bin";
-
-/// DNS proposal file name
-pub const DNS_PROTO_FILENAME: &str = "dns_proto.bin";
-
-/// P2P proposal file name
-pub const P2P_PROTO_FILENAME: &str = "p2p_proto.bin";
-
-/// DNS kick proposal file name
-pub const DNS_KICK_PROTO_FILENAME: &str = "dns_kick_proto.bin";
-
-/// P2P kick proposal file name
-pub const P2P_KICK_PROTO_FILENAME: &str = "p2p_kick_proto.bin";
-
-/// New namespace definition file name (for kick workflow)
-pub const NEW_NAMESPACE_DEF_FILENAME: &str = "newNamespaceDef.bin";
-
-/// Party ID file name
-pub const PARTY_ID_FILENAME: &str = "partyId";
-
-/// Kick target file name
-pub const KICK_TARGET_FILENAME: &str = "kick-target";
-
-/// Kick participant ID file name
-pub const KICK_PARTICIPANT_ID_FILENAME: &str = "kick-participant-id";
-
-/// New threshold file name
-pub const NEW_THRESHOLD_FILENAME: &str = "new-threshold";
-
-/// Prefix for prepared submission files
-pub const PREPARED_SUBMISSION_PREFIX: &str = "prepared-submission";
-
 // Base directory names (relative to root directory)
-/// Data directory name (contains keys, workflow-data, and dars)
+/// Data directory name (contains the Noise key, SQLite database, and DARs)
 pub const DATA_DIR: &str = "data";
 
 /// Noise private key filename (inside data/)

--- a/src/db/crypto.rs
+++ b/src/db/crypto.rs
@@ -125,7 +125,9 @@ pub fn encrypt_bytes(plaintext: &[u8]) -> Result<Vec<u8>> {
 ///
 /// # Errors
 ///
-/// Returns an error only if the stored blob has a malformed nonce length.
+/// In practice this never returns an error — too-short or undecryptable blobs
+/// are returned unchanged. The `Result` is kept for symmetry with the
+/// encryption path and forward-compatibility.
 pub fn decrypt_bytes(stored: &[u8]) -> Result<Vec<u8>> {
     let Some(key) = ENCRYPTION_KEY.get() else {
         return Ok(stored.to_vec());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,9 @@
+//! Decentralized Party Manager — coordinates Canton "decentralized party"
+//! onboarding and governance across participant nodes. Instances communicate
+//! with each other over an encrypted Noise channel (coordinator/peer model) and
+//! with Canton via its Admin and Ledger gRPC APIs, exposing an HTTP server with
+//! an embedded React UI.
+
 pub mod auth;
 pub mod canton_id;
 pub mod config;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,3 +1,10 @@
+//! HTTP server and always-on Noise listener.
+//!
+//! Builds the actix-web application (REST API + embedded React UI + Swagger),
+//! wires shared [`AppState`], and runs the long-lived Noise listener that
+//! handles inbound peer messages (invites, signing, health, cancellation)
+//! independently of any coordinator-driven workflow.
+
 mod action_serializer;
 mod assets;
 mod audit;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,7 +1,9 @@
 //! HTTP server and always-on Noise listener.
 //!
-//! Builds the actix-web application (REST API + embedded React UI + Swagger),
-//! wires shared [`AppState`], and runs the long-lived Noise listener that
+//! Builds the actix-web application (REST API + embedded React UI; a Swagger UI
+//! is mounted only in test/dev builds, i.e. `cfg!(any(test, feature =
+//! "test-mode"))`), wires shared [`AppState`], and runs the long-lived Noise
+//! listener that
 //! handles inbound peer messages (invites, signing, health, cancellation)
 //! independently of any coordinator-driven workflow.
 

--- a/src/server/peer_status.rs
+++ b/src/server/peer_status.rs
@@ -1,4 +1,3 @@
-// src/server/peer_status.rs
 use std::{
     collections::HashMap,
     sync::Arc,

--- a/src/server/queries.rs
+++ b/src/server/queries.rs
@@ -1,3 +1,9 @@
+//! Canton ledger query layer.
+//!
+//! Read-side helpers that query the Canton Ledger API (active contracts,
+//! governance state, holdings, transfers, rewards, etc.) and shape the results
+//! into the response types served by the HTTP handlers.
+
 use std::{
     cmp::Reverse,
     collections::HashMap,

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -567,13 +567,6 @@ pub struct WorkflowRunsResponse {
     pub runs: Vec<WorkflowRun>,
 }
 
-/// Payload for the `CancelWorkflow` Noise message — the coordinator tells an
-/// peer to abort its in-flight run for `instance_name`.
-#[derive(Clone, Debug, Serialize, Deserialize, utoipa::ToSchema)]
-pub struct CancelWorkflowPayload {
-    pub instance_name: String,
-}
-
 /// Response for key status check
 #[derive(Serialize, utoipa::ToSchema)]
 pub struct KeyStatusResponse {

--- a/src/workflow/contracts/steps/sign.rs
+++ b/src/workflow/contracts/steps/sign.rs
@@ -211,7 +211,7 @@ pub async fn sign_submissions(
         .export_key_pair(tonic::Request::new(ExportKeyPairRequest {
             fingerprint: key_fingerprint.clone(),
             protocol_version: CANTON_PROTOCOL_VERSION,
-            password: String::new(), // No password encryption — see TODO in module docs
+            password: String::new(), // Empty: the exported key pair is not passphrase-protected.
         }))
         .await
         .map_err(|e| {

--- a/src/workflow/state.rs
+++ b/src/workflow/state.rs
@@ -244,12 +244,6 @@ impl<S: WorkflowStep + 'static> WorkflowState<S> {
             .await;
     }
 
-    /// Mark the run as Cancelled. Used by the cancel propagation path on
-    /// peers when they receive a `CancelWorkflow` Noise message.
-    pub async fn mark_cancelled(&self) {
-        self.persist_status(WorkflowProgress::Cancelled, None).await;
-    }
-
     async fn persist_step_progress(&self, step: S, completed: Vec<CantonId>) {
         let updated_at = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)

--- a/src/workflow/storage.rs
+++ b/src/workflow/storage.rs
@@ -82,7 +82,7 @@ pub mod identity_kinds {
     /// canonical source for sign.rs's "load my DAML signing key" lookup.
     pub const PEER_PUBLIC_KEYS: &str = "peer_public_keys";
     /// Each peer's `participant_id` file content. Coordinator's row set
-    /// holds one per peer; an peer's row set holds just their own.
+    /// holds one per peer; a peer's row set holds just their own.
     pub const PARTICIPANT_ID: &str = "participant_id";
 }
 


### PR DESCRIPTION
## Summary

Prepares the repository for open-sourcing: adds licensing and contributor
documentation, corrects documentation drift found in a full doc/code audit, and
removes dead code. All changes are additive/corrective — no behavioural changes.

## Changes

### License
- Added Apache-2.0 `LICENSE` + `NOTICE`; set `license = "Apache-2.0"` in `Cargo.toml` and `frontend/package.json`; updated the README license section. (Apache-2.0 chosen for its explicit patent grant and alignment with the Canton/Daml/Splice ecosystem.)

### Contributor docs
- Added `docs/CONTRIBUTING.md`, `docs/CODE_OF_CONDUCT.md`, `docs/SECURITY.md`.
- Added `.github/PULL_REQUEST_TEMPLATE.md` and `.github/ISSUE_TEMPLATE/` (bug report, feature request, config).
- README: added a Contributing section and a complete documentation index.

### Documentation audit fixes
- Corrected stale governance package IDs `-v0-rc4` → `-v1-rc1` across ARCHITECTURE / INTEGRATION_GUIDE / USE_CASES (copy-pasting the old IDs would have failed symbolic lookup).
- Rewrote `USER_GUIDE.md` — removed a documented `node.toml` / `/config`-mount config mechanism that does not exist; it is now env-var (`DECPM_*`) based and linked from the README.
- README: completed the `DECPM_*` env-var table, removed the non-existent `GET /amulet-rules` endpoint (and noted the live Swagger UI), dropped the stale `workflow-data/` directory entry, and standardized the Docker image reference.
- INTEGRATION_GUIDE: fixed the `/auth-config` response shape, corrected `--test` (it is a compile-time feature, not a runtime flag), the `/kick` request body, the Docker `DECPM_DIR`/data-path examples, the minimum Rust version, pinned the image tag (no `:latest`), and completed the propose-type table.
- ARCHITECTURE: corrected the topology threshold formula, added the `governance-utility-credential` package and the `GovernableAction_ProposerCancel` choice, and completed the Noise message tables and legacy action count.
- `CLAUDE.md`: corrected the database-testing section (Postgres → SQLite, the project's actual database).
- Fixed `.env` location guidance (loaded from the `--dir`/`DECPM_DIR` root, per `src/main.rs`).

### Code cleanup
- Removed dead code: 17 unused filesystem-layout constants, `CancelWorkflowPayload`, and `WorkflowState::mark_cancelled()` — all referenced a `CancelWorkflow` Noise message that no longer exists (cancellation runs via `CancelInvite`).
- Fixed stale/incorrect doc comments (`crypto.rs`, `auth/mod.rs`, `sign.rs`) and added crate- and module-level overviews.

## Verification
- `cargo fmt -- --check` ✅
- `cargo check` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅

## Follow-ups (out of scope for this PR)
- Confirm `conduct@bitsafe.finance` / `security@bitsafe.finance` are monitored, and enable GitHub private vulnerability reporting.
- Decide the public-facing org/brand: LICENSE/contacts say *BitSafe*; the repo, Docker image, and deps say *DLC-link*.
- The private `canton-lib` dependency still blocks external builds/CI (separate decision).
- `fetch_decentralized_parties` retains an unused `_party_credentials` parameter (cosmetic `TODO`; removal ripples across call sites).
