### PR TITLE
Add keycloak internal_url for rust server

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ The database file path can be overridden with the `--db` CLI flag.
 | `DECPM_KEYCLOAK_URL` | Keycloak server URL for frontend auth | _(none)_ |
 | `DECPM_KEYCLOAK_REALM` | Keycloak realm name for frontend auth | _(none)_ |
 | `DECPM_KEYCLOAK_CLIENT_ID` | Keycloak client ID for frontend auth | _(none)_ |
+| `DECPM_KEYCLOAK_INTERNAL_URL` | Internal/backchannel Keycloak URL the server uses for OIDC discovery, JWKS, and introspection when it cannot reach `DECPM_KEYCLOAK_URL` directly (e.g. that is a tailnet host but the pod is in-cluster) | `DECPM_KEYCLOAK_URL` |
 | `DECPM_AUTH0_DOMAIN` | Auth0 tenant domain for frontend auth (mutually exclusive with `DECPM_KEYCLOAK_*`) | _(none)_ |
 | `DECPM_AUTH0_CLIENT_ID` | Auth0 SPA client ID for frontend auth | _(none)_ |
 | `DECPM_AUTH0_AUDIENCE` | Auth0 API audience the SPA's access tokens target | _(none)_ |

--- a/docs/INTEGRATION_GUIDE.md
+++ b/docs/INTEGRATION_GUIDE.md
@@ -275,6 +275,7 @@ CLI options (every flag has a matching `DECPM_*` env var; flags override env):
 | `--keycloak-url` | `DECPM_KEYCLOAK_URL` | (none) | Keycloak server URL (frontend auth gating) |
 | `--keycloak-realm` | `DECPM_KEYCLOAK_REALM` | (none) | Keycloak realm name (frontend auth gating) |
 | `--keycloak-client-id` | `DECPM_KEYCLOAK_CLIENT_ID` | (none) | OAuth2 client ID (frontend auth gating) |
+| `--keycloak-internal-url` | `DECPM_KEYCLOAK_INTERNAL_URL` | (`DECPM_KEYCLOAK_URL`) | Internal/backchannel Keycloak URL the server uses for OIDC discovery/JWKS/introspection when it cannot reach `--keycloak-url` directly (e.g. tailnet host, in-cluster pod) |
 | `--auth0-domain` | `DECPM_AUTH0_DOMAIN` | (none) | Auth0 tenant domain (frontend auth gating; mutually exclusive with `--keycloak-*`) |
 | `--auth0-client-id` | `DECPM_AUTH0_CLIENT_ID` | (none) | Auth0 SPA client ID (frontend auth gating) |
 | `--auth0-audience` | `DECPM_AUTH0_AUDIENCE` | (none) | Auth0 API audience (target for SPA access tokens) |
