### PR TITLE
refact(workflow): shared topology-retry helper + extend to kick

### DIFF
--- a/src/workflow/kick/steps/proposals/sign.rs
+++ b/src/workflow/kick/steps/proposals/sign.rs
@@ -3,7 +3,6 @@ use canton_proto_rs::com::digitalasset::canton::{
     protocol::v30::SignedTopologyTransaction,
     topology::admin::v30::{
         SignTransactionsRequest, StoreId, Synchronizer, store_id, synchronizer,
-        topology_manager_write_service_client::TopologyManagerWriteServiceClient,
     },
 };
 use prost::Message;
@@ -13,7 +12,10 @@ use crate::{
     config::NodeConfig,
     error::Result,
     utils,
-    workflow::storage::{WorkflowStorage, artifact_kinds},
+    workflow::{
+        storage::{WorkflowStorage, artifact_kinds},
+        topology::sign_transactions_with_topology_retry,
+    },
 };
 
 /// Sign kick proposals
@@ -46,11 +48,7 @@ pub async fn sign_proposals(
     let p2p_transaction: SignedTopologyTransaction =
         utils::read_first_message_from_bytes(&items[1])?;
 
-    // Sign both proposals
-    let mut topology_client =
-        TopologyManagerWriteServiceClient::connect(config.admin_api_url()).await?;
-
-    let request = tonic::Request::new(SignTransactionsRequest {
+    let request = SignTransactionsRequest {
         transactions: vec![dns_transaction, p2p_transaction],
         signed_by: vec![],
         store: Some(StoreId {
@@ -59,13 +57,10 @@ pub async fn sign_proposals(
             })),
         }),
         force_flags: vec![],
-    });
+    };
 
     tracing::debug!("Calling SignTransactions RPC for kick proposals...");
