### PR TITLE
fix(ui): surface proposal errors + fix transfer proposal submission

### DIFF
--- a/deploy-all.sh
+++ b/deploy-all.sh
@@ -2,9 +2,17 @@
 
 set -e
 
+KUBE_CONTEXT="$(kubectl config current-context)"
+if [[ "$KUBE_CONTEXT" != *devnet* ]]; then
+  echo "Refusing to deploy: current kube context '$KUBE_CONTEXT' does not contain 'devnet'." >&2
+  echo "Switch to a devnet context with 'kubectl config use-context <ctx>' and retry." >&2
+  exit 1
+fi
+echo "Using kube context: $KUBE_CONTEXT"
+
 aws sso login
 
-TAG="0.1.7"
+TAG="0.1.8"
 IMAGE="public.ecr.aws/dlc-link/canton-decparty-manager"
 DEPLOY_DIR="zarf/deployments/devnet"
 

--- a/frontend/src/components/GovernanceSection.tsx
+++ b/frontend/src/components/GovernanceSection.tsx
@@ -4010,11 +4010,11 @@ export const GovernanceSection = ({
                         setProposalInputHoldingCids(e.target.value)
                       }
                       fullWidth
-                      helperText="Optional — pin specific Holding contracts to spend. Leave empty to let Canton auto-select holdings of the chosen instrument up to the amount."
+                      helperText="Optional — pin specific Holding contracts to spend. Leave empty to spend all of your holdings of the chosen instrument (change is returned)."
                       slotProps={{
                         input: {
                           endAdornment: fieldHelpAdornment(
-                            "Optional list of specific Holding contract ids to spend, comma-separated. Leave empty to let Canton auto-select holdings up to the amount.",
+                            "Optional list of specific Holding contract ids to spend, comma-separated. Leave empty to spend all of your holdings of the chosen instrument; the transfer consumes what it needs and returns change.",
                             "Help for Input Holding CIDs",
                           ),
                         },

--- a/frontend/src/components/GovernanceSection.tsx
+++ b/frontend/src/components/GovernanceSection.tsx
@@ -4010,11 +4010,11 @@ export const GovernanceSection = ({
                         setProposalInputHoldingCids(e.target.value)
                       }
                       fullWidth
-                      helperText="Optional — pin specific Holding contracts to spend. Leave empty to spend all of your holdings of the chosen instrument (change is returned)."
+                      helperText="Optional — pin specific Holding contracts to spend. Leave empty to let the server select your holdings of the chosen instrument automatically (change is returned)."
                       slotProps={{
                         input: {
                           endAdornment: fieldHelpAdornment(
-                            "Optional list of specific Holding contract ids to spend, comma-separated. Leave empty to spend all of your holdings of the chosen instrument; the transfer consumes what it needs and returns change.",
+                            "Optional list of specific Holding contract ids to spend, comma-separated. Leave empty to let the server select your holdings of the chosen instrument automatically; the transfer consumes what it needs and returns change.",
                             "Help for Input Holding CIDs",
                           ),
                         },

--- a/frontend/src/components/GovernanceSection.tsx
+++ b/frontend/src/components/GovernanceSection.tsx
@@ -3401,6 +3401,16 @@ export const GovernanceSection = ({
 
   return (
     <Box sx={{ mt: 2 }}>
+      {/* Shared across both halves: the proposals view (`view="proposals"`)
+          does not render `showActionsHalf`, so keeping the error here ensures
+          a failed `/governance/propose` (or action) surfaces in either view
+          instead of failing silently. */}
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+          {error}
+        </Alert>
+      )}
+
       {showActionsHalf && (
       <>
       {view !== "actions" && (
@@ -3431,12 +3441,6 @@ export const GovernanceSection = ({
       )}
 
       <Collapse in={expanded}>
-        {error && (
-          <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
-            {error}
-          </Alert>
-        )}
-
         {(data?.gov_core_out_of_date || governanceState?.out_of_date) && (
           <Alert severity="warning" sx={{ mb: 2 }}>
             The governance core contract is out of date

--- a/src/server/handlers/governance.rs
+++ b/src/server/handlers/governance.rs
@@ -35,7 +35,7 @@ use crate::{
             get_holdings, get_instruments, get_open_burn_requests, get_open_mint_requests,
             get_open_transfer_instructions, get_provider_services, get_registrar_services,
             get_transfer_factories, get_user_services, get_vaults, query_contracts_by_template,
-            resolve_contract_package_ref,
+            resolve_contract_package_ref, select_input_holdings,
         },
         transfer_context::{
             AcceptTransferContext, ProposeTransferArgs, fetch as fetch_accept_transfer_context,
@@ -1141,6 +1141,38 @@ pub async fn propose_action(
                     });
                 }
             };
+            // The token-standard transfer factory rejects an empty
+            // `inputHoldingCids` ("No holdings provided"). When the caller
+            // didn't pin specific holdings, fund the transfer with every
+            // Holding the sender owns for this instrument and let the choice
+            // consume what it needs (returning change).
+            if input_holding_cids.is_empty() {
+                match select_input_holdings(
+                    &data.config,
+                    party_id,
+                    Some(token.clone()),
+                    &admin,
+                    &instrument_id.id,
+                )
+                .await
+                {
+                    Ok(cids) if cids.is_empty() => {
+                        return HttpResponse::BadRequest().json(ErrorResponse {
+                            error: format!(
+                                "No holdings of instrument {} owned by {} to fund the transfer",
+                                instrument_id.id, party_id
+                            ),
+                        });
+                    }
+                    Ok(cids) => *input_holding_cids = cids,
+                    Err(e) => {
+                        tracing::warn!("Failed to select input holdings for transfer: {e:#}");
+                        return HttpResponse::InternalServerError().json(ErrorResponse {
+                            error: format!("Failed to select input holdings: {e}"),
+                        });
+                    }
+                }
+            }
             match fetch_factory_for_propose(
                 data.config.canton.network,
                 ProposeTransferArgs {

--- a/src/server/queries.rs
+++ b/src/server/queries.rs
@@ -3844,6 +3844,7 @@ async fn fetch_holding_views(
 /// Intermediate parse result that retains `owner` so callers can drop holdings
 /// the party can see (via interface visibility) but doesn't actually own.
 struct HoldingView {
+    contract_id: String,
     owner: String,
     instrument_admin: CantonId,
     instrument_id: String,
@@ -3874,11 +3875,33 @@ fn extract_holding_view(created: &CreatedEvent) -> Option<HoldingView> {
     let instrument_id = field_text(instrument_record, "id")?;
 
     Some(HoldingView {
+        contract_id: created.contract_id.clone(),
         owner,
         instrument_admin,
         instrument_id,
         amount,
     })
+}
+
+/// Collect the contract ids of every `Holding` the party owns for a given
+/// instrument `(admin, id)`. Used by the Transfer proposal flow to fund the
+/// transfer when the caller doesn't pin specific holdings: the token-standard
+/// transfer factory rejects an empty `inputHoldingCids` ("No holdings
+/// provided"), so we hand it every matching holding and let the choice consume
+/// what it needs and return change.
+pub async fn select_input_holdings(
+    config: &NodeConfig,
+    party_id: &CantonId,
+    token: Option<String>,
+    instrument_admin: &CantonId,
+    instrument_id: &str,
+) -> Result<Vec<String>> {
+    let raw = fetch_holding_views(config, party_id, token).await?;
+    Ok(raw
+        .into_iter()
+        .filter(|h| h.instrument_admin == *instrument_admin && h.instrument_id == instrument_id)
+        .map(|h| h.contract_id)
+        .collect())
 }
 
 /// Result of the per-party preapproval lookup. `utility` is the set of

--- a/src/server/queries.rs
+++ b/src/server/queries.rs
@@ -3841,8 +3841,9 @@ async fn fetch_holding_views(
     Ok(holdings)
 }
 
-/// Intermediate parse result that retains `owner` so callers can drop holdings
-/// the party can see (via interface visibility) but doesn't actually own.
+/// Intermediate parse result. `owner` lets `fetch_holding_views` drop holdings
+/// the party can see (via interface visibility) but doesn't actually own,
+/// before the views reach any caller.
 struct HoldingView {
     contract_id: String,
     owner: String,

--- a/src/server/transfer_context.rs
+++ b/src/server/transfer_context.rs
@@ -129,7 +129,13 @@ pub async fn fetch_factory_for_propose(
                 requested_at: micros_to_rfc3339(args.requested_at_micros)?,
                 execute_before: micros_to_rfc3339(args.execute_before_micros)?,
                 input_holding_cids: Some(args.input_holding_cids.to_vec()),
-                meta: Some(Meta { values: None }),
+                // `values` has no skip_serializing_if, so `None` serializes as
+                // `"values": null`. The registry's token-standard Metadata
+                // decoder expects an object — `null` fails with
+                // "Expected { but was null". Send an empty map instead.
+                meta: Some(Meta {
+                    values: Some(HashMap::new()),
+                }),
             },
             extra_args: ExtraArgs {
                 context: Context {

--- a/zarf/deployments/devnet/participant1/deployment.yaml
+++ b/zarf/deployments/devnet/participant1/deployment.yaml
@@ -46,7 +46,7 @@ spec:
               mountPath: /app
       containers:
         - name: dec-party-manager
-          image: public.ecr.aws/dlc-link/canton-decparty-manager:0.1.7
+          image: public.ecr.aws/dlc-link/canton-decparty-manager:0.1.8
           imagePullPolicy: Always
           command: ["dec-party-manager", "serve"]
           ports:

--- a/zarf/deployments/devnet/participant2/deployment.yaml
+++ b/zarf/deployments/devnet/participant2/deployment.yaml
@@ -46,7 +46,7 @@ spec:
               mountPath: /app
       containers:
         - name: dec-party-manager
-          image: public.ecr.aws/dlc-link/canton-decparty-manager:0.1.7
+          image: public.ecr.aws/dlc-link/canton-decparty-manager:0.1.8
           imagePullPolicy: Always
           command: ["dec-party-manager", "serve"]
           ports:

--- a/zarf/deployments/devnet/participant3/deployment.yaml
+++ b/zarf/deployments/devnet/participant3/deployment.yaml
@@ -46,7 +46,7 @@ spec:
               mountPath: /app
       containers:
         - name: dec-party-manager
-          image: public.ecr.aws/dlc-link/canton-decparty-manager:0.1.7
+          image: public.ecr.aws/dlc-link/canton-decparty-manager:0.1.8
           imagePullPolicy: Always
           command: ["dec-party-manager", "serve"]
           ports:


### PR DESCRIPTION
## Summary

Fixes a silent failure when submitting a **Transfer** proposal from the **New Proposal** dialog. A screen recording showed the Submit button flicker disabled and re-enable, with the dialog staying open and no feedback. Root-causing surfaced three distinct bugs, each masking the next.

## Changes

- **UI — surface proposal errors** (`GovernanceSection.tsx`): the error `<Alert>` only rendered inside the `showActionsHalf` block, but the New Proposal dialog runs with `view="proposals"`, so any `/governance/propose` failure was swallowed silently. Hoisted the Alert above both halves so failures are visible in either view.
- **Server — empty metadata map** (`transfer_context.rs`): `Meta.values` has no `skip_serializing_if`, so `values: None` serialized as `"values": null`. The registry's token-standard `Metadata` decoder expects an object and rejected it with `Expected { but was null`. Now sends an empty map (`{}`).
- **Server — auto-select input holdings** (`queries.rs`, `governance.rs`): an empty `inputHoldingCids` made the registry reject the transfer-factory request with `No holdings provided`. When the caller doesn't pin holdings, we now select every `Holding` the sender owns for the instrument and fund the transfer with them (the choice consumes what it needs and returns change). Captured `contract_id` in `HoldingView`, added `select_input_holdings`, and corrected the misleading UI helper text.
- **Deploy** (`deploy-all.sh`, participant manifests): bump devnet image to `0.1.8` and refuse to deploy unless the current kube context contains `devnet`. *(Unrelated to the bug fix — carried over from working tree.)*

## Testing

- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo test` (transfer suite) passes
- `tsc -b` clean
- Error progression confirmed each fix in turn: `Expected { but was null` → `No holdings provided` → resolved.
