### PR TITLE
fix(dars): make DAR distribution reliable (tokio-noise fork + timeouts + decouple + retry)

### DIFF
--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -1,9 +1,9 @@
 name: Setup build environment
-description: Install system deps, configure SSH for git, and cache cargo + npm artifacts.
+description: Install system deps, configure git auth for private deps, and cache cargo + npm artifacts.
 
 inputs:
-  ssh-private-key:
-    description: SSH private key used to fetch git dependencies
+  github-token:
+    description: Token used to fetch private git dependencies over HTTPS
     required: true
   extra-packages:
     description: Additional apt packages to install (space-separated)
@@ -50,17 +50,19 @@ runs:
       with:
         node-version: '22'
 
-    - name: Setup SSH
+    # Fetch private git dependencies (e.g. canton-lib) over HTTPS using the
+    # workflow GITHUB_TOKEN instead of a bot SSH deploy key — same approach as
+    # the cargo-deny job. `CARGO_NET_GIT_FETCH_WITH_CLI=true` makes cargo shell
+    # out to git, so this insteadOf rewrite is honored for dependency fetches.
+    - name: Configure git auth for private deps
       shell: bash
       env:
-        SSH_DIR: ${{ steps.env.outputs.ssh-dir }}
-        SSH_PRIVATE_KEY: ${{ inputs.ssh-private-key }}
+        GH_TOKEN: ${{ inputs.github-token }}
       run: |
-        mkdir -p "$SSH_DIR"
-        ssh-keyscan github.com >> "$SSH_DIR/known_hosts"
-        echo "$SSH_PRIVATE_KEY" > "$SSH_DIR/id_ed25519"
-        chmod 600 "$SSH_DIR/id_ed25519"
-        git config --global core.sshCommand "ssh -i $SSH_DIR/id_ed25519 -o StrictHostKeyChecking=no"
+        git config --global \
+          url."https://x-access-token:${GH_TOKEN}@github.com/".insteadOf "git@github.com:"
+        git config --global --add \
+          url."https://x-access-token:${GH_TOKEN}@github.com/".insteadOf "ssh://git@github.com/"
 
     # Cargo registry/git caches are owned by Swatinem/rust-cache@v2 in
     # the calling workflow. Don't double-cache CARGO_HOME here — the two

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   cargo:
     name: Format, Clippy & Unit Tests
-    runs-on: ubuntu-8-core
+    runs-on: ubuntu-latest # TEMP stopgap: ubuntu-8-core larger runners unavailable — revert once restored
     container: rust:slim-bookworm
     # Pin coverage instrumentation AND incremental at the job level so the
     # build, clippy, and coverage steps share one fingerprint and reuse
@@ -90,7 +90,7 @@ jobs:
 
   integration-test:
     name: Integration Tests
-    runs-on: ubuntu-8-core
+    runs-on: ubuntu-latest # TEMP stopgap: ubuntu-8-core larger runners unavailable — revert once restored
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
@@ -157,7 +157,7 @@ jobs:
 
   daml:
     name: DAML Build & Test
-    runs-on: ubuntu-8-core
+    runs-on: ubuntu-latest # TEMP stopgap: ubuntu-8-core larger runners unavailable — revert once restored
     defaults:
       run:
         working-directory: daml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-build-env
         with:
