### PR TITLE
fix(workflow): refresh ledger token per step to avoid expiry during peer wait

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "frontend",
       "version": "0.0.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@auth0/auth0-react": "^2.16.2",
         "@emotion/react": "^11.14.0",

--- a/src/workflow/contracts/coordinator.rs
+++ b/src/workflow/contracts/coordinator.rs
@@ -77,12 +77,14 @@ async fn run_workflow(
     let instance_name = config.instance_name.clone();
     let dec_party_id = config.decentralized_party_id.clone();
 
-    // Get credentials for the decentralized party
+    // Auth handle for the decentralized party. We deliberately fetch a fresh
+    // token at each ledger-touching step rather than caching one snapshot up
+    // front: a workflow can sit in `WaitingForPeers` for an arbitrarily long
+    // time, and a token captured before that wait would be expired by the time
+    // Prepare/Execute run automatically once peers accept. `get_credentials`
+    // returns a cached-with-refresh token, so per-step calls are cheap.
     let auth = workflow_auth
         .ok_or_else(|| anyhow::anyhow!("Auth not configured, cannot run contracts workflow"))?;
-    let creds = auth.get_credentials(&config.decentralized_party_id).await?;
-    let token = creds.token;
-    let user_id = creds.user_id;
 
     loop {
         let current_step = workflow_state.current_step().await;
@@ -93,8 +95,16 @@ async fn run_workflow(
             }
             ContractsStep::PrepareSubmissions => {
                 tracing::info!("Coordinator executing: Prepare submissions");
-                prepare_submissions(&node_config, &db, &instance_name, &config, &token, &user_id)
-                    .await?;
+                let creds = auth.get_credentials(&config.decentralized_party_id).await?;
+                prepare_submissions(
+                    &node_config,
+                    &db,
+                    &instance_name,
+                    &config,
+                    &creds.token,
+                    &creds.user_id,
+                )
+                .await?;
 
                 // Load prepared submissions from storage to ship to peers with the
                 // SignSubmissions command. Pair with the contracts config so the
@@ -134,8 +144,16 @@ async fn run_workflow(
                 }
                 workflow_state.clear_peer_data().await;
 
-                execute_submissions(&node_config, &db, &instance_name, &config, &token, &user_id)
-                    .await?;
+                let creds = auth.get_credentials(&config.decentralized_party_id).await?;
+                execute_submissions(
+                    &node_config,
+                    &db,
+                    &instance_name,
+                    &config,
+                    &creds.token,
+                    &creds.user_id,
+                )
+                .await?;
                 workflow_state.advance_step().await;
             }
             ContractsStep::Complete => {


### PR DESCRIPTION
## Problem

A governance contract deployment workflow failed with:

```
Authorization error: Could not verify JWT token: The Token has expired ...
UNAUTHENTICATED(6): The command is missing a (valid) JWT token
```

on the `InteractiveSubmissionService/PrepareSubmission` call — even though the user never pressed a button after submitting; the workflow auto-progressed once peers accepted.

## Root cause

The contracts coordinator (`src/workflow/contracts/coordinator.rs`) fetched the decentralized party's **backend M2M ledger token once, as a plain `String`, before the workflow loop**, then reused that snapshot for both `PrepareSubmissions` and `ExecuteSubmissions`.

A workflow can sit in `WaitingForPeers` for an arbitrarily long time. By the time peers accept and Prepare/Execute run automatically, the captured token has aged past its TTL, so the ledger rejects it as expired.

The token machinery itself is fine — `TokenManager::get_token()` already does cached-with-refresh (and re-auths M2M client_credentials when within 60s of expiry). The bug was simply capturing the token *before* the wait and never asking for it again.

## Fix

Call `auth.get_credentials()` at each ledger-touching step (Prepare, Execute) instead of once up front. Since `get_credentials()` → `get_token()` returns a cached token and only re-authenticates near expiry, per-step calls are cheap and eliminate the staleness window.

## Testing

- `cargo clippy --all-targets --all-features -- -D warnings` passes clean.