### PR TITLE
fix(transfer): exclude locked holdings and bound offer deadline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1111,7 +1111,7 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "dec-party-manager"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "actix-cors",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dec-party-manager"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/frontend/src/components/GovernanceSection.tsx
+++ b/frontend/src/components/GovernanceSection.tsx
@@ -133,6 +133,12 @@ const defaultFarConfig: FarConfig = {
 const defaultVaultRulesCid = DEVNET_VAULT_RULES.contract_id;
 const defaultVaultBackendSignatory = DEVNET_VAULT_BACKEND_SIGNATORY;
 
+/// Freely-transferable balance of a holding: total minus the locked
+/// (escrowed) portion. A transfer can only be funded from unlocked holdings,
+/// so the amount field is capped on this rather than `amount`.
+const holdingAvailable = (h: Holding): number =>
+  Number(h.amount) - Number(h.locked_amount);
+
 export const GovernanceSection = ({
   partyId,
   rulesContractId: initialRulesContractId,
@@ -3898,7 +3904,9 @@ export const GovernanceSection = ({
                           value={key}
                           disabled={!hasFactory}
                         >
-                          {label} — balance {h.amount}
+                          {label} — available {holdingAvailable(h)}
+                          {Number(h.locked_amount) > 0 &&
+                            ` (${h.locked_amount} locked)`}
                           {!hasFactory && " (no factory available)"}
                         </MenuItem>
                       );
@@ -3922,9 +3930,17 @@ export const GovernanceSection = ({
                         >
                           <Chip
                             size="small"
-                            label={`Available balance: ${holding.amount}`}
+                            label={`Available balance: ${holdingAvailable(holding)}`}
                             color="primary"
                           />
+                          {Number(holding.locked_amount) > 0 && (
+                            <Chip
+                              size="small"
+                              label={`Locked: ${holding.locked_amount}`}
+                              variant="outlined"
+                              color="warning"
+                            />
+                          )}
                           <Chip
                             size="small"
                             label={`Admin: ${holding.instrument_admin}`}
@@ -3975,7 +3991,7 @@ export const GovernanceSection = ({
                           `${h.instrument_admin}::${h.instrument_id}` ===
                           selectedHoldingKey,
                       );
-                      return holding ? n > Number(holding.amount) : false;
+                      return holding ? n > holdingAvailable(holding) : false;
                     })()}
                     helperText={(() => {
                       if (!proposalAmount) return "";
@@ -3987,8 +4003,8 @@ export const GovernanceSection = ({
                           `${h.instrument_admin}::${h.instrument_id}` ===
                           selectedHoldingKey,
                       );
-                      if (holding && n > Number(holding.amount)) {
-                        return `Exceeds available balance (${holding.amount})`;
+                      if (holding && n > holdingAvailable(holding)) {
+                        return `Exceeds available balance (${holdingAvailable(holding)})`;
                       }
                       return "";
                     })()}

--- a/frontend/src/components/GovernanceSection.tsx
+++ b/frontend/src/components/GovernanceSection.tsx
@@ -139,6 +139,10 @@ const defaultVaultBackendSignatory = DEVNET_VAULT_BACKEND_SIGNATORY;
 const holdingAvailable = (h: Holding): number =>
   Number(h.amount) - Number(h.locked_amount);
 
+/// Default validity window (hours) for a Transfer proposal / two-step offer.
+/// Mirrors the backend default; overridable per-transfer in the form.
+const DEFAULT_TRANSFER_EXPIRY_HOURS = 24;
+
 export const GovernanceSection = ({
   partyId,
   rulesContractId: initialRulesContractId,
@@ -183,6 +187,11 @@ export const GovernanceSection = ({
   const [proposalInstrumentIdAdmin, setProposalInstrumentIdAdmin] = useState("");
   const [proposalInstrumentIdId, setProposalInstrumentIdId] = useState("");
   const [proposalInputHoldingCids, setProposalInputHoldingCids] = useState("");
+  // Validity window (hours) for a Transfer proposal / two-step offer. Defaults
+  // to the backend's default (24h) but is overridable; bounding it lets an
+  // unaccepted offer expire and release escrow instead of locking funds.
+  const [proposalTransferExpiryHours, setProposalTransferExpiryHours] =
+    useState(String(DEFAULT_TRANSFER_EXPIRY_HOURS));
   const [proposalTransferInstructionCid, setProposalTransferInstructionCid] = useState("");
   const [proposalDescription, setProposalDescription] = useState("");
   // Utility-onboarding proposal state
@@ -1361,6 +1370,7 @@ export const GovernanceSection = ({
     );
     setProposalInstrumentIdId("");
     setProposalInputHoldingCids("");
+    setProposalTransferExpiryHours(String(DEFAULT_TRANSFER_EXPIRY_HOURS));
     setProposalTransferInstructionCid("");
     setProposalDescription("");
     setProposalProviderServiceCid("");
@@ -1408,7 +1418,17 @@ export const GovernanceSection = ({
               .map(({ id }) => ({ id })),
           };
           break;
-        case "transfer":
+        case "transfer": {
+          // Send the override only when it's a valid positive integer that
+          // differs from the default; otherwise omit it and let the backend
+          // apply its default window.
+          const expiryHours = Number(proposalTransferExpiryHours);
+          const validityWindowHours =
+            Number.isInteger(expiryHours) &&
+            expiryHours > 0 &&
+            expiryHours !== DEFAULT_TRANSFER_EXPIRY_HOURS
+              ? expiryHours
+              : undefined;
           proposal = {
             type: "transfer",
             transfer_factory_cid: proposalTransferFactoryCid,
@@ -1417,8 +1437,12 @@ export const GovernanceSection = ({
             amount: proposalAmount,
             instrument_id: { admin: proposalInstrumentIdAdmin, id: proposalInstrumentIdId },
             input_holding_cids: proposalInputHoldingCids ? proposalInputHoldingCids.split(",").map((s) => s.trim()).filter(Boolean) : [],
+            ...(validityWindowHours !== undefined && {
+              validity_window_hours: validityWindowHours,
+            }),
           };
           break;
+        }
         case "accept_transfer":
           proposal = {
             type: "accept_transfer",
@@ -4005,6 +4029,42 @@ export const GovernanceSection = ({
                       );
                       if (holding && n > holdingAvailable(holding)) {
                         return `Exceeds available balance (${holdingAvailable(holding)})`;
+                      }
+                      return "";
+                    })()}
+                  />
+                  <TextField
+                    size="small"
+                    label="Offer expiry (hours)"
+                    value={proposalTransferExpiryHours}
+                    onChange={(e) =>
+                      setProposalTransferExpiryHours(e.target.value)
+                    }
+                    fullWidth
+                    type="number"
+                    slotProps={{
+                      htmlInput: { min: 1, step: 1 },
+                      input: {
+                        endAdornment: fieldHelpAdornment(
+                          `How long the transfer stays valid (default ${DEFAULT_TRANSFER_EXPIRY_HOURS}h). If the recipient isn't preapproved, this becomes an offer they must accept before it expires; after expiry the escrowed funds are released back to you.`,
+                          "Help for Offer expiry",
+                        ),
+                      },
+                    }}
+                    error={(() => {
+                      const n = Number(proposalTransferExpiryHours);
+                      return (
+                        proposalTransferExpiryHours !== "" &&
+                        (!Number.isInteger(n) || n <= 0)
+                      );
+                    })()}
+                    helperText={(() => {
+                      const n = Number(proposalTransferExpiryHours);
+                      if (
+                        proposalTransferExpiryHours !== "" &&
+                        (!Number.isInteger(n) || n <= 0)
+                      ) {
+                        return "Enter a positive whole number of hours";
                       }
                       return "";
                     })()}

--- a/frontend/src/components/HoldingsSection.tsx
+++ b/frontend/src/components/HoldingsSection.tsx
@@ -184,6 +184,14 @@ export const HoldingsSection = ({
                 align="right"
               >
                 {h.amount}
+                {Number(h.locked_amount) > 0 && (
+                  <Box
+                    component="span"
+                    sx={{ color: "warning.main", ml: 0.5 }}
+                  >
+                    ({h.locked_amount} locked)
+                  </Box>
+                )}
               </TableCell>
               <TableCell sx={{ py: 1 }}>
                 <Chip

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -926,7 +926,11 @@ export interface TransferPreapprovalsResponse {
 export interface Holding {
   instrument_admin: string;
   instrument_id: string;
+  /** Total held across all Holding contracts, including locked ones. */
   amount: string;
+  /** Portion of `amount` locked (escrowed for an in-flight transfer) and not
+   *  freely transferable. Available = amount - locked_amount. */
+  locked_amount: string;
   preapproval_set_up: boolean;
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -472,6 +472,10 @@ export type ProposalType =
       amount: string;
       instrument_id: { admin: string; id: string };
       input_holding_cids: string[];
+      /** How long the transfer/offer stays valid, in hours. Omitted = backend
+       *  default (24h). Lets an unaccepted two-step offer expire and release
+       *  escrow instead of locking funds indefinitely. */
+      validity_window_hours?: number;
     }
   | {
       type: "accept_transfer";

--- a/src/server/action_serializer.rs
+++ b/src/server/action_serializer.rs
@@ -151,18 +151,25 @@ pub struct TransferValidity {
 }
 
 impl TransferValidity {
-    /// A window starting at `now_micros` and lasting
-    /// [`TRANSFER_VALIDITY_WINDOW_MICROS`]. `now_micros` is captured once by the
-    /// caller so the registry and on-chain payloads agree byte-for-byte.
+    /// A window starting at `now_micros` and lasting the default
+    /// [`TRANSFER_VALIDITY_WINDOW_MICROS`].
+    pub fn from_now(now_micros: i64) -> Self {
+        Self::from_now_with_window(now_micros, TRANSFER_VALIDITY_WINDOW_MICROS)
+    }
+
+    /// A window starting at `now_micros` and lasting `window_micros`. Used when
+    /// the caller (e.g. the propose handler) lets the user override the default
+    /// expiry. `now_micros` is captured once so the registry and on-chain
+    /// payloads agree byte-for-byte.
     ///
     /// `executeBefore` is clamped to [`TRANSFER_EXECUTE_BEFORE_MICROS`] (the
-    /// module's max Daml `Time`) so an unexpectedly large `now_micros` can never
-    /// serialize an out-of-range timestamp.
-    pub fn from_now(now_micros: i64) -> Self {
+    /// module's max Daml `Time`) so a large `now_micros`/`window_micros` can
+    /// never serialize an out-of-range timestamp.
+    pub fn from_now_with_window(now_micros: i64, window_micros: i64) -> Self {
         Self {
             requested_at_micros: now_micros,
             execute_before_micros: now_micros
-                .saturating_add(TRANSFER_VALIDITY_WINDOW_MICROS)
+                .saturating_add(window_micros)
                 .min(TRANSFER_EXECUTE_BEFORE_MICROS),
         }
     }
@@ -971,6 +978,9 @@ pub fn build_proposal_create_args(
             amount,
             instrument_id,
             input_holding_cids,
+            // The validity window is applied via `transfer_validity` (the
+            // timestamps below), not serialized as its own field.
+            validity_window_hours: _,
         } => {
             let transfer_record = make_record(vec![
                 field("sender", make_party(governance_party)),
@@ -2205,6 +2215,7 @@ mod tests {
                 id: "instr-1".to_string(),
             },
             input_holding_cids: vec!["hc-1".to_string()],
+            validity_window_hours: None,
         };
         let (package, module, entity, record) =
             build_proposal_create_args("gov", "proposer", &proposal, None, None)?;

--- a/src/server/action_serializer.rs
+++ b/src/server/action_serializer.rs
@@ -121,14 +121,46 @@ fn make_empty_extra_args() -> Value {
     make_extra_args(make_empty_text_map())
 }
 
-/// Placeholder timestamps used when serializing a `Transfer` record into a
-/// `TransferProposal`. Exposed so the registry choice-context fetch uses the
-/// *same* values — the registrar resolves the context for these exact choice
-/// arguments, so any drift between propose-time and execute-time payloads
-/// fails interpretation. `0` is epoch and `i64::MAX / 1000` is the maximum
-/// Daml `Time` value (well past any realistic deadline).
+/// Fallback timestamps for serializing a `Transfer` record when no explicit
+/// validity window is supplied (tests only — the propose handler always passes
+/// a real, bounded window). `0` is epoch and `i64::MAX / 1000` is the maximum
+/// Daml `Time` value.
+///
+/// These were the *production* values once, but an effectively-infinite
+/// `executeBefore` meant a two-step transfer offer the receiver never accepted
+/// locked the sender's holdings forever. Production now bounds the window via
+/// [`TransferValidity`]; see [`TRANSFER_VALIDITY_WINDOW_MICROS`].
 pub const TRANSFER_REQUESTED_AT_MICROS: i64 = 0;
 pub const TRANSFER_EXECUTE_BEFORE_MICROS: i64 = i64::MAX / 1000;
+
+/// How long a `Transfer` proposal (and, for two-step transfers, the resulting
+/// offer) stays executable/acceptable after creation. Bounding this means an
+/// unaccepted offer expires and its escrowed holdings can be reclaimed, rather
+/// than locking funds indefinitely. 24h matches the daml test fixtures and the
+/// governance action timeout.
+pub const TRANSFER_VALIDITY_WINDOW_MICROS: i64 = 24 * 60 * 60 * 1_000_000;
+
+/// The `requestedAt` / `executeBefore` pair stamped onto a `Transfer`. The same
+/// instance must be used for both the registry choice-context fetch and the
+/// on-chain `TransferProposal` create args — the registrar resolves the context
+/// for these exact values, so any drift fails interpretation at execute time.
+#[derive(Clone, Copy, Debug)]
+pub struct TransferValidity {
+    pub requested_at_micros: i64,
+    pub execute_before_micros: i64,
+}
+
+impl TransferValidity {
+    /// A window starting at `now_micros` and lasting
+    /// [`TRANSFER_VALIDITY_WINDOW_MICROS`]. `now_micros` is captured once by the
+    /// caller so the registry and on-chain payloads agree byte-for-byte.
+    pub fn from_now(now_micros: i64) -> Self {
+        Self {
+            requested_at_micros: now_micros,
+            execute_before_micros: now_micros.saturating_add(TRANSFER_VALIDITY_WINDOW_MICROS),
+        }
+    }
+}
 
 fn make_extra_args(context_values: Value) -> Value {
     make_record(vec![
@@ -871,7 +903,14 @@ pub fn build_proposal_create_args(
     proposer: &str,
     proposal: &ProposalType,
     transfer_choice_context: Option<&ChoiceContext>,
+    transfer_validity: Option<TransferValidity>,
 ) -> Result<(ProposalPackage, &'static str, &'static str, Record)> {
+    // Fall back to the (unbounded) const window only when no explicit validity
+    // is supplied — i.e. tests; the propose handler always passes a real one.
+    let validity = transfer_validity.unwrap_or(TransferValidity {
+        requested_at_micros: TRANSFER_REQUESTED_AT_MICROS,
+        execute_before_micros: TRANSFER_EXECUTE_BEFORE_MICROS,
+    });
     Ok(match proposal {
         ProposalType::SetupCcPreapproval {
             provider,
@@ -941,13 +980,13 @@ pub fn build_proposal_create_args(
                 field(
                     "requestedAt",
                     Value {
-                        sum: Some(value::Sum::Timestamp(TRANSFER_REQUESTED_AT_MICROS)),
+                        sum: Some(value::Sum::Timestamp(validity.requested_at_micros)),
                     },
                 ),
                 field(
                     "executeBefore",
                     Value {
-                        sum: Some(value::Sum::Timestamp(TRANSFER_EXECUTE_BEFORE_MICROS)),
+                        sum: Some(value::Sum::Timestamp(validity.execute_before_micros)),
                     },
                 ),
                 field(
@@ -1857,6 +1896,26 @@ mod tests {
     use super::*;
     use crate::canton_id::{NAMESPACE_LENGTH, Namespace};
 
+    #[test]
+    fn transfer_validity_from_now_bounds_the_window() {
+        let now = 1_700_000_000_000_000;
+        let v = TransferValidity::from_now(now);
+        assert_eq!(v.requested_at_micros, now);
+        assert_eq!(
+            v.execute_before_micros,
+            now + TRANSFER_VALIDITY_WINDOW_MICROS
+        );
+        // The window is finite (24h), not the old effectively-infinite deadline.
+        assert!(v.execute_before_micros < TRANSFER_EXECUTE_BEFORE_MICROS);
+    }
+
+    #[test]
+    fn transfer_validity_from_now_saturates_instead_of_overflowing() {
+        // A near-max `now` must not panic on overflow; it saturates.
+        let v = TransferValidity::from_now(i64::MAX - 5);
+        assert_eq!(v.execute_before_micros, i64::MAX);
+    }
+
     // Locks the AV_* constructor strings against the on-ledger
     // `Splice.Api.Token.MetadataV1.AnyValue` definition. A typo here would
     // surface as a runtime interpretation error far from the source, so the
@@ -2079,7 +2138,7 @@ mod tests {
             expected_dso: party_id(),
         };
         let (package, module, entity, record) =
-            build_proposal_create_args("gov", "proposer", &proposal, None)?;
+            build_proposal_create_args("gov", "proposer", &proposal, None, None)?;
 
         assert_eq!(package, ProposalPackage::GovernanceTokenCustody);
         assert_eq!(module, "Governance.TokenCustody.SetupCcPreapproval");
@@ -2141,7 +2200,7 @@ mod tests {
             input_holding_cids: vec!["hc-1".to_string()],
         };
         let (package, module, entity, record) =
-            build_proposal_create_args("gov", "proposer", &proposal, None)?;
+            build_proposal_create_args("gov", "proposer", &proposal, None, None)?;
 
         assert_eq!(package, ProposalPackage::GovernanceTokenCustody);
         assert_eq!(module, "Governance.TokenCustody.TransferProposal");
@@ -2210,7 +2269,7 @@ mod tests {
             description: "mint it".to_string(),
         };
         let (mint_package, mint_module, mint_entity, mint_record) =
-            build_proposal_create_args("gov", "proposer", &mint, None)?;
+            build_proposal_create_args("gov", "proposer", &mint, None, None)?;
 
         // Package enum is GovernanceUtilityOnboarding even though the module
         // lives under `Governance.TokenIssuance`.
@@ -2247,7 +2306,7 @@ mod tests {
             description: "burn it".to_string(),
         };
         let (burn_package, burn_module, burn_entity, burn_record) =
-            build_proposal_create_args("gov", "proposer", &burn, None)?;
+            build_proposal_create_args("gov", "proposer", &burn, None, None)?;
 
         assert_eq!(burn_package, ProposalPackage::GovernanceUtilityOnboarding);
         assert_eq!(burn_module, "Governance.TokenIssuance.BurnProposal");
@@ -2293,7 +2352,7 @@ mod tests {
 
         // ---- No choice context: context.values is an EMPTY TextMap ----
         let (package, module, entity, record) =
-            build_proposal_create_args("gov", "proposer", &proposal, None)?;
+            build_proposal_create_args("gov", "proposer", &proposal, None, None)?;
         assert_eq!(package, ProposalPackage::GovernanceTokenCustody);
         assert_eq!(module, "Governance.TokenCustody.AcceptTransfer");
         assert_eq!(entity, "AcceptTransferProposal");
@@ -2329,7 +2388,7 @@ mod tests {
             )]),
         };
         let (_, _, _, record) =
-            build_proposal_create_args("gov", "proposer", &proposal, Some(&ctx))?;
+            build_proposal_create_args("gov", "proposer", &proposal, Some(&ctx), None)?;
         let extra_args = as_record(field_value(&record, "extraArgs"));
         let context = as_record(field_value(extra_args, "context"));
         let values = field_value(context, "values");
@@ -2371,7 +2430,7 @@ mod tests {
             deposit_initial_amount_usd: Some(DamlDecimal::parse("5.0")?),
         };
         let (package, module, entity, record) =
-            build_proposal_create_args("gov", "proposer", &proposal, None)?;
+            build_proposal_create_args("gov", "proposer", &proposal, None, None)?;
 
         assert_eq!(package, ProposalPackage::GovernanceUtilityCredential);
         assert_eq!(module, "Governance.UtilityCredential.OfferPaidCredential");
@@ -2424,7 +2483,7 @@ mod tests {
             create_allocation_factory: false,
         };
         let (package, module, entity, record) =
-            build_proposal_create_args("gov", "proposer", &proposal, None)?;
+            build_proposal_create_args("gov", "proposer", &proposal, None, None)?;
 
         assert_eq!(package, ProposalPackage::GovernanceUtilityOnboarding);
         assert_eq!(module, "Governance.UtilityOnboarding.SetupUtility");
@@ -2564,7 +2623,7 @@ mod tests {
 
         for case in cases {
             let (package, module, entity, record) =
-                build_proposal_create_args("gov", "proposer", &case.proposal, None)?;
+                build_proposal_create_args("gov", "proposer", &case.proposal, None, None)?;
             assert_eq!(package, case.package, "package for {module}");
             assert_eq!(module, case.module);
             assert_eq!(entity, case.entity, "entity for {module}");

--- a/src/server/action_serializer.rs
+++ b/src/server/action_serializer.rs
@@ -154,10 +154,16 @@ impl TransferValidity {
     /// A window starting at `now_micros` and lasting
     /// [`TRANSFER_VALIDITY_WINDOW_MICROS`]. `now_micros` is captured once by the
     /// caller so the registry and on-chain payloads agree byte-for-byte.
+    ///
+    /// `executeBefore` is clamped to [`TRANSFER_EXECUTE_BEFORE_MICROS`] (the
+    /// module's max Daml `Time`) so an unexpectedly large `now_micros` can never
+    /// serialize an out-of-range timestamp.
     pub fn from_now(now_micros: i64) -> Self {
         Self {
             requested_at_micros: now_micros,
-            execute_before_micros: now_micros.saturating_add(TRANSFER_VALIDITY_WINDOW_MICROS),
+            execute_before_micros: now_micros
+                .saturating_add(TRANSFER_VALIDITY_WINDOW_MICROS)
+                .min(TRANSFER_EXECUTE_BEFORE_MICROS),
         }
     }
 }
@@ -1910,10 +1916,11 @@ mod tests {
     }
 
     #[test]
-    fn transfer_validity_from_now_saturates_instead_of_overflowing() {
-        // A near-max `now` must not panic on overflow; it saturates.
+    fn transfer_validity_from_now_clamps_to_max_daml_time() {
+        // A near-max `now` must neither panic on overflow nor serialize past the
+        // module's max Daml `Time`; it clamps to TRANSFER_EXECUTE_BEFORE_MICROS.
         let v = TransferValidity::from_now(i64::MAX - 5);
-        assert_eq!(v.execute_before_micros, i64::MAX);
+        assert_eq!(v.execute_before_micros, TRANSFER_EXECUTE_BEFORE_MICROS);
     }
 
     // Locks the AV_* constructor strings against the on-ledger

--- a/src/server/handlers/governance.rs
+++ b/src/server/handlers/governance.rs
@@ -1100,9 +1100,19 @@ pub async fn propose_action(
     // Bounded validity window for any Transfer proposal, captured ONCE so the
     // registry choice-context fetch and the on-chain create args agree
     // byte-for-byte. A bounded `executeBefore` lets an unaccepted two-step offer
-    // expire and release its escrow instead of locking funds forever.
-    let transfer_validity =
-        action_serializer::TransferValidity::from_now(chrono::Utc::now().timestamp_micros());
+    // expire and release its escrow instead of locking funds forever. The
+    // window defaults to 24h but the caller may override it per-transfer.
+    let now_micros = chrono::Utc::now().timestamp_micros();
+    let transfer_validity = match &body.proposal {
+        ProposalType::Transfer {
+            validity_window_hours: Some(hours),
+            ..
+        } => action_serializer::TransferValidity::from_now_with_window(
+            now_micros,
+            i64::from(*hours).saturating_mul(60 * 60 * 1_000_000),
+        ),
+        _ => action_serializer::TransferValidity::from_now(now_micros),
+    };
 
     let mut resolved_proposal = body.proposal.clone();
     let transfer_choice_context = match &mut resolved_proposal {

--- a/src/server/handlers/governance.rs
+++ b/src/server/handlers/governance.rs
@@ -1097,6 +1097,13 @@ pub async fn propose_action(
     //     the dec party's ACS, so we also substitute the resolved factory cid.
     //     Canton Coin is excluded — its `AmuletRules` factory and context come
     //     from the DSO scan API. See `needs_registry_context`.
+    // Bounded validity window for any Transfer proposal, captured ONCE so the
+    // registry choice-context fetch and the on-chain create args agree
+    // byte-for-byte. A bounded `executeBefore` lets an unaccepted two-step offer
+    // expire and release its escrow instead of locking funds forever.
+    let transfer_validity =
+        action_serializer::TransferValidity::from_now(chrono::Utc::now().timestamp_micros());
+
     let mut resolved_proposal = body.proposal.clone();
     let transfer_choice_context = match &mut resolved_proposal {
         ProposalType::AcceptTransfer {
@@ -1182,8 +1189,8 @@ pub async fn propose_action(
                     instrument_admin: &admin,
                     instrument_id: &instrument_id.id,
                     input_holding_cids,
-                    requested_at_micros: action_serializer::TRANSFER_REQUESTED_AT_MICROS,
-                    execute_before_micros: action_serializer::TRANSFER_EXECUTE_BEFORE_MICROS,
+                    requested_at_micros: transfer_validity.requested_at_micros,
+                    execute_before_micros: transfer_validity.execute_before_micros,
                 },
             )
             .await
@@ -1217,6 +1224,7 @@ pub async fn propose_action(
             &member_party_id.to_string(),
             &resolved_proposal,
             transfer_choice_context.as_ref().map(|r| &r.context),
+            Some(transfer_validity),
         ) {
             Ok(args) => args,
             Err(e) => {

--- a/src/server/queries.rs
+++ b/src/server/queries.rs
@@ -3718,22 +3718,33 @@ pub async fn get_holdings(
     let raw = fetch_holding_views(config, party_id, token.clone()).await?;
 
     // Aggregate amounts by (admin, id). A party can own many Holding contracts
-    // for the same instrument (one per UTXO-style entry).
-    let mut totals: HashMap<(String, String), (CantonId, String, DamlDecimal)> = HashMap::new();
+    // for the same instrument (one per UTXO-style entry). Track the locked
+    // subtotal separately: locked holdings are escrowed for an in-flight
+    // transfer/allocation and can't fund a new one, so the UI shows them apart
+    // from the freely-transferable balance.
+    let mut totals: HashMap<(String, String), (CantonId, String, DamlDecimal, DamlDecimal)> =
+        HashMap::new();
     for raw_holding in raw {
         let key = (
             raw_holding.instrument_admin.to_string(),
             raw_holding.instrument_id.clone(),
         );
+        let locked_delta = if raw_holding.is_locked {
+            raw_holding.amount
+        } else {
+            DamlDecimal::ZERO
+        };
         totals
             .entry(key)
-            .and_modify(|(_, _, total)| {
+            .and_modify(|(_, _, total, locked)| {
                 *total += raw_holding.amount;
+                *locked += locked_delta;
             })
             .or_insert((
                 raw_holding.instrument_admin,
                 raw_holding.instrument_id,
                 raw_holding.amount,
+                locked_delta,
             ));
     }
 
@@ -3746,7 +3757,7 @@ pub async fn get_holdings(
 
     let mut holdings: Vec<HoldingInfo> = totals
         .into_values()
-        .map(|(instrument_admin, instrument_id, amount)| {
+        .map(|(instrument_admin, instrument_id, amount, locked_amount)| {
             let preapproval_set_up = if instrument_id == AMULET_INSTRUMENT_ID {
                 preapprovals.has_amulet
             } else {
@@ -3762,6 +3773,7 @@ pub async fn get_holdings(
                 instrument_admin,
                 instrument_id,
                 amount,
+                locked_amount,
                 preapproval_set_up,
             }
         })
@@ -3843,13 +3855,16 @@ async fn fetch_holding_views(
 
 /// Intermediate parse result. `owner` lets `fetch_holding_views` drop holdings
 /// the party can see (via interface visibility) but doesn't actually own,
-/// before the views reach any caller.
+/// before the views reach any caller. `is_locked` is `true` when the Holding
+/// carries a `lock` (it's reserved for an in-flight transfer/allocation); such
+/// holdings can't fund a new `TransferFactory_Transfer`.
 struct HoldingView {
     contract_id: String,
     owner: String,
     instrument_admin: CantonId,
     instrument_id: String,
     amount: DamlDecimal,
+    is_locked: bool,
 }
 
 fn extract_holding_view(created: &CreatedEvent) -> Option<HoldingView> {
@@ -3875,21 +3890,38 @@ fn extract_holding_view(created: &CreatedEvent) -> Option<HoldingView> {
     let instrument_admin: CantonId = field_party(instrument_record, "admin")?.parse().ok()?;
     let instrument_id = field_text(instrument_record, "id")?;
 
+    // `lock : Optional Lock` — present (`Some`) means the holding is locked for
+    // an in-flight transfer/allocation. A missing field is treated as unlocked.
+    let is_locked = view_record
+        .fields
+        .iter()
+        .find(|f| f.label == "lock")
+        .and_then(|f| f.value.as_ref())
+        .is_some_and(|v| match &v.sum {
+            Some(value::Sum::Optional(opt)) => opt.value.is_some(),
+            _ => false,
+        });
+
     Some(HoldingView {
         contract_id: created.contract_id.clone(),
         owner,
         instrument_admin,
         instrument_id,
         amount,
+        is_locked,
     })
 }
 
-/// Collect the contract ids of every `Holding` the party owns for a given
-/// instrument `(admin, id)`. Used by the Transfer proposal flow to fund the
-/// transfer when the caller doesn't pin specific holdings: the token-standard
+/// Collect the contract ids of every *unlocked* `Holding` the party owns for a
+/// given instrument `(admin, id)`. Used by the Transfer proposal flow to fund
+/// the transfer when the caller doesn't pin specific holdings: the token-standard
 /// transfer factory rejects an empty `inputHoldingCids` ("No holdings
 /// provided"), so we hand it every matching holding and let the choice consume
 /// what it needs and return change.
+///
+/// Locked holdings are excluded: they're reserved for an in-flight
+/// transfer/allocation, and feeding one to `TransferFactory_Transfer` fails at
+/// execute time with `AssertionFailed: Input holding lock must match`.
 pub async fn select_input_holdings(
     config: &NodeConfig,
     party_id: &CantonId,
@@ -3900,7 +3932,11 @@ pub async fn select_input_holdings(
     let raw = fetch_holding_views(config, party_id, token).await?;
     Ok(raw
         .into_iter()
-        .filter(|h| h.instrument_admin == *instrument_admin && h.instrument_id == instrument_id)
+        .filter(|h| {
+            !h.is_locked
+                && h.instrument_admin == *instrument_admin
+                && h.instrument_id == instrument_id
+        })
         .map(|h| h.contract_id)
         .collect())
 }
@@ -4295,6 +4331,85 @@ mod tests {
             extract_transfer_instruction_info(&make_event(TRANSFER_PENDING_RECEIVER_ACCEPTANCE, 0))
                 .expect("expired offer should still be returned, just past-deadline");
         assert_eq!(info.expires_at, 0);
+    }
+
+    // ------------------------------------------------------------------------
+    // extract_holding_view
+    //
+    // The `lock` field on the Holding interface view decides whether a holding
+    // can fund a transfer. A locked holding fed to TransferFactory_Transfer
+    // fails at execute time with "Input holding lock must match", so the parser
+    // must surface `is_locked` for select_input_holdings to filter on.
+    // ------------------------------------------------------------------------
+
+    // `<prefix>::<34-byte-multihash-hex>`; CantonId::parse rejects other shapes.
+    const HOLDING_FP: &str = "1220c4010d6883f367c7f45d55b2449501620130f9b21e96379f17dea455ac7a5892";
+
+    /// Build a `CreatedEvent` carrying a `HoldingV1.Holding` interface view.
+    /// `lock` populates the optional `lock` field — `None` for an unlocked
+    /// holding, `Some` (any record) for a locked one.
+    fn make_holding_event(amount: &str, lock: Option<Value>) -> CreatedEvent {
+        let view = InterfaceView {
+            interface_id: Some(Identifier {
+                package_id: "#splice-api-token-holding-v1".to_string(),
+                module_name: "Splice.Api.Token.HoldingV1".to_string(),
+                entity_name: "Holding".to_string(),
+            }),
+            view_status: None,
+            view_value: Some(Record {
+                record_id: None,
+                fields: vec![
+                    field("owner", party_value(&format!("owner::{HOLDING_FP}"))),
+                    field("amount", numeric_value(amount)),
+                    field(
+                        "instrumentId",
+                        record_value(vec![
+                            field("admin", party_value(&format!("admin::{HOLDING_FP}"))),
+                            field("id", text_value("Test01")),
+                        ]),
+                    ),
+                    field("lock", optional_value(lock)),
+                ],
+            }),
+        };
+        CreatedEvent {
+            offset: 0,
+            node_id: 0,
+            contract_id: "holding-cid".to_string(),
+            template_id: None,
+            contract_key: None,
+            create_arguments: None,
+            created_event_blob: vec![],
+            interface_views: vec![view],
+            witness_parties: vec![],
+            signatories: vec![],
+            observers: vec![],
+            created_at: None,
+            package_name: String::new(),
+            representative_package_id: String::new(),
+            acs_delta: false,
+        }
+    }
+
+    #[test]
+    fn extract_holding_view_unlocked_when_lock_absent() {
+        let view = extract_holding_view(&make_holding_event("20.0", None))
+            .expect("unlocked holding view should parse");
+        assert!(!view.is_locked);
+        assert_eq!(view.instrument_id, "Test01");
+        assert_eq!(view.amount, DamlDecimal::parse("20.0").expect("decimal"));
+    }
+
+    #[test]
+    fn extract_holding_view_locked_when_lock_present() {
+        // A non-empty record stands in for the Lock payload; only presence matters.
+        let lock = record_value(vec![field(
+            "holders",
+            party_value(&format!("locker::{HOLDING_FP}")),
+        )]);
+        let view = extract_holding_view(&make_holding_event("5.0", Some(lock)))
+            .expect("locked holding view should still parse");
+        assert!(view.is_locked);
     }
 
     // ------------------------------------------------------------------------

--- a/src/server/queries.rs
+++ b/src/server/queries.rs
@@ -4392,12 +4392,29 @@ mod tests {
     }
 
     #[test]
-    fn extract_holding_view_unlocked_when_lock_absent() {
+    fn extract_holding_view_unlocked_when_lock_none() {
+        // The `lock` field is present but an empty `Optional` (None) — the
+        // on-ledger shape for an unlocked holding.
         let view = extract_holding_view(&make_holding_event("20.0", None))
             .expect("unlocked holding view should parse");
         assert!(!view.is_locked);
         assert_eq!(view.instrument_id, "Test01");
         assert_eq!(view.amount, DamlDecimal::parse("20.0").expect("decimal"));
+    }
+
+    #[test]
+    fn extract_holding_view_unlocked_when_lock_field_missing() {
+        // Defensive path: if the interface view omits the `lock` field entirely,
+        // the holding is treated as unlocked rather than failing to parse.
+        let mut event = make_holding_event("7.0", None);
+        if let Some(view) = event.interface_views.first_mut()
+            && let Some(record) = view.view_value.as_mut()
+        {
+            record.fields.retain(|f| f.label != "lock");
+        }
+        let view =
+            extract_holding_view(&event).expect("holding view without a lock field should parse");
+        assert!(!view.is_locked);
     }
 
     #[test]

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -1206,6 +1206,11 @@ pub enum ProposalType {
         instrument_id: InstrumentId,
         #[serde(default)]
         input_holding_cids: Vec<String>,
+        /// How long the transfer (and, for two-step transfers, the resulting
+        /// offer) stays valid, in hours. `None` uses the default window. A
+        /// bounded window lets an unaccepted offer expire and release escrow.
+        #[serde(default)]
+        validity_window_hours: Option<u32>,
     },
     /// Accept an incoming token transfer
     AcceptTransfer { transfer_instruction_cid: String },
@@ -1328,9 +1333,20 @@ impl ProposalType {
     /// submission error after a proposal contract is already created.
     pub fn validate(&self) -> Result<(), String> {
         match self {
-            ProposalType::Transfer { amount, .. }
-            | ProposalType::Mint { amount, .. }
-            | ProposalType::Burn { amount, .. } => validate_positive_amount(amount, "amount"),
+            ProposalType::Transfer {
+                amount,
+                validity_window_hours,
+                ..
+            } => {
+                validate_positive_amount(amount, "amount")?;
+                if *validity_window_hours == Some(0) {
+                    return Err("validity_window_hours must be greater than 0".to_string());
+                }
+                Ok(())
+            }
+            ProposalType::Mint { amount, .. } | ProposalType::Burn { amount, .. } => {
+                validate_positive_amount(amount, "amount")
+            }
             ProposalType::OfferPaidCredential {
                 deposit_initial_amount_usd: Some(d),
                 ..
@@ -2227,7 +2243,7 @@ mod tests {
         let ns = "1220c4010d6883f367c7f45d55b2449501620130f9b21e96379f17dea455ac7a5892";
         let to = CantonId::parse(&format!("recv::{ns}")).unwrap();
         let admin = CantonId::parse(&format!("admin::{ns}")).unwrap();
-        let mk = |amount: &str| ProposalType::Transfer {
+        let mk = |amount: &str, window: Option<u32>| ProposalType::Transfer {
             transfer_factory_cid: "tf".to_string(),
             expected_admin: admin.clone(),
             receiver: to.clone(),
@@ -2237,9 +2253,13 @@ mod tests {
                 id: "i".into(),
             },
             input_holding_cids: Vec::new(),
+            validity_window_hours: window,
         };
-        assert!(mk("0").validate().is_err());
-        assert!(mk("-1.5").validate().is_err());
-        assert!(mk("0.0001").validate().is_ok());
+        assert!(mk("0", None).validate().is_err());
+        assert!(mk("-1.5", None).validate().is_err());
+        assert!(mk("0.0001", None).validate().is_ok());
+        // A custom (positive) window is accepted; a zero-hour window is rejected.
+        assert!(mk("1.0", Some(48)).validate().is_ok());
+        assert!(mk("1.0", Some(0)).validate().is_err());
     }
 }

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -1708,8 +1708,15 @@ pub struct BurnRequestsResponse {
 pub struct HoldingInfo {
     pub instrument_admin: CantonId,
     pub instrument_id: String,
+    /// Total amount held, summed across every active `Holding` contract for
+    /// this instrument — including locked ones.
     #[schema(value_type = String)]
     pub amount: DamlDecimal,
+    /// Portion of `amount` that is locked (escrowed for an in-flight
+    /// transfer/allocation) and therefore not freely transferable. The
+    /// available balance is `amount - locked_amount`.
+    #[schema(value_type = String)]
+    pub locked_amount: DamlDecimal,
     /// True if a `TransferPreapproval` is in place for this party for this
     /// instrument. CC (Amulet) holdings match when any
     /// `Splice.AmuletRules:TransferPreapproval` exists; utility-token holdings


### PR DESCRIPTION
## What

Executing a confirmed **Transfer** proposal failed with `DAML_FAILURE … AssertionFailed: 'Input holding lock must match'`, and in other cases funds appeared to vanish — locked in escrow, shown with a 1970 creation date and an unchanged balance.

## Changes
- **Exclude locked holdings from transfer funding.** `select_input_holdings` auto-selected *every* holding the sender owned, including ones already locked by an in-flight transfer — which the token-standard `TransferFactory_Transfer` rejects. `extract_holding_view` now reads the `lock` field and locked holdings are skipped.
- **Surface locked balance.** `get_holdings` reports `locked_amount`; the holdings list and transfer dialog show available = total − locked, so escrowed funds don't read as an unchanged balance.
- **Bound the offer deadline.** `executeBefore` was effectively infinite, so an unaccepted two-step offer locked funds forever, and `requestedAt` was epoch (rendered as 1970). Now stamped with a bounded 24h `TransferValidity` window, computed once and shared between the registry choice-context call and the on-chain create args so they still match byte-for-byte.

## Not covered (follow-up)
- Two-step transfers to a receiver **without** a `TransferPreapproval` still create an offer the receiver must accept — the universal fix is preapproval onboarding (each receiver runs `SetupTokenPreapproval`).
- Reclaiming already-stuck offers needs a `WithdrawTransfer` governance action (a decentralized sender can't single-submit `TransferInstruction_Withdraw`).

## Testing
- `cargo fmt -- --check` and `cargo clippy --all-targets --all-features -- -D warnings` clean
- Unit tests for holding lock parsing and the validity window