-          ssh-private-key: ${{ secrets.BOT_SSH_PRIVATE_KEY }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           extra-packages: jq bc curl
       # rust-cache trims target/ to only artifacts referenced by the
       # current Cargo.lock (drops orphaned rlibs, build script junk) and
@@ -96,7 +96,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-build-env
         with:
-          ssh-private-key: ${{ secrets.BOT_SSH_PRIVATE_KEY }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           extra-packages: jq curl
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4304,7 +4304,7 @@ dependencies = [
 [[package]]
 name = "tokio-noise"
 version = "0.0.4"
-source = "git+https://github.com/DLC-link/tokio-noise?rev=5826090637d1c06aab396d0c55dc3303a1fffe5f#5826090637d1c06aab396d0c55dc3303a1fffe5f"
+source = "git+https://github.com/DLC-link/tokio-noise?rev=a021216e534d239255581dc002d3892f1080463e#a021216e534d239255581dc002d3892f1080463e"
 dependencies = [
  "log",
  "snow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1111,7 +1111,7 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "dec-party-manager"
-version = "0.1.8"
+version = "0.1.10"
 dependencies = [
  "actix-cors",
  "actix-web",
@@ -4304,8 +4304,7 @@ dependencies = [
 [[package]]
 name = "tokio-noise"
 version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616a12b07009d6d8b98eea1117fb073e862c5a035caa22cb8208224c58911323"
+source = "git+https://github.com/DLC-link/tokio-noise?rev=5826090637d1c06aab396d0c55dc3303a1fffe5f#5826090637d1c06aab396d0c55dc3303a1fffe5f"
 dependencies = [
  "log",
  "snow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4304,7 +4304,7 @@ dependencies = [
 [[package]]
 name = "tokio-noise"
 version = "0.0.4"
-source = "git+https://github.com/DLC-link/tokio-noise?rev=a021216e534d239255581dc002d3892f1080463e#a021216e534d239255581dc002d3892f1080463e"
+source = "git+https://github.com/DLC-link/tokio-noise?rev=5a941dbe07b322dcc068b1a96c5cb11379f21652#5a941dbe07b322dcc068b1a96c5cb11379f21652"
 dependencies = [
  "log",
  "snow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,11 +100,13 @@ tempfile = { version = "3.14" }
 wiremock = { version = "0.6" }
 
 [patch.crates-io]
-# Fork of tokio-noise 0.0.4. Upstream's `poll_write` asserts the kernel accepted
-# the whole noise packet in one write and panics otherwise; under sustained load
-# on a real link (e.g. 1 MiB DAR chunks over testnet) the TCP send buffer fills,
-# the write goes partial, and the coordinator's connection task panics — peers
-# see "persistent communication errors with coordinator". The fork buffers the
-# unflushed ciphertext instead. Applies to hyper-noise's transitive dependency
-# too. Drop this once upstream ships a fix. Branch: fix/partial-write.
-tokio-noise = { git = "https://github.com/DLC-link/tokio-noise", rev = "5826090637d1c06aab396d0c55dc3303a1fffe5f" }
+# Fork of tokio-noise 0.0.4 (also replaces hyper-noise's transitive dep).
+# Upstream's `poll_write` asserts the kernel accepted the whole noise packet in
+# one write and panics on a partial write; under sustained load on a real link
+# (e.g. 1 MiB DAR chunks over testnet) the send buffer fills and the
+# coordinator's connection task panics — peers see "persistent communication
+# errors with coordinator". The fork buffers the unflushed ciphertext, and also
+# drains it from `poll_read` so a request/response flow can't deadlock with
+# bytes stuck in the write buffer. Drop this once upstream ships a fix.
+# Pinned to commit a021216 (branch fix/partial-write of DLC-link/tokio-noise).
+tokio-noise = { git = "https://github.com/DLC-link/tokio-noise", rev = "a021216e534d239255581dc002d3892f1080463e" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dec-party-manager"
-version = "0.1.8"
+version = "0.1.10"
 edition = "2024"
 license = "Apache-2.0"
 
@@ -98,3 +98,13 @@ keycloak = { git = "ssh://git@github.com/DLC-link/canton-lib", branch = "main" }
 static_assertions = { version = "1.1" }
 tempfile = { version = "3.14" }
 wiremock = { version = "0.6" }
+
+[patch.crates-io]
+# Fork of tokio-noise 0.0.4. Upstream's `poll_write` asserts the kernel accepted
+# the whole noise packet in one write and panics otherwise; under sustained load
+# on a real link (e.g. 1 MiB DAR chunks over testnet) the TCP send buffer fills,
+# the write goes partial, and the coordinator's connection task panics — peers
+# see "persistent communication errors with coordinator". The fork buffers the
+# unflushed ciphertext instead. Applies to hyper-noise's transitive dependency
+# too. Drop this once upstream ships a fix. Branch: fix/partial-write.
+tokio-noise = { git = "https://github.com/DLC-link/tokio-noise", rev = "5826090637d1c06aab396d0c55dc3303a1fffe5f" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,5 +108,5 @@ wiremock = { version = "0.6" }
 # errors with coordinator". The fork buffers the unflushed ciphertext, and also
 # drains it from `poll_read` so a request/response flow can't deadlock with
 # bytes stuck in the write buffer. Drop this once upstream ships a fix.
-# Pinned to commit a021216 (branch fix/partial-write of DLC-link/tokio-noise).
-tokio-noise = { git = "https://github.com/DLC-link/tokio-noise", rev = "a021216e534d239255581dc002d3892f1080463e" }
+# Pinned to commit 5a941db on DLC-link/tokio-noise `main` (squash-merge of PR #1).
+tokio-noise = { git = "https://github.com/DLC-link/tokio-noise", rev = "5a941dbe07b322dcc068b1a96c5cb11379f21652" }

--- a/src/noise/client.rs
+++ b/src/noise/client.rs
@@ -83,9 +83,7 @@ impl NoiseClient {
 
         // Connect with timeout
         let tcp_stream =
-            match tokio::time::timeout(request_timeout, TcpStream::connect(&socket_addr))
-                .await
-            {
+            match tokio::time::timeout(request_timeout, TcpStream::connect(&socket_addr)).await {
                 Ok(Ok(stream)) => stream,
                 Ok(Err(e)) => {
                     return Err(NoiseError::TcpConnectionFailed(format!(

--- a/src/noise/client.rs
+++ b/src/noise/client.rs
@@ -1,4 +1,4 @@
-use std::{marker::PhantomData, sync::Arc};
+use std::{marker::PhantomData, sync::Arc, time::Duration};
 
 use bytes::Bytes;
 use hyper::{Body, Request};
@@ -9,8 +9,8 @@ use tokio_noise::handshakes::nn_psk2::Initiator;
 use crate::{
     config::{NodeConfig, Peer},
     noise::{
-        Message, MessageType, NOISE_REQUEST_TIMEOUT, NoiseError, NoiseKeypair, parse_flexible_uri,
-        parse_public_key,
+        Message, MessageType, NOISE_CHUNK_TIMEOUT, NOISE_REQUEST_TIMEOUT, NoiseError, NoiseKeypair,
+        parse_flexible_uri, parse_public_key,
     },
 };
 
@@ -41,8 +41,20 @@ impl NoiseClient {
         })
     }
 
-    /// Send a message to the coordinator
+    /// Send a message to the coordinator with the default control-plane timeout.
     pub async fn send_message(&self, message: &Message) -> Result<Bytes, NoiseError> {
+        self.send_message_with_timeout(message, NOISE_REQUEST_TIMEOUT)
+            .await
+    }
+
+    /// Send a message to the coordinator, applying `request_timeout` to both the
+    /// TCP connect and the Noise/HTTP round-trip. Used so large chunk fetches can
+    /// run on a longer budget than fast control-plane polls.
+    pub async fn send_message_with_timeout(
+        &self,
+        message: &Message,
+        request_timeout: Duration,
+    ) -> Result<Bytes, NoiseError> {
         let socket_addr = format!(
             "{address}:{port}",
             address = self.coordinator.address,
@@ -65,7 +77,7 @@ impl NoiseClient {
 
         // Connect with timeout
         let tcp_stream =
-            match tokio::time::timeout(NOISE_REQUEST_TIMEOUT, TcpStream::connect(&socket_addr))
+            match tokio::time::timeout(request_timeout, TcpStream::connect(&socket_addr))
                 .await
             {
                 Ok(Ok(stream)) => stream,
@@ -95,7 +107,7 @@ impl NoiseClient {
             tcp_stream,
             initiator,
             request,
-            Some(NOISE_REQUEST_TIMEOUT),
+            Some(request_timeout),
         )
         .await?;
 
@@ -273,7 +285,11 @@ impl NoiseClient {
     /// Request a specific chunk from the coordinator
     async fn request_chunk(&self, chunk_index: u32) -> Result<Vec<u8>, NoiseError> {
         let message = Message::new(MessageType::GetChunk, chunk_index.to_be_bytes().to_vec());
-        let response = self.send_message(&message).await?;
+        // Chunks can be up to CHUNK_SIZE (1 MiB); give them the longer budget so
+        // a slow stream isn't cut short by the control-plane timeout.
+        let response = self
+            .send_message_with_timeout(&message, NOISE_CHUNK_TIMEOUT)
+            .await?;
 
         let resp_msg = Message::from_bytes(&response).map_err(|_| NoiseError::InvalidMessage)?;
 

--- a/src/noise/client.rs
+++ b/src/noise/client.rs
@@ -9,8 +9,9 @@ use tokio_noise::handshakes::nn_psk2::Initiator;
 use crate::{
     config::{NodeConfig, Peer},
     noise::{
-        Message, MessageType, NOISE_CHUNK_TIMEOUT, NOISE_REQUEST_TIMEOUT, NoiseError, NoiseKeypair,
-        is_transient, parse_flexible_uri, parse_public_key,
+        CHUNK_SIZE, MAX_CHUNK_COUNT, MAX_CHUNKED_TOTAL_SIZE, Message, MessageType,
+        NOISE_CHUNK_TIMEOUT, NOISE_REQUEST_TIMEOUT, NoiseError, NoiseKeypair, is_transient,
+        parse_flexible_uri, parse_public_key,
     },
 };
 
@@ -279,6 +280,26 @@ impl NoiseClient {
         let command =
             MessageType::try_from(command_type).map_err(|_| NoiseError::InvalidMessage)?;
 
+        // Bound coordinator-supplied metadata before allocating or looping
+        // (mirrors `send_noise_message_with_chunked_response`): a malicious or
+        // buggy coordinator could otherwise advertise multi-GB sizes and OOM
+        // us, or send a chunk_count inconsistent with total_size.
+        if total_size > MAX_CHUNKED_TOTAL_SIZE || chunk_count > MAX_CHUNK_COUNT {
+            tracing::warn!(
+                "chunked-response metadata exceeds caps: total_size={total_size} \
+                 chunk_count={chunk_count}"
+            );
+            return Err(NoiseError::InvalidMessage);
+        }
+        let expected_chunks = total_size.div_ceil(CHUNK_SIZE);
+        if chunk_count != expected_chunks {
+            tracing::warn!(
+                "chunked-response chunk_count {chunk_count} inconsistent with total_size \
+                 {total_size} (expected {expected_chunks})"
+            );
+            return Err(NoiseError::InvalidMessage);
+        }
+
         tracing::info!(
             "Receiving chunked payload for {command:?}: {total_size} bytes in {chunk_count} chunks"
         );
@@ -291,6 +312,14 @@ impl NoiseClient {
         for chunk_index in 0..chunk_count {
             let chunk_data = self.request_chunk_with_retry(chunk_index as u32).await?;
             payload.extend_from_slice(&chunk_data);
+        }
+
+        if payload.len() != total_size {
+            tracing::warn!(
+                "chunked-response assembly produced {} bytes but metadata declared {total_size}",
+                payload.len()
+            );
+            return Err(NoiseError::InvalidMessage);
         }
 
         tracing::info!(
@@ -337,7 +366,22 @@ impl NoiseClient {
             return Err(NoiseError::InvalidMessage);
         }
 
-        // Chunk response: [chunk_index (4 bytes)] [chunk_data (variable)]
+        // Chunk response: [chunk_index (4 bytes)] [chunk_data (variable)].
+        // Verify the echoed index matches what we asked for so a server bug or
+        // cross-peer cache mix-up can't silently corrupt the assembled payload.
+        let received_index = u32::from_be_bytes([
+            resp_msg.payload[0],
+            resp_msg.payload[1],
+            resp_msg.payload[2],
+            resp_msg.payload[3],
+        ]);
+        if received_index != chunk_index {
+            tracing::warn!(
+                "chunk response carried wrong index: requested {chunk_index}, got {received_index}"
+            );
+            return Err(NoiseError::InvalidMessage);
+        }
+
         Ok(resp_msg.payload[4..].to_vec())
     }
 }

--- a/src/noise/client.rs
+++ b/src/noise/client.rs
@@ -10,9 +10,14 @@ use crate::{
     config::{NodeConfig, Peer},
     noise::{
         Message, MessageType, NOISE_CHUNK_TIMEOUT, NOISE_REQUEST_TIMEOUT, NoiseError, NoiseKeypair,
-        parse_flexible_uri, parse_public_key,
+        is_transient, parse_flexible_uri, parse_public_key,
     },
 };
+
+/// Max attempts to fetch a single chunk (each on a fresh connection) before the
+/// chunked transfer gives up. Lets a transient stall/reset recover in place
+/// instead of restarting the whole download.
+const CHUNK_FETCH_MAX_ATTEMPTS: usize = 3;
 
 /// Client for connecting to the coordinator
 pub struct NoiseClient {
@@ -267,10 +272,13 @@ impl NoiseClient {
             "Receiving chunked payload for {command:?}: {total_size} bytes in {chunk_count} chunks"
         );
 
-        // Fetch all chunks
+        // Fetch all chunks. Each chunk is retried in place on a fresh
+        // connection so a single slow/stalled chunk (e.g. transient coordinator
+        // load) doesn't discard every already-downloaded chunk and force the
+        // whole transfer to restart from chunk 0.
         let mut payload = Vec::with_capacity(total_size);
         for chunk_index in 0..chunk_count {
-            let chunk_data = self.request_chunk(chunk_index as u32).await?;
+            let chunk_data = self.request_chunk_with_retry(chunk_index as u32).await?;
             payload.extend_from_slice(&chunk_data);
         }
 
@@ -280,6 +288,27 @@ impl NoiseClient {
         );
 
         Ok(Message::new(command, payload))
+    }
+
+    /// Request a chunk, retrying transient failures (connection reset, timeout,
+    /// truncated body) on a fresh connection up to `CHUNK_FETCH_MAX_ATTEMPTS`.
+    /// Non-transient errors (bad message, decode failure) fail immediately.
+    async fn request_chunk_with_retry(&self, chunk_index: u32) -> Result<Vec<u8>, NoiseError> {
+        let mut attempt = 1;
+        loop {
+            match self.request_chunk(chunk_index).await {
+                Ok(data) => return Ok(data),
+                Err(e) if attempt < CHUNK_FETCH_MAX_ATTEMPTS && is_transient(&e) => {
+                    tracing::warn!(
+                        "chunk {chunk_index} fetch attempt {attempt}/{CHUNK_FETCH_MAX_ATTEMPTS} \
+                         failed: {e}; retrying"
+                    );
+                    attempt += 1;
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                }
+                Err(e) => return Err(e),
+            }
+        }
     }
 
     /// Request a specific chunk from the coordinator

--- a/src/noise/client.rs
+++ b/src/noise/client.rs
@@ -121,8 +121,19 @@ impl NoiseClient {
             return Err(NoiseError::BadStatusCode(response.status()));
         }
 
-        // Read response body
-        let resp_body_bytes = hyper::body::to_bytes(response.body_mut()).await?;
+        // Read response body, bounded by `request_timeout`. `send_request`'s
+        // timeout only covers receiving the response *head*, not streaming the
+        // body — so without this, a stalled large body (e.g. a chunk that
+        // freezes mid-transfer) would hang until the server closes the
+        // connection instead of failing fast here and letting the caller retry.
+        let resp_body_bytes =
+            match tokio::time::timeout(request_timeout, hyper::body::to_bytes(response.body_mut()))
+                .await
+            {
+                Ok(Ok(bytes)) => bytes,
+                Ok(Err(e)) => return Err(NoiseError::from(e)),
+                Err(_) => return Err(NoiseError::RequestTimeout),
+            };
 
         tracing::debug!(
             "Received response from coordinator: {count} bytes",

--- a/src/noise/mod.rs
+++ b/src/noise/mod.rs
@@ -19,8 +19,22 @@ use zeroize::Zeroizing;
 
 use crate::{config::NoiseRetryConfig, error::Result};
 
-/// Timeout for Noise protocol operations
+/// Timeout for control-plane Noise requests (command polls, acks, small
+/// messages): covers connect + handshake + one round-trip. Kept short so a
+/// dead coordinator is detected quickly.
 pub const NOISE_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Timeout for streaming a single large chunk (up to `CHUNK_SIZE`). A 1 MiB
+/// chunk can take far longer than the control-plane timeout to stream over a
+/// CPU-constrained or high-latency link (e.g. while the coordinator is also
+/// uploading its own DARs), so chunk fetches get a longer budget.
+pub const NOISE_CHUNK_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Server-side per-connection handler timeout. `hyper-noise` counts the full
+/// response write against this, so it MUST exceed `NOISE_CHUNK_TIMEOUT` — the
+/// server must never cancel a chunk response the client is still willing to
+/// read.
+pub const NOISE_HANDLER_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// Message types for the Noise protocol communication
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]

--- a/src/noise/mod.rs
+++ b/src/noise/mod.rs
@@ -24,17 +24,20 @@ use crate::{config::NoiseRetryConfig, error::Result};
 /// dead coordinator is detected quickly.
 pub const NOISE_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// Timeout for streaming a single large chunk (up to `CHUNK_SIZE`). A 1 MiB
-/// chunk can take far longer than the control-plane timeout to stream over a
-/// CPU-constrained or high-latency link (e.g. while the coordinator is also
-/// uploading its own DARs), so chunk fetches get a longer budget.
-pub const NOISE_CHUNK_TIMEOUT: Duration = Duration::from_secs(60);
+/// Per-phase timeout for fetching a single chunk (connect, request, and the
+/// response-body read are each bounded by this). A healthy 1 MiB chunk
+/// transfers in well under a second; this is sized to absorb load spikes while
+/// still catching a *stalled* chunk quickly so the caller can retry it on a
+/// fresh connection (see `request_chunk_with_retry`) rather than waiting on the
+/// server's handler timeout.
+pub const NOISE_CHUNK_TIMEOUT: Duration = Duration::from_secs(25);
 
-/// Server-side per-connection handler timeout. `hyper-noise` counts the full
-/// response write against this, so it MUST exceed `NOISE_CHUNK_TIMEOUT` — the
-/// server must never cancel a chunk response the client is still willing to
-/// read.
-pub const NOISE_HANDLER_TIMEOUT: Duration = Duration::from_secs(120);
+/// Server-side per-connection handler timeout (`hyper-noise` counts the full
+/// response write against it). Acts as a backstop — the client now bounds its
+/// own chunk reads via `NOISE_CHUNK_TIMEOUT`, so the client gives up (and
+/// retries) first; this just bounds a connection the client already abandoned.
+/// Kept comfortably above `NOISE_CHUNK_TIMEOUT`.
+pub const NOISE_HANDLER_TIMEOUT: Duration = Duration::from_secs(45);
 
 /// Message types for the Noise protocol communication
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]

--- a/src/noise/mod.rs
+++ b/src/noise/mod.rs
@@ -617,7 +617,7 @@ pub async fn load_or_generate_keypair<P: AsRef<Path>>(path: P) -> Result<NoiseKe
 ///
 /// Exhaustive match (no wildcard) — adding a new `NoiseError` variant will
 /// fail to compile here until it's explicitly classified as retryable or not.
-fn is_transient(err: &NoiseError) -> bool {
+pub(crate) fn is_transient(err: &NoiseError) -> bool {
     match err {
         NoiseError::TcpConnectionTimeout(_)
         | NoiseError::TcpConnectionFailed(_)

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -59,8 +59,8 @@ use crate::{
     db::schema::{Commitable, SchemaRead, SchemaWrite},
     error::Result,
     noise::{
-        CHUNK_SIZE, MAX_CHUNKED_TOTAL_SIZE, MAX_PAYLOAD_SIZE, Message, MessageType, NoiseKeypair,
-        load_or_generate_keypair, parse_public_key,
+        CHUNK_SIZE, MAX_CHUNKED_TOTAL_SIZE, MAX_PAYLOAD_SIZE, Message, MessageType,
+        NOISE_HANDLER_TIMEOUT, NoiseKeypair, load_or_generate_keypair, parse_public_key,
     },
     server::middleware::AuthMiddleware,
     server::peer_status::LastSeen,
@@ -2098,7 +2098,11 @@ async fn handle_incoming_connection(
                 Ok(Response::new(Body::empty()))
             }
         },
-        Some(Duration::from_secs(5)),
+        // Must exceed the client's per-chunk timeout (NOISE_CHUNK_TIMEOUT) — this
+        // bounds the whole response write, and a 1 MiB chunk can take well over
+        // the old 5s on a CPU-constrained node, which truncated DAR transfers
+        // mid-body ("end of file before message length reached").
+        Some(NOISE_HANDLER_TIMEOUT),
     )
     .await;
 

--- a/src/workflow/dars/coordinator.rs
+++ b/src/workflow/dars/coordinator.rs
@@ -67,8 +67,6 @@ async fn run_workflow(
     let dar_payload = encode_dars_payload(&config)?;
     workflow_state.set_command_payload(dar_payload).await;
 
-    let mut coordinator_completed = false;
-
     loop {
         let current_step = workflow_state.current_step().await;
 
@@ -77,14 +75,21 @@ async fn run_workflow(
                 tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
             }
             DarsStep::UploadDars => {
-                if !coordinator_completed {
-                    tracing::info!("Coordinator executing: Upload DARs");
-                    contracts::upload_dars(&node_config, &config.dar_files).await?;
-                    coordinator_completed = true;
-                }
+                // While peers are downloading, this node ONLY serves chunks
+                // (handled by the Noise listener). The coordinator's own DAR
+                // upload is deferred to `Complete` so its CPU/IO doesn't
+                // contend with — and stall — the chunk transfer to peers on
+                // CPU-limited nodes.
                 tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
             }
             DarsStep::Complete => {
+                // All peers have finished downloading (the step only advances
+                // here once every peer completed UploadDars), so there's no
+                // chunk-serving load left to compete with. Upload our own DARs
+                // now. (Reached once, then we break — re-runs only on a resume,
+                // where re-uploading is idempotent.)
+                tracing::info!("Coordinator executing: Upload DARs");
+                contracts::upload_dars(&node_config, &config.dar_files).await?;
                 tracing::info!("DARs upload workflow complete!");
                 tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
                 break;


### PR DESCRIPTION
## Problem

Distributing DAR files over the Noise channel failed on testnet. Three root causes, peeled back one at a time and each verified against the live nodes:

1. **Coordinator panic** — `tokio-noise 0.0.4`'s `poll_write` `assert_eq!`s that the kernel accepted the whole ~2 KiB packet and panics on a partial TCP write. Under load (1 MiB DAR chunks) the send buffer fills → panic → peers see `Peer failed: persistent communication errors with coordinator`. Invisible on loopback/CI; deterministic on a real link.
2. **5 s server handler timeout** — shorter than the client's own timeout, so it truncated chunk bodies mid-write (`end of file before message length reached`).
3. **Per-connection deadlock** — even after buffering a partial write, `poll_write` returned `Ready` without arming a write-readiness waker, so in a request/response flow (send `GetChunk`, then await the read) the buffered ciphertext never drained → stall until timeout.

## Changes

- **`[patch.crates-io]` → `DLC-link/tokio-noise` fork** (also replaces `hyper-noise`'s transitive dep). Buffers unflushed ciphertext on a partial/`WouldBlock` write instead of asserting, and drains it from `poll_read` so a request/response flow can't deadlock. (DLC-link/tokio-noise#1, merged; pinned to `5a941db`.)
- **Noise timeouts** (`noise/mod.rs`): `NOISE_CHUNK_TIMEOUT` 25 s for chunk fetches (control polls keep `NOISE_REQUEST_TIMEOUT` 10 s); `NOISE_HANDLER_TIMEOUT` 45 s server backstop. The client now also bounds the response *body* read, not just the request head.
- **Decoupled the coordinator's own DAR upload** from chunk serving (`dars/coordinator.rs`): moved from the `UploadDars` step to `Complete` so it no longer competes for CPU with serving chunks to peers.
- **Per-chunk retry** (`noise/client.rs`): a stalled/failed chunk retries on a fresh connection instead of discarding every already-downloaded chunk.
- **Chunked-receive hardening** (review feedback): bound `total_size`/`chunk_count`, verify `chunk_count == total_size.div_ceil(CHUNK_SIZE)`, verify the echoed chunk index, and check the assembled length — parity with `send_noise_message_with_chunked_response`.

## Verification

- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- End-to-end on testnet: single-DAR and multi-DAR (5 DARs / 7.49 MB / 8 chunks) distributions both complete (`DARs upload workflow complete!`).