-    let response = topology_client
-        .sign_transactions(request)
-        .await?
-        .into_inner();
+    let response = sign_transactions_with_topology_retry(config, request, "kick").await?;
 
     if response.transactions.len() != 2 {
         anyhow::bail!(

--- a/src/workflow/mod.rs
+++ b/src/workflow/mod.rs
@@ -4,6 +4,7 @@ pub mod kick;
 pub mod onboarding;
 pub mod state;
 pub mod storage;
+pub mod topology;
 
 use anyhow::Context;
 use canton_proto_rs::com::digitalasset::canton::{

--- a/src/workflow/onboarding/steps/proposals/sign.rs
+++ b/src/workflow/onboarding/steps/proposals/sign.rs
@@ -3,19 +3,19 @@ use canton_proto_rs::com::digitalasset::canton::{
     protocol::v30::SignedTopologyTransaction,
     topology::admin::v30::{
         SignTransactionsRequest, StoreId, Synchronizer, store_id, synchronizer,
-        topology_manager_write_service_client::TopologyManagerWriteServiceClient,
     },
 };
 use prost::Message;
 use sqlx::SqlitePool;
-use tokio::time;
 
 use crate::{
     config::NodeConfig,
-    consts::{topology_retry_delay_secs, topology_retry_max_attempts},
     error::Result,
     utils,
-    workflow::storage::{WorkflowStorage, artifact_kinds},
+    workflow::{
+        storage::{WorkflowStorage, artifact_kinds},
+        topology::sign_transactions_with_topology_retry,
+    },
 };
 
 /// Sign a single topology proposal and persist the result.
@@ -43,63 +43,19 @@ async fn sign_proposal(
     let transaction: SignedTopologyTransaction =
         utils::read_first_message_from_bytes(proposal_data)?;
 
-    let mut topology_client =
-        TopologyManagerWriteServiceClient::connect(config.admin_api_url()).await?;
+    let request = SignTransactionsRequest {
+        transactions: vec![transaction],
+        signed_by: vec![],
+        store: Some(StoreId {
+            store: Some(store_id::Store::Synchronizer(Synchronizer {
+                kind: Some(synchronizer::Kind::PhysicalId(synchronizer_id)),
+            })),
+        }),
+        force_flags: vec![],
+    };
 
-    // Canton propagates a freshly-generated namespace key into the signing-key
-    // store asynchronously — 10-20s on devnet's kubectl-tunneled cluster. A peer
-    // that signs the DNS/P2P topology transaction before that completes is
-    // rejected with TOPOLOGY_NO_APPROPRIATE_SIGNING_KEY_IN_STORE. That is
-    // transient propagation lag, not a genuine failure, so retry on it using the
-    // same budget the topology-submit steps use (configurable via the
-    // DPM_TOPOLOGY_RETRY_* env vars). Any other error fails immediately.
-    let max_attempts = topology_retry_max_attempts();
-    let retry_delay = time::Duration::from_secs(topology_retry_delay_secs());
-
-    let mut signed = None;
-    for attempt in 1..=max_attempts {
-        // `SignTransactionsRequest` takes ownership of its fields, so the
-        // request is rebuilt on each attempt.
-        let request = tonic::Request::new(SignTransactionsRequest {
-            transactions: vec![transaction.clone()],
-            signed_by: vec![],
-            store: Some(StoreId {
-                store: Some(store_id::Store::Synchronizer(Synchronizer {
-                    kind: Some(synchronizer::Kind::PhysicalId(synchronizer_id.clone())),
-                })),
-            }),
-            force_flags: vec![],
-        });
-
-        tracing::debug!(
-            "Calling SignTransactions RPC for {proposal_type} (attempt {attempt}/{max_attempts})..."
-        );
-        match topology_client.sign_transactions(request).await {
-            Ok(response) => {
-                signed = Some(response.into_inner());
-                break;
-            }
-            Err(status)
-                if attempt < max_attempts
-                    && status
-                        .message()
-                        .contains("TOPOLOGY_NO_APPROPRIATE_SIGNING_KEY") =>
-            {
-                tracing::warn!(
-                    "{proposal_type} signing key not yet propagated to Canton \
-                     (attempt {attempt}/{max_attempts}), retrying in {retry_delay:?}..."
-                );
-                time::sleep(retry_delay).await;
-            }
-            Err(status) => return Err(status.into()),
-        }
-    }
-
-    let response = signed.ok_or_else(|| {
-        anyhow::anyhow!(
-            "{proposal_type} signing key never propagated to Canton after {max_attempts} attempts"
-        )
-    })?;
+    tracing::debug!("Calling SignTransactions RPC for {proposal_type}...");
+    let response = sign_transactions_with_topology_retry(config, request, proposal_type).await?;
 
     if response.transactions.is_empty() {
         anyhow::bail!("No signed transaction returned for {proposal_type}");

--- a/src/workflow/topology.rs
+++ b/src/workflow/topology.rs
@@ -1,0 +1,148 @@
+//! Cross-workflow Canton topology helpers.
+//!
+//! Workflows (onboarding, kick, …) that submit signed topology transactions
+//! to Canton share the same write path
+//! ([`TopologyManagerWriteServiceClient::sign_transactions`]) and the same
+//! transient failure mode while a freshly-restarted participant's local
+//! topology store is reconciling. This module owns the retry policy so
+//! callers don't reach across workflow boundaries to share it.
+
+use std::time::Duration;
+
+use canton_proto_rs::com::digitalasset::canton::topology::admin::v30::{
+    SignTransactionsRequest, SignTransactionsResponse,
+    topology_manager_write_service_client::TopologyManagerWriteServiceClient,
+};
+
+use crate::{
+    config::NodeConfig,
+    consts::{topology_retry_delay_secs, topology_retry_max_attempts},
+    error::Result,
+};
+
+/// Call `sign_transactions` on the participant's TopologyManagerWriteService,
+/// retrying only when Canton returns
+/// `TOPOLOGY_NO_APPROPRIATE_SIGNING_KEY_IN_STORE` — the transient that
+/// surfaces while a freshly-restarted participant's local topology store is
+/// still reconciling its own signing keys.
+///
+/// All other gRPC errors bubble up immediately. On a healthy synchronizer
+/// the first attempt succeeds, so production code paths pay no retry-loop
+/// overhead.
+///
+/// The retry budget is [`topology_retry_max_attempts`] ×
+/// [`topology_retry_delay_secs`] (env-configurable via
+/// `DPM_TOPOLOGY_RETRY_MAX_ATTEMPTS` / `DPM_TOPOLOGY_RETRY_DELAY_SECS`,
+/// defaults 30 × 2s = 60s), shared with the post-write topology-propagation
+/// polls in `submit.rs::wait_for_dns_in_topology` /
+/// `wait_for_p2p_in_topology`.
+///
+/// `label` is a short tag included in log lines (e.g. `"DNS"`, `"P2P"`,
+/// `"kick"`) so operators can distinguish which sign path is retrying.
+pub async fn sign_transactions_with_topology_retry(
+    config: &NodeConfig,
+    request: SignTransactionsRequest,
+    label: &str,
+) -> Result<SignTransactionsResponse> {
+    let mut topology_client =
+        TopologyManagerWriteServiceClient::connect(config.admin_api_url()).await?;
+
+    let max_attempts = topology_retry_max_attempts();
+    let retry_delay = Duration::from_secs(topology_retry_delay_secs());
+
+    let mut attempt = 0usize;
+    loop {
+        attempt += 1;
+        match topology_client
+            .sign_transactions(tonic::Request::new(request.clone()))
+            .await
+        {
+            Ok(response) => {
+                if attempt > 1 {
+                    tracing::info!(
+                        "{label}: sign_transactions succeeded on attempt {attempt}/{max_attempts}",
+                    );
+                }
+                return Ok(response.into_inner());
+            }
+            Err(status) if is_topology_signing_key_not_ready(&status) => {
+                if attempt >= max_attempts {
+                    anyhow::bail!(
+                        "{label}: sign_transactions still returning \
+                         TOPOLOGY_NO_APPROPRIATE_SIGNING_KEY_IN_STORE after \
+                         {max_attempts} attempts: {status}",
+                    );
+                }
+                tracing::warn!(
+                    "{label}: TOPOLOGY_NO_APPROPRIATE_SIGNING_KEY_IN_STORE \
+                     on attempt {attempt}/{max_attempts}, retrying in {retry_delay:?}",
+                );
+                tokio::time::sleep(retry_delay).await;
+            }
+            Err(status) => return Err(status.into()),
+        }
+    }
+}
+
+/// Returns true iff the gRPC status is Canton's signal that a participant's
+/// local topology store doesn't yet have a usable signing key for the
+/// transaction it was asked to sign. This is a transient that resolves once
+/// Canton finishes reconciling the participant's `OwnerToKeyMapping` /
+/// `NamespaceDelegation` — typically within seconds of participant startup
+/// (longer on slow/tunneled deployments).
+///
+/// Matches on the Canton error name in the status message rather than the
+/// gRPC code, because Canton surfaces this error as different gRPC codes in
+/// different paths — observed as `NOT_FOUND` from `sign_transactions`
+/// (devnet run 2026-05-21, four occurrences on P2 with code
+/// `'Some requested entity was not found'`), but historically documented
+/// as `FAILED_PRECONDITION` elsewhere. The error-name string is the stable
+/// semantic identifier; the gRPC code is implementation detail that varies
+/// across Canton versions and call paths.
+fn is_topology_signing_key_not_ready(status: &tonic::Status) -> bool {
+    status
+        .message()
+        .contains("TOPOLOGY_NO_APPROPRIATE_SIGNING_KEY_IN_STORE")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Real status text Canton returned from `sign_transactions` on devnet
+    /// (2026-05-21 IT run). Code is `NOT_FOUND`, not `FAILED_PRECONDITION` —
+    /// this is the exact case the original predicate missed.
+    #[test]
+    fn detects_canton_not_found_form() {
+        let status = tonic::Status::not_found(
+            "TOPOLOGY_NO_APPROPRIATE_SIGNING_KEY_IN_STORE(11,0): \
+             Could not find an appropriate signing key to issue the topology transaction",
+        );
+        assert!(is_topology_signing_key_not_ready(&status));
+    }
+
+    /// Canton has historically surfaced the same error via FAILED_PRECONDITION
+    /// in other paths. Match this too so future Canton-version changes don't
+    /// reintroduce the flake.
+    #[test]
+    fn detects_failed_precondition_form() {
+        let status = tonic::Status::failed_precondition(
+            "TOPOLOGY_NO_APPROPRIATE_SIGNING_KEY_IN_STORE(9,abc): \
+             No appropriate signing key for namespace …",
+        );
+        assert!(is_topology_signing_key_not_ready(&status));
+    }
+
+    #[test]
+    fn rejects_other_canton_errors() {
+        let status =
+            tonic::Status::failed_precondition("SOME_OTHER_TOPOLOGY_ERROR: irrelevant detail");
+        assert!(!is_topology_signing_key_not_ready(&status));
+    }
+
+    #[test]
+    fn rejects_empty_message() {
+        let status = tonic::Status::internal("");
+        assert!(!is_topology_signing_key_not_ready(&status));
+    }
+}


### PR DESCRIPTION
## Summary

Re-creation of #169 (which can no longer be reopened — its branch history was rewritten at close time, so GitHub permanently blocks reopen). Rebased cleanly onto the current open-sourced `main`; contains **only** the two genuinely-new commits, nothing already on `main`.

- `refact(workflow)`: extracted the onboarding topology-retry into a shared `src/workflow/topology.rs` helper.
- `fix(kick)`: applied the same `TOPOLOGY_NO_APPROPRIATE_SIGNING_KEY_IN_STORE` retry to kick proposal signing (previously only onboarding had it).

**2 commits, 4 files, +172/−72.**

## Context

Supersedes #169. The original review there from @schronck still applies — two items to tighten before merge:
1. `wait_for_ports_free` probes `127.0.0.1` but `NoiseServer` binds `node.listen_address`.
2. (second nit from that thread)

## Type of change
- [X] Refactor / bug fix
