### PR TITLE
fix(ci): authenticate cargo-deny private deps via GITHUB_TOKEN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,27 +135,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      # The action runs cargo-deny in its own Docker container, so host-side
-      # SSH setup is invisible to it — pass the bot key + github.com host
-      # keys via the action's inputs, and force git-cli so cargo doesn't
-      # fall back to libgit2's ssh-agent path (which has no key inside the
-      # container).
-      - name: Capture github.com host keys
-        id: keyscan
+      # Authenticate the private `common` git dependency over HTTPS using the
+      # workflow GITHUB_TOKEN instead of a bot SSH deploy key. cargo-deny runs
+      # on the host (not the action's Docker container) so this git credential
+      # config is visible to cargo's dependency fetch.
+      - name: Configure git auth for private deps
         run: |
-          {
-            echo 'known-hosts<<KNOWN_HOSTS_EOF'
-            ssh-keyscan github.com
-            echo KNOWN_HOSTS_EOF
-          } >> "$GITHUB_OUTPUT"
+          git config --global \
+            url."https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "git@github.com:"
+          git config --global --add \
+            url."https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "ssh://git@github.com/"
+      - name: Install cargo-deny
+        run: |
+          VERSION=0.19.8
+          curl --silent -L "https://github.com/EmbarkStudios/cargo-deny/releases/download/${VERSION}/cargo-deny-${VERSION}-x86_64-unknown-linux-musl.tar.gz" \
+            | sudo tar -xz --strip-components=1 -C /usr/local/bin
       # Only `advisories` until a deny.toml is checked in; bans, licenses,
       # and sources need policy decisions to be useful.
-      - uses: EmbarkStudios/cargo-deny-action@v2
-        with:
-          command: check advisories
-          ssh-key: ${{ secrets.BOT_SSH_PRIVATE_KEY }}
-          ssh-known-hosts: ${{ steps.keyscan.outputs.known-hosts }}
-          use-git-cli: true
+      - name: cargo-deny check advisories
+        run: cargo-deny check advisories
 
   daml:
     name: DAML Build & Test


### PR DESCRIPTION
## Summary

The `Cargo Deny` CI job has been failing with `git@github.com: Permission denied (publickey)` when resolving the private `common` dependency (from `canton-lib`). It authenticated via the `BOT_SSH_PRIVATE_KEY` deploy key, which is no longer accepted. `Cargo Audit` is unaffected because it uses `GITHUB_TOKEN` and doesn't clone the git dependency.

This switches the `cargo-deny` job off the bot SSH key:

- Drops the `EmbarkStudios/cargo-deny-action` Docker container (which couldn't see host git config, hence the SSH-key workaround) and the `ssh-keyscan` step.
- Configures `git` to rewrite `git@github.com:` / `ssh://git@github.com/` to HTTPS with `x-access-token:${{ secrets.GITHUB_TOKEN }}`.
- Installs the `cargo-deny` binary (same v0.19.8) and runs `cargo-deny check advisories` on the host, so the credential config applies to cargo's fetch.

## Caveat for the reviewer

This relies on `GITHUB_TOKEN` having **read access to the private `canton-lib` repo**. By default the workflow token is scoped to this repository only — if `canton-lib` does not grant access to this repo's Actions token, the fetch will still fail and we'll need a PAT / GitHub App token (or to restore the bot deploy key) instead. Worth confirming on the CI run.