### PR TITLE
perf(noise): bump chunk size to 1 MiB

### DIFF
--- a/src/noise/mod.rs
+++ b/src/noise/mod.rs
@@ -88,11 +88,21 @@ pub enum MessageType {
     Chunk = 0x0302,
 }
 
-/// Maximum payload size before chunking is required (1KB to stay safely under Noise frame limits)
-pub const MAX_PAYLOAD_SIZE: usize = 1024;
+/// Maximum payload size sent inline in a single message before the chunked
+/// fetch protocol kicks in. Matched to `CHUNK_SIZE` so any payload that fits
+/// in one chunk is delivered in a single round-trip; larger payloads are
+/// split into `CHUNK_SIZE` chunks. The `tokio-noise` transport streams and
+/// auto-fragments writes, so this is not constrained by the Noise frame size.
+pub const MAX_PAYLOAD_SIZE: usize = 1024 * 1024;
 
-/// Chunk size for large payloads
-pub const CHUNK_SIZE: usize = 1024;
+/// Chunk size for large payloads (1 MiB).
+///
+/// Each chunk is fetched in its own Noise call (a fresh TCP connect, handshake,
+/// and one round-trip), so fewer and larger chunks mean far fewer round-trips
+/// over high-latency links. The `tokio-noise` transport streams writes and
+/// auto-fragments them into ~2 KiB frames, so this is not bound by the Noise
+/// frame size — only by `MAX_CHUNKED_TOTAL_SIZE`.
+pub const CHUNK_SIZE: usize = 1024 * 1024;
 
 /// Hard ceiling on the assembled size of a chunked response. Bounds peer-supplied
 /// `total_size` so a malicious or buggy peer can't ask the client to allocate


### PR DESCRIPTION
## What

Bumped `CHUNK_SIZE` and `MAX_PAYLOAD_SIZE` from 1 KiB to 1 MiB in `src/noise/mod.rs`.

## Why

Each chunk of a large payload is fetched in its own Noise call (fresh TCP connect + handshake + one round-trip). At 1 KiB chunks, distributing a multi-MB payload (e.g. a 9 MB DAR bundle) takes thousands of sequential round-trips — minutes over WAN latency, exceeding the workflow timeout. At 1 MiB chunks it's a handful.

The `tokio-noise` transport already streams writes and auto-fragments them into ~2 KiB frames, so the application-level chunk size was never bound by the Noise frame limit — only by `MAX_CHUNKED_TOTAL_SIZE` (16 MiB), which is unchanged.

Raising `MAX_PAYLOAD_SIZE` to match means any payload that fits in a single chunk is now sent inline in one round-trip, skipping the chunk-fetch protocol entirely.

## Effect

For a 9 MB payload over 300 ms latency: ~9,200 chunks → 9 chunks (~46–92 min → ~10–20 s).

`MAX_CHUNK_COUNT` auto-derives to 16. Both server paths (`noise/server.rs`, `server/mod.rs`) and the client share these consts, so they stay symmetric.

## Verification

`cargo clippy --all-targets --all-features -- -D warnings` passes clean.