@@ -323,6 +324,7 @@ All node configuration is provided through environment variables (or their equiv
 | `DECPM_KEYCLOAK_URL` | `--keycloak-url` | string | (none) | Keycloak server URL for frontend auth gating |
 | `DECPM_KEYCLOAK_REALM` | `--keycloak-realm` | string | (none) | Keycloak realm name for frontend auth gating |
 | `DECPM_KEYCLOAK_CLIENT_ID` | `--keycloak-client-id` | string | (none) | OAuth2 client ID for frontend auth gating |
+| `DECPM_KEYCLOAK_INTERNAL_URL` | `--keycloak-internal-url` | string | (`DECPM_KEYCLOAK_URL`) | Internal/backchannel Keycloak URL the server uses for OIDC discovery, JWKS, and introspection when it cannot reach `DECPM_KEYCLOAK_URL` directly (e.g. tailnet host but in-cluster pod). Does not change the token issuer |
 | `DECPM_AUTH0_DOMAIN` | `--auth0-domain` | string | (none) | Auth0 tenant domain for frontend auth gating (mutually exclusive with `DECPM_KEYCLOAK_*`) |
 | `DECPM_AUTH0_CLIENT_ID` | `--auth0-client-id` | string | (none) | Auth0 SPA client ID for frontend auth gating |
 | `DECPM_AUTH0_AUDIENCE` | `--auth0-audience` | string | (none) | Auth0 API audience targeted by SPA access tokens |

--- a/src/auth/validators/common.rs
+++ b/src/auth/validators/common.rs
@@ -50,6 +50,30 @@ pub(super) fn oidc_discovery_base_of(cfg: &KeycloakConfig) -> String {
     format!("{}/realms/{}", base.trim_end_matches('/'), cfg.realm)
 }
 
+/// Force `url`'s scheme + host + port to match `authority_source`, preserving
+/// path and query. Returns `url` unchanged if either input fails to parse.
+///
+/// Lets the server fetch JWKS / introspection from the same host it reached
+/// discovery on (the internal host) instead of trusting the host advertised in
+/// the discovery document, which — depending on Keycloak's hostname config —
+/// can be the public frontend host an in-cluster pod cannot reach. The token
+/// `iss` is validated separately and is unaffected.
+pub(super) fn rewrite_authority(url: &str, authority_source: &str) -> String {
+    let (Ok(mut target), Ok(src)) = (
+        reqwest::Url::parse(url),
+        reqwest::Url::parse(authority_source),
+    ) else {
+        return url.to_string();
+    };
+    if target.set_scheme(src.scheme()).is_err()
+        || target.set_host(src.host_str()).is_err()
+        || target.set_port(src.port()).is_err()
+    {
+        return url.to_string();
+    }
+    target.into()
+}
+
 /// Canonical OIDC issuer for an Auth0 tenant. Auth0 issues
 /// `https://{domain}/` in the JWT, but `extract_issuer` strips trailing
 /// slashes — match against the slash-less form so the comparison lines up.
@@ -224,6 +248,36 @@ mod tests {
             password: None,
         };
         assert_eq!(oidc_discovery_base_of(&cfg), oidc_issuer_of(&cfg));
+    }
+
+    #[test]
+    fn rewrite_authority_swaps_host_keeps_path() {
+        // Discovery advertised a public host; we rewrite it to the internal one
+        // while preserving the realm/certs path and query.
+        assert_eq!(
+            rewrite_authority(
+                "https://public.example/realms/x/protocol/openid-connect/certs?foo=bar",
+                "http://kc.svc.cluster.local:8080",
+            ),
+            "http://kc.svc.cluster.local:8080/realms/x/protocol/openid-connect/certs?foo=bar"
+        );
+    }
+
+    #[test]
+    fn rewrite_authority_is_noop_when_authority_matches() {
+        assert_eq!(
+            rewrite_authority("https://kc.example/realms/x/certs", "https://kc.example"),
+            "https://kc.example/realms/x/certs"
+        );
+    }
+
+    #[test]
+    fn rewrite_authority_returns_input_on_unparseable() {
+        assert_eq!(rewrite_authority("not a url", "http://kc.svc"), "not a url");
+        assert_eq!(
+            rewrite_authority("https://kc.example/certs", "not a url"),
+            "https://kc.example/certs"
+        );
     }
 
     #[test]

--- a/src/auth/validators/common.rs
+++ b/src/auth/validators/common.rs
@@ -33,6 +33,23 @@ pub(super) fn oidc_issuer_of(cfg: &KeycloakConfig) -> String {
     format!("{}/realms/{}", cfg.url.trim_end_matches('/'), cfg.realm)
 }
 
+/// Base URL the *server* fetches OIDC metadata from (discovery, JWKS,
+/// introspection) for a Keycloak-shaped config. Mirrors [`oidc_issuer_of`] but
+/// swaps in `internal_url` (the backchannel address) when it is set and
+/// non-empty, so a server that cannot reach the public/tailnet `url` — which
+/// remains the token `iss` — can still fetch metadata via an in-cluster
+/// address. When `internal_url` is unset this returns exactly the issuer
+/// string, so single-URL configs behave identically to before. Issuer matching
+/// continues to use [`oidc_issuer_of`].
+pub(super) fn oidc_discovery_base_of(cfg: &KeycloakConfig) -> String {
+    let base = cfg
+        .internal_url
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .unwrap_or(&cfg.url);
+    format!("{}/realms/{}", base.trim_end_matches('/'), cfg.realm)
+}
+
 /// Canonical OIDC issuer for an Auth0 tenant. Auth0 issues
 /// `https://{domain}/` in the JWT, but `extract_issuer` strips trailing
 /// slashes — match against the slash-less form so the comparison lines up.
@@ -141,6 +158,7 @@ mod tests {
     fn oidc_issuer_matches_keycloak_shape() {
         let cfg = KeycloakConfig {
             url: "https://keycloak.example.com/".to_string(),
+            internal_url: None,
             realm: "bitsafe".to_string(),
             client_id: "dpm".to_string(),
             client_secret: None,
@@ -151,6 +169,61 @@ mod tests {
             oidc_issuer_of(&cfg),
             "https://keycloak.example.com/realms/bitsafe"
         );
+    }
+
+    #[test]
+    fn discovery_base_falls_back_to_url_when_internal_unset() {
+        let cfg = KeycloakConfig {
+            url: "https://kc.example.com".to_string(),
+            internal_url: None,
+            realm: "bitsafe".to_string(),
+            client_id: "dpm".to_string(),
+            client_secret: None,
+            username: None,
+            password: None,
+        };
+        // Unset internal_url → identical to the issuer, preserving old behavior.
+        assert_eq!(oidc_discovery_base_of(&cfg), oidc_issuer_of(&cfg));
+        assert_eq!(
+            oidc_discovery_base_of(&cfg),
+            "https://kc.example.com/realms/bitsafe"
+        );
+    }
+
+    #[test]
+    fn discovery_base_uses_internal_url_when_set() {
+        let cfg = KeycloakConfig {
+            url: "https://kc.public.example/".to_string(),
+            internal_url: Some("http://kc.svc.cluster.local/".to_string()),
+            realm: "bitsafe".to_string(),
+            client_id: "dpm".to_string(),
+            client_secret: None,
+            username: None,
+            password: None,
+        };
+        // Discovery targets the internal host; issuer stays the public URL.
+        assert_eq!(
+            oidc_discovery_base_of(&cfg),
+            "http://kc.svc.cluster.local/realms/bitsafe"
+        );
+        assert_eq!(
+            oidc_issuer_of(&cfg),
+            "https://kc.public.example/realms/bitsafe"
+        );
+    }
+
+    #[test]
+    fn discovery_base_treats_empty_internal_url_as_unset() {
+        let cfg = KeycloakConfig {
+            url: "https://kc.example.com".to_string(),
+            internal_url: Some(String::new()),
+            realm: "bitsafe".to_string(),
+            client_id: "dpm".to_string(),
+            client_secret: None,
+            username: None,
+            password: None,
+        };
+        assert_eq!(oidc_discovery_base_of(&cfg), oidc_issuer_of(&cfg));
     }
 
     #[test]

--- a/src/auth/validators/jwt.rs
+++ b/src/auth/validators/jwt.rs
@@ -20,7 +20,10 @@ use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode, decode_header};
 use serde::Deserialize;
 use tokio::sync::RwLock;
 
-use super::common::{RealmAccess, auth0_issuer_of, collect_roles, extract_issuer, oidc_issuer_of};
+use super::common::{
+    RealmAccess, auth0_issuer_of, collect_roles, extract_issuer, oidc_discovery_base_of,
+    oidc_issuer_of,
+};
 use crate::{
     auth::validator::{Principal, ValidationError},
     config::{Auth0Config, KeycloakConfig, PartyCredentials},
@@ -43,6 +46,14 @@ pub struct JwtValidator {
 struct CachedJwks {
     keys: HashMap<String, KeyEntry>,
     expires_at: SystemTime,
+}
+
+/// A matched trusted issuer: the `client_id` to enforce against the token's
+/// `azp`, plus the base URL the server fetches OIDC metadata from (equal to
+/// the issuer unless a backchannel `internal_url` is configured).
+struct TrustedIssuer {
+    client_id: String,
+    discovery_base: String,
 }
 
 #[derive(Clone)]
@@ -151,15 +162,18 @@ impl JwtValidator {
         }
 
         let issuer = extract_issuer(token)?;
-        let Some(expected_client_id) = self.find_trusted_client_id(&issuer).await else {
+        let Some(trusted) = self.find_trusted(&issuer).await else {
             tracing::warn!("rejected token from untrusted issuer: {issuer}");
             return Err(ValidationError::UntrustedIssuer(issuer));
         };
+        let expected_client_id = trusted.client_id;
 
         let header = decode_header(token).map_err(|_| ValidationError::MalformedToken)?;
         let kid = header.kid.ok_or(ValidationError::MalformedToken)?;
 
-        let entry = self.resolve_key(&issuer, &kid).await?;
+        let entry = self
+            .resolve_key(&issuer, &trusted.discovery_base, &kid)
+            .await?;
 
         // Pin algorithm: reject if the token's header advertises an alg
         // different from the JWK's. Without this, an attacker who could
@@ -226,35 +240,57 @@ impl JwtValidator {
         })
     }
 
-    /// Find the expected `client_id` (for the `azp` check) corresponding to
-    /// the given issuer. Searches inbound Keycloak, inbound Auth0, and any
-    /// per-party Keycloak or Auth0 configs.
-    async fn find_trusted_client_id(&self, issuer: &str) -> Option<String> {
+    /// Find the trusted config matching the given issuer, returning both the
+    /// expected `client_id` (for the `azp` check) and the discovery base the
+    /// server should fetch OIDC metadata from. Searches inbound Keycloak,
+    /// inbound Auth0, and any per-party Keycloak or Auth0 configs.
+    ///
+    /// For Keycloak the discovery base is `oidc_discovery_base_of` (which
+    /// honors `internal_url`); for Auth0 it is the issuer itself (Auth0 has no
+    /// separate backchannel URL here).
+    async fn find_trusted(&self, issuer: &str) -> Option<TrustedIssuer> {
         if let Some(ref cfg) = self.inbound
             && oidc_issuer_of(cfg) == issuer
         {
-            return Some(cfg.client_id.clone());
+            return Some(TrustedIssuer {
+                client_id: cfg.client_id.clone(),
+                discovery_base: oidc_discovery_base_of(cfg),
+            });
         }
         if let Some(ref cfg) = self.auth0
             && auth0_issuer_of(cfg) == issuer
         {
-            return Some(cfg.client_id.clone());
+            return Some(TrustedIssuer {
+                client_id: cfg.client_id.clone(),
+                discovery_base: issuer.to_string(),
+            });
         }
         let creds = self.party_credentials.read().await;
         for party in creds.iter() {
             if let Some(ref a) = party.auth0
                 && format!("https://{}", a.domain.trim_end_matches('/')) == issuer
             {
-                return Some(a.client_id.clone());
+                return Some(TrustedIssuer {
+                    client_id: a.client_id.clone(),
+                    discovery_base: issuer.to_string(),
+                });
             }
             if oidc_issuer_of(&party.keycloak) == issuer {
-                return Some(party.keycloak.client_id.clone());
+                return Some(TrustedIssuer {
+                    client_id: party.keycloak.client_id.clone(),
+                    discovery_base: oidc_discovery_base_of(&party.keycloak),
+                });
             }
         }
         None
     }
 
-    async fn resolve_key(&self, issuer: &str, kid: &str) -> Result<KeyEntry, ValidationError> {
+    async fn resolve_key(
+        &self,
+        issuer: &str,
+        discovery_base: &str,
+        kid: &str,
+    ) -> Result<KeyEntry, ValidationError> {
         // Fast path: cached JWKS still fresh.
         {
             let cache = self.jwks_cache.read().await;
@@ -266,7 +302,7 @@ impl JwtValidator {
             }
         }
 
-        let keys = self.fetch_jwks(issuer).await?;
+        let keys = self.fetch_jwks(discovery_base, issuer).await?;
         let entry = keys
             .get(kid)
             .cloned()
@@ -286,8 +322,16 @@ impl JwtValidator {
         Ok(entry)
     }
 
-    async fn fetch_jwks(&self, issuer: &str) -> Result<HashMap<String, KeyEntry>, ValidationError> {
-        let discovery_url = format!("{issuer}/.well-known/openid-configuration");
+    /// Fetch and parse the JWKS for an issuer. `discovery_base` is where the
+    /// OIDC metadata is actually fetched from (honors `internal_url`); `issuer`
+    /// is used only for cache keys and error context. They are equal unless a
+    /// backchannel URL is configured.
+    async fn fetch_jwks(
+        &self,
+        discovery_base: &str,
+        issuer: &str,
+    ) -> Result<HashMap<String, KeyEntry>, ValidationError> {
+        let discovery_url = format!("{discovery_base}/.well-known/openid-configuration");
         let discovery: OidcDiscovery = self
             .http
             .get(&discovery_url)
@@ -521,6 +565,7 @@ mod tests {
 
         let inbound = KeycloakConfig {
             url: server.uri(),
+            internal_url: None,
             realm: "test".to_string(),
             client_id: "dpm".to_string(),
             client_secret: None,
@@ -577,6 +622,66 @@ mod tests {
         assert_eq!(principal.issuer, issuer);
         assert!(principal.has_role("admin"));
         assert!(principal.has_role("user"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn fetches_metadata_from_internal_url_while_trusting_public_issuer() -> anyhow::Result<()>
+    {
+        // The server cannot reach the public `url` (an unreachable host), but
+        // `internal_url` points at the reachable IdP. Discovery + JWKS must be
+        // fetched from `internal_url`, while the token's `iss` (the public url,
+        // what a browser login carries) still anchors trust. Proves the
+        // frontchannel/backchannel split: if discovery were still derived from
+        // `iss`, this would fail to reach `unreachable.invalid`.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/realms/test/.well-known/openid-configuration"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "jwks_uri": format!("{}/jwks", server.uri()),
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/jwks"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "keys": [{
+                    "kid": TEST_KID,
+                    "kty": "RSA",
+                    "use": "sig",
+                    "alg": "RS256",
+                    "n": TEST_JWK_N,
+                    "e": TEST_JWK_E,
+                }],
+            })))
+            .mount(&server)
+            .await;
+
+        let public_url = "https://unreachable.invalid".to_string();
+        let inbound = KeycloakConfig {
+            url: public_url.clone(),
+            internal_url: Some(server.uri()),
+            realm: "test".to_string(),
+            client_id: "dpm".to_string(),
+            client_secret: None,
+            username: None,
+            password: None,
+        };
+        let validator = JwtValidator::new(
+            Some(inbound),
+            None,
+            std::sync::Arc::new(tokio::sync::RwLock::new(Vec::new())),
+            reqwest::Client::new(),
+        );
+
+        let issuer = format!("{public_url}/realms/test");
+        let token = rs256_token(&issuer, "dpm", 3600)?;
+        let principal = validator
+            .validate(&token)
+            .await
+            .map_err(|e| anyhow::anyhow!("expected token to validate via internal_url: {e:?}"))?;
+        assert_eq!(principal.issuer, issuer);
+        assert!(principal.has_role("admin"));
         Ok(())
     }
 

--- a/src/auth/validators/jwt.rs
+++ b/src/auth/validators/jwt.rs
@@ -22,7 +22,7 @@ use tokio::sync::RwLock;
 
 use super::common::{
     RealmAccess, auth0_issuer_of, collect_roles, extract_issuer, oidc_discovery_base_of,
-    oidc_issuer_of,
+    oidc_issuer_of, rewrite_authority,
 };
 use crate::{
     auth::validator::{Principal, ValidationError},
@@ -349,9 +349,12 @@ impl JwtValidator {
                 message: e.to_string(),
             })?;
 
+        // Fetch keys from the host we reached discovery on, not the host the
+        // discovery doc advertises — see `rewrite_authority`.
+        let jwks_uri = rewrite_authority(&discovery.jwks_uri, discovery_base);
         let jwks: JwkSet = self
             .http
-            .get(&discovery.jwks_uri)
+            .get(&jwks_uri)
             .send()
             .await
             .and_then(|r| r.error_for_status())
@@ -629,16 +632,19 @@ mod tests {
     async fn fetches_metadata_from_internal_url_while_trusting_public_issuer() -> anyhow::Result<()>
     {
         // The server cannot reach the public `url` (an unreachable host), but
-        // `internal_url` points at the reachable IdP. Discovery + JWKS must be
-        // fetched from `internal_url`, while the token's `iss` (the public url,
-        // what a browser login carries) still anchors trust. Proves the
-        // frontchannel/backchannel split: if discovery were still derived from
-        // `iss`, this would fail to reach `unreachable.invalid`.
+        // `internal_url` points at the reachable IdP. The token's `iss` (the
+        // public url, what a browser login carries) still anchors trust.
+        //
+        // Crucially, discovery here advertises a `jwks_uri` on the UNREACHABLE
+        // public host — exactly what a Keycloak with a pinned frontend hostname
+        // does. Validation must still succeed because `rewrite_authority`
+        // redirects the key fetch to the internal host we reached discovery on.
+        // Following `jwks_uri` verbatim would fail against `unreachable.invalid`.
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/realms/test/.well-known/openid-configuration"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-                "jwks_uri": format!("{}/jwks", server.uri()),
+                "jwks_uri": "https://unreachable.invalid/jwks",
             })))
             .mount(&server)
             .await;

--- a/src/auth/validators/oidc_introspection.rs
+++ b/src/auth/validators/oidc_introspection.rs
@@ -8,7 +8,9 @@ use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use tokio::sync::RwLock;
 
-use super::common::{RealmAccess, collect_roles, extract_issuer, oidc_issuer_of};
+use super::common::{
+    RealmAccess, collect_roles, extract_issuer, oidc_discovery_base_of, oidc_issuer_of,
+};
 use crate::{
     auth::validator::{Principal, ValidationError},
     config::{KeycloakConfig, PartyCredentials},
@@ -119,7 +121,10 @@ impl OidcIntrospectionValidator {
             ValidationError::UntrustedIssuer(issuer.clone())
         })?;
 
-        let endpoint = self.resolve_introspection_endpoint(&issuer).await?;
+        let discovery_base = oidc_discovery_base_of(&config);
+        let endpoint = self
+            .resolve_introspection_endpoint(&issuer, &discovery_base)
+            .await?;
         let response = self.introspect(&endpoint, token, &config).await?;
 
         if !response.active {
@@ -183,9 +188,14 @@ impl OidcIntrospectionValidator {
             .map(|p| p.keycloak.clone())
     }
 
+    /// Resolve (and cache) the introspection endpoint for an issuer.
+    /// `discovery_base` is where the OIDC metadata is actually fetched from
+    /// (honors `internal_url`); `issuer` keys the cache and error context. They
+    /// are equal unless a backchannel URL is configured.
     async fn resolve_introspection_endpoint(
         &self,
         issuer: &str,
+        discovery_base: &str,
     ) -> Result<String, ValidationError> {
         {
             let cache = self.discovery_cache.read().await;
@@ -196,7 +206,7 @@ impl OidcIntrospectionValidator {
             }
         }
 
-        let url = format!("{issuer}/.well-known/openid-configuration");
+        let url = format!("{discovery_base}/.well-known/openid-configuration");
         let doc: OidcDiscovery = self
             .http
             .get(&url)
@@ -298,6 +308,7 @@ mod tests {
     fn inbound_config(server_uri: &str) -> KeycloakConfig {
         KeycloakConfig {
             url: server_uri.to_string(),
+            internal_url: None,
             realm: "test".to_string(),
             client_id: "dpm".to_string(),
             client_secret: Some("secret".to_string()),

--- a/src/auth/validators/oidc_introspection.rs
+++ b/src/auth/validators/oidc_introspection.rs
@@ -10,6 +10,7 @@ use tokio::sync::RwLock;
 
 use super::common::{
     RealmAccess, collect_roles, extract_issuer, oidc_discovery_base_of, oidc_issuer_of,
+    rewrite_authority,
 };
 use crate::{
     auth::validator::{Principal, ValidationError},
@@ -228,12 +229,15 @@ impl OidcIntrospectionValidator {
                 message: e.to_string(),
             })?;
 
-        let endpoint =
+        let advertised =
             doc.introspection_endpoint
                 .ok_or_else(|| ValidationError::DiscoveryFailed {
                     issuer: issuer.to_string(),
                     message: "provider does not advertise introspection_endpoint".to_string(),
                 })?;
+        // Call introspection on the host we reached discovery on, not the host
+        // the discovery doc advertises — see `rewrite_authority`.
+        let endpoint = rewrite_authority(&advertised, discovery_base);
 
         let mut cache = self.discovery_cache.write().await;
         cache.insert(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -106,6 +106,15 @@ pub enum Commands {
         #[arg(long, env = "DECPM_KEYCLOAK_CLIENT_ID")]
         keycloak_client_id: Option<String>,
 
+        /// Internal/backchannel Keycloak base URL the server uses for OIDC
+        /// discovery, JWKS, and introspection when it cannot reach
+        /// `DECPM_KEYCLOAK_URL` directly — e.g. that points at a tailnet
+        /// (`.ts.net`) host the browser can reach but the in-cluster pod
+        /// cannot, so the server uses the cluster Service instead. Defaults to
+        /// `DECPM_KEYCLOAK_URL` when unset; does not change the token issuer.
+        #[arg(long, env = "DECPM_KEYCLOAK_INTERNAL_URL")]
+        keycloak_internal_url: Option<String>,
+
         // Auth0 (top-level, for frontend gating). Env-only: hidden from
         // --help so operators always configure these via deploy env vars,
         // mirroring `DECPM_KEYCLOAK_*` but with no CLI flag surface.

--- a/src/config.rs
+++ b/src/config.rs
@@ -52,8 +52,24 @@ impl NetworkConfig {
 /// 2. Password flow: Set `client_id`, `username`, and `password`
 #[derive(Clone, Debug, Default, Deserialize, Serialize, utoipa::ToSchema)]
 pub struct KeycloakConfig {
-    /// Keycloak server URL (e.g., "https://keycloak.example.com")
+    /// Keycloak server URL (e.g., "https://keycloak.example.com"). This is the
+    /// URL the browser logs in against and is what appears as the token `iss`,
+    /// so it anchors issuer matching during validation.
     pub url: String,
+    /// Internal/backchannel base URL the *server* uses to reach this Keycloak
+    /// for OIDC discovery, JWKS, and introspection.
+    ///
+    /// Set this when the server cannot reach `url` directly — e.g. `url` is a
+    /// tailnet (`.ts.net`) address the browser can reach but the in-cluster pod
+    /// cannot, so the server fetches metadata via the cluster Service instead.
+    /// In OIDC terms `url` is the frontchannel (browser-facing) URL and this is
+    /// the backchannel (server-to-server) URL.
+    ///
+    /// Falls back to `url` when unset or empty, so existing single-URL configs
+    /// behave exactly as before. Does not affect issuer matching — tokens still
+    /// carry `url` as `iss`.
+    #[serde(default)]
+    pub internal_url: Option<String>,
     /// Keycloak realm name
     pub realm: String,
     /// OAuth2 client ID

--- a/src/config.rs
+++ b/src/config.rs
@@ -68,7 +68,10 @@ pub struct KeycloakConfig {
     /// Falls back to `url` when unset or empty, so existing single-URL configs
     /// behave exactly as before. Does not affect issuer matching — tokens still
     /// carry `url` as `iss`.
-    #[serde(default)]
+    ///
+    /// `skip_serializing`: server-only address, must never reach the browser
+    /// via `GET /node-config`.
+    #[serde(default, skip_serializing)]
     pub internal_url: Option<String>,
     /// Keycloak realm name
     pub realm: String,

--- a/src/db/rows.rs
+++ b/src/db/rows.rs
@@ -116,6 +116,10 @@ impl PartyCredentialsRow {
             user_id: self.user_id,
             keycloak: KeycloakConfig {
                 url: self.keycloak_url,
+                // Per-party credentials are not stored with a backchannel URL;
+                // the server-side internal URL is an env-configured, inbound
+                // (frontend-gating) concern. Falls back to `url`.
+                internal_url: None,
                 realm: self.keycloak_realm,
                 client_id: crypto::decrypt(&self.keycloak_client_id)?,
                 client_secret: crypto::decrypt_opt(self.keycloak_client_secret)?,

--- a/src/db/sqlite.rs
+++ b/src/db/sqlite.rs
@@ -1123,6 +1123,7 @@ mod tests {
             user_id: "test-user".to_string(),
             keycloak: KeycloakConfig {
                 url: "https://kc.example.com".to_string(),
+                internal_url: None,
                 realm: "test".to_string(),
                 client_id: "client-1".to_string(),
                 client_secret: Some("secret".to_string()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,11 +115,12 @@ async fn main() -> Result {
             if let Some(net) = canton_network {
                 config.canton.network = *net;
             }
-            if keycloak_url.is_some()
-                || keycloak_realm.is_some()
-                || keycloak_client_id.is_some()
-                || keycloak_internal_url.is_some()
-            {
+            // `internal_url` is deliberately not in this guard: it only
+            // supplements a real Keycloak config and is meaningless on its
+            // own, so it must not by itself materialize a config with empty
+            // url/realm/client_id. It is applied below only when one of those
+            // three has already established the config.
+            if keycloak_url.is_some() || keycloak_realm.is_some() || keycloak_client_id.is_some() {
                 let kc = config.keycloak.get_or_insert(KeycloakConfig {
                     url: String::new(),
                     internal_url: None,
@@ -141,6 +142,11 @@ async fn main() -> Result {
                 if let Some(client_id) = keycloak_client_id {
                     kc.client_id = client_id.clone();
                 }
+            } else if keycloak_internal_url.is_some() {
+                tracing::warn!(
+                    "DECPM_KEYCLOAK_INTERNAL_URL is set but DECPM_KEYCLOAK_URL/REALM/CLIENT_ID \
+                     are not; no Keycloak config was created and the internal URL is ignored"
+                );
             }
 
             if let (Some(domain), Some(client_id)) = (auth0_domain, auth0_client_id) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,6 +70,7 @@ async fn main() -> Result {
             keycloak_url,
             keycloak_realm,
             keycloak_client_id,
+            keycloak_internal_url,
             auth0_domain,
             auth0_client_id,
             auth0_audience,
@@ -114,9 +115,14 @@ async fn main() -> Result {
             if let Some(net) = canton_network {
                 config.canton.network = *net;
             }
-            if keycloak_url.is_some() || keycloak_realm.is_some() || keycloak_client_id.is_some() {
+            if keycloak_url.is_some()
+                || keycloak_realm.is_some()
+                || keycloak_client_id.is_some()
+                || keycloak_internal_url.is_some()
+            {
                 let kc = config.keycloak.get_or_insert(KeycloakConfig {
                     url: String::new(),
+                    internal_url: None,
                     realm: String::new(),
                     client_id: String::new(),
                     client_secret: None,
@@ -125,6 +131,9 @@ async fn main() -> Result {
                 });
                 if let Some(url) = keycloak_url {
                     kc.url = url.clone();
+                }
+                if let Some(internal_url) = keycloak_internal_url {
+                    kc.internal_url = Some(internal_url.clone());
                 }
                 if let Some(realm) = keycloak_realm {
                     kc.realm = realm.clone();

--- a/src/server/handlers/party_config.rs
+++ b/src/server/handlers/party_config.rs
@@ -273,6 +273,7 @@ pub async fn save_party_config(
         // string still means "clear" via `filter`.
         KeycloakConfig {
             url: req.keycloak_url,
+            internal_url: None,
             realm: req.keycloak_realm,
             client_id: req.keycloak_client_id,
             client_secret: req.keycloak_client_secret.filter(|s| !s.is_empty()),
@@ -282,6 +283,7 @@ pub async fn save_party_config(
     } else {
         KeycloakConfig {
             url: req.keycloak_url,
+            internal_url: None,
             realm: req.keycloak_realm,
             client_id: req.keycloak_client_id,
             client_secret: merge_optional_secret(
@@ -661,6 +663,7 @@ mod tests {
             user_id: "test-user".to_string(),
             keycloak: KeycloakConfig {
                 url: "https://original-keycloak.example.com".to_string(),
+                internal_url: None,
                 realm: "test-realm".to_string(),
                 client_id: "test-client".to_string(),
                 client_secret: Some("super-secret".to_string()),
@@ -738,6 +741,7 @@ mod tests {
         let mut config = NodeConfig::default();
         config.keycloak = Some(KeycloakConfig {
             url: "https://deployed-keycloak.example.com".to_string(),
+            internal_url: None,
             realm: "deployed-realm".to_string(),
             client_id: "frontend-gating-client".to_string(),
             client_secret: None,


### PR DESCRIPTION
<!-- Thanks for contributing! Please fill out the sections below. -->

## Summary

Core mechanism — the token's iss (built from url) still anchors trust, but the server now fetches OIDC metadata from a separate base:

- config.rs — added internal_url: Option<String> to KeycloakConfig (#[serde(default)], documented as the backchannel URL).
- common.rs — new oidc_discovery_base_of(): uses internal_url when set & non-empty, else falls back to url. oidc_issuer_of() (issuer matching) is unchanged.
- jwt.rs— the trust lookup now returns a TrustedIssuer { client_id, discovery_base }; resolve_key/fetch_jwks fetch from the discovery base, with cache + errors still keyed by the public issuer.
- oidc_introspection.rs — same split for the introspection endpoint.
- cli.rs — new DECPM_KEYCLOAK_INTERNAL_URL env / --keycloak-internal-url arg.
- main.rs — plumbed into the inbound KeycloakConfig.
- /auth-config is untouched — the browser still gets url (public), never the internal URL.

Backward compatibility — when internal_url is unset/empty, oidc_discovery_base_of returns exactly the issuer string, so every fetch path behaves identically to before. Existing deployments need no config change. Tests cover unset, set, and empty-string cases, plus an end-to-end JWT test where url is unreachable and validation succeeds only via internal_url.

## Related issues

Solves the issue where the server and the client using the same Keycloak base URL however it is separate network-wise.

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build / CI / chore

## Checklist

- [X] `cargo fmt -- --check` passes
- [X] `cargo clippy --all-targets --all-features -- -D warnings` is clean
- [X] `cargo test` passes
- [X] Added/updated tests where appropriate
- [X] Updated documentation where appropriate
- [ ] Commits follow the `<type>(<scope>): <subject>` convention

## Notes for reviewers