### PR TITLE
fix(workflow): proceed at party threshold instead of requiring all peers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1328,7 +1328,7 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "decman"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "actix-cors",
  "actix-web",

--- a/crates/decman/Cargo.toml
+++ b/crates/decman/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "decman"
-version = "1.3.0"
+version = "1.4.0"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/crates/decman/src/db/schema.rs
+++ b/crates/decman/src/db/schema.rs
@@ -99,8 +99,9 @@ pub trait SchemaRead {
     /// Get a single workflow run by its instance name.
     async fn get_workflow_run(&self, instance_name: &str) -> Result<Option<WorkflowRun>>;
 
-    /// Look up the in-progress run for a given (kind, role) on this node.
-    /// Returns at most one row thanks to the partial unique index.
+    /// Look up an in-progress run for a given (kind, role) on this node. With
+    /// concurrent same-kind runs (the per-kind unique index was dropped in
+    /// migration 000013) several may match; returns the lowest `instance_name`.
     async fn get_active_workflow_run(
         &self,
         kind: WorkflowKind,

--- a/crates/decman/src/db/sqlite.rs
+++ b/crates/decman/src/db/sqlite.rs
@@ -355,9 +355,14 @@ impl SchemaRead for SqlitePool {
         kind: WorkflowKind,
         role: WorkflowRole,
     ) -> Result<Option<WorkflowRun>> {
+        // ORDER BY instance_name so that, with concurrent same-kind runs (the
+        // per-kind unique index was dropped in migration 000013), this picks the
+        // same run as `pick_coordinator_run` (lowest instance_name) — the
+        // persisted-row cancel path must not target a different run than the feed.
         let row = sqlx::query_as::<_, WorkflowRunRow>(
             "SELECT * FROM workflow_runs \
              WHERE kind = ? AND role = ? AND status = 'inprogress' \
+             ORDER BY instance_name \
              LIMIT 1",
         )
         .bind(kind.as_str())

--- a/crates/decman/src/noise/server.rs
+++ b/crates/decman/src/noise/server.rs
@@ -97,18 +97,8 @@ impl ActiveWorkflow {
     }
 }
 
-/// How many peers must connect before a coordinator workflow leaves
-/// `WaitingForPeers`, given the decentralized party's signing threshold `m`
-/// (the total number of signers required, *including* the coordinator) and the
-/// number of `expected_peers` (which never includes the coordinator).
-///
-/// The coordinator participates itself, so `m - 1` peer connections make a
-/// quorum present and the workflow can start. The result is clamped:
-/// - `expected_peers == 0` returns `0` — there are no peers to wait for, so the
-///   start gate is satisfied immediately (the no-peer / solo case);
-/// - otherwise it is clamped to at least one peer (a `0` requirement could
-///   never be tripped by a peer connect event, so it would hang the wait) and
-///   to at most the peers actually available.
+/// Peer quorum: `m - 1` (the coordinator signs itself), clamped to
+/// `[1, expected_peers]` so a peer event can always trip it (`0` if no peers).
 fn peers_for_party_threshold(m: usize, expected_peers: usize) -> usize {
     if expected_peers == 0 {
         return 0;
@@ -116,13 +106,8 @@ fn peers_for_party_threshold(m: usize, expected_peers: usize) -> usize {
     m.saturating_sub(1).clamp(1, expected_peers)
 }
 
-/// Resolve the **start-gate** quorum for a coordinator run: how many peers must
-/// connect before the workflow leaves `WaitingForPeers`. `None` means "require
-/// every expected peer" — the original behaviour — and is also the safe,
-/// no-regression fallback whenever a party threshold can't be resolved.
-///
-/// This only governs when the workflow *starts*; the per-step signing gate
-/// still waits for every expected peer (see `WorkflowState::peer_threshold`).
+/// Peer quorum for a run (`WorkflowState::peer_threshold`). `None` = require
+/// every expected peer — also the fallback when the threshold can't be resolved.
 async fn resolve_peer_threshold(
     kind: WorkflowKind,
     dec_party_id: Option<&CantonId>,
@@ -133,18 +118,12 @@ async fn resolve_peer_threshold(
         return None;
     }
     match kind {
-        // Onboarding defines the party's owner set, so every invitee must take
-        // part. DARs is a file distribution — the coordinator serves chunks to
-        // each peer, so it must wait for all selected peers regardless. AddParty
-        // brings in a brand-new member who cannot be skipped (`invitees` carries
-        // them), and ChangeThreshold has every remaining member sign with no
-        // exclusions. All four therefore require the full set even to start.
+        // These define/extend the owner set or need every member — require all.
         WorkflowKind::Onboarding
         | WorkflowKind::Dars
         | WorkflowKind::AddParty
         | WorkflowKind::ChangeThreshold => None,
-        // Operate on an existing M-of-N party: a quorum of owners is enough to
-        // begin, so a slow/absent owner no longer blocks the workflow's start.
+        // Existing M-of-N party: a quorum is enough.
         WorkflowKind::Kick | WorkflowKind::Contracts => {
             let party_id = dec_party_id?;
             let m = lookup_party_threshold(db, party_id).await?;
@@ -153,11 +132,8 @@ async fn resolve_peer_threshold(
     }
 }
 
-/// Read the decentralized party's signing threshold `M` from the local cache
-/// (`dec_parties`). Returns `None` if the party isn't cached or the stored
-/// value is unusable (missing, non-positive, or out of range), in which case
-/// the caller requires every expected peer. `M` is a meaningful M-of-N
-/// threshold only when `>= 1`, so a cached `0` is treated as invalid.
+/// Party signing threshold `M` from the `dec_parties` cache, or `None` (caller
+/// requires all) when it's absent or invalid (`< 1`).
 async fn lookup_party_threshold(db: &SqlitePool, party_id: &CantonId) -> Option<usize> {
     let party_id_str = party_id.to_string();
     let parties = match SchemaRead::get_dec_parties_by_prefix(db, &party_id.prefix).await {
@@ -277,12 +253,6 @@ impl<S: WorkflowStep + 'static> NoiseServer<S> {
             .cloned()
             .collect();
 
-        // How many peers must connect / complete a peer-gated step before the
-        // workflow advances. Onboarding keeps requiring every invitee (it
-        // defines the party's owner set); the post-onboarding workflows operate
-        // on an existing M-of-N party, so a quorum is enough and an absent owner
-        // no longer stalls them. `None` => require all (also the safe fallback
-        // when a party threshold can't be resolved).
         let peer_threshold = resolve_peer_threshold(
             S::kind(),
             persisted.as_ref().and_then(|run| run.dec_party_id.as_ref()),
@@ -723,24 +693,15 @@ mod tests {
 
     #[test]
     fn party_threshold_subtracts_the_coordinators_own_signature() {
-        // 2-of-3 party (coordinator + 2 peers): coordinator signs itself, so a
-        // single peer signature completes the quorum.
         assert_eq!(peers_for_party_threshold(2, 2), 1);
-        // 3-of-4 party (coordinator + 3 peers): need two more peers.
         assert_eq!(peers_for_party_threshold(3, 3), 2);
-        // 3-of-5 / unanimous 4-of-4 etc. still resolve to M-1 peers.
         assert_eq!(peers_for_party_threshold(4, 4), 3);
     }
 
     #[test]
     fn party_threshold_is_clamped_into_range() {
-        // M = 1 (coordinator alone suffices) would resolve to 0 peers, which a
-        // peer event could never trip — clamp up to 1 so the wait can complete.
-        assert_eq!(peers_for_party_threshold(1, 3), 1);
-        // A threshold larger than the peers available is clamped down to all of
-        // them, reproducing the original require-all behaviour.
-        assert_eq!(peers_for_party_threshold(9, 2), 2);
-        // No peers at all => nothing to wait for.
-        assert_eq!(peers_for_party_threshold(5, 0), 0);
+        assert_eq!(peers_for_party_threshold(1, 3), 1); // M=1 → 0 clamps up to 1
+        assert_eq!(peers_for_party_threshold(9, 2), 2); // over-count clamps to all
+        assert_eq!(peers_for_party_threshold(5, 0), 0); // no peers
     }
 }

--- a/crates/decman/src/noise/server.rs
+++ b/crates/decman/src/noise/server.rs
@@ -134,7 +134,7 @@ async fn resolve_peer_threshold(
 
 /// Party signing threshold `M` from the `dec_parties` cache, or `None` (caller
 /// requires all) when it's absent or invalid (`< 1`).
-async fn lookup_party_threshold(db: &SqlitePool, party_id: &CantonId) -> Option<usize> {
+pub(crate) async fn lookup_party_threshold(db: &SqlitePool, party_id: &CantonId) -> Option<usize> {
     let party_id_str = party_id.to_string();
     let parties = match SchemaRead::get_dec_parties_by_prefix(db, &party_id.prefix).await {
         Ok(parties) => parties,

--- a/crates/decman/src/noise/server.rs
+++ b/crates/decman/src/noise/server.rs
@@ -97,16 +97,18 @@ impl ActiveWorkflow {
     }
 }
 
-/// Peers that must act before a coordinator workflow advances, given the
-/// decentralized party's signing threshold `m` (the total number of signers
-/// required, *including* the coordinator) and the number of `expected_peers`
-/// (which never includes the coordinator).
+/// How many peers must connect before a coordinator workflow leaves
+/// `WaitingForPeers`, given the decentralized party's signing threshold `m`
+/// (the total number of signers required, *including* the coordinator) and the
+/// number of `expected_peers` (which never includes the coordinator).
 ///
-/// The coordinator always participates and contributes one signature itself,
-/// so `m - 1` peer signatures complete the quorum. The result is clamped to at
-/// least one peer — a coordinator-only quorum is never tripped by a peer
-/// connect/complete event, so it would hang the wait — and to at most the
-/// peers actually available.
+/// The coordinator participates itself, so `m - 1` peer connections make a
+/// quorum present and the workflow can start. The result is clamped:
+/// - `expected_peers == 0` returns `0` — there are no peers to wait for, so the
+///   start gate is satisfied immediately (the no-peer / solo case);
+/// - otherwise it is clamped to at least one peer (a `0` requirement could
+///   never be tripped by a peer connect event, so it would hang the wait) and
+///   to at most the peers actually available.
 fn peers_for_party_threshold(m: usize, expected_peers: usize) -> usize {
     if expected_peers == 0 {
         return 0;
@@ -114,9 +116,13 @@ fn peers_for_party_threshold(m: usize, expected_peers: usize) -> usize {
     m.saturating_sub(1).clamp(1, expected_peers)
 }
 
-/// Resolve the peer quorum for a coordinator run. `None` means "require every
-/// expected peer" — the original behaviour — and is also the safe, no-regression
-/// fallback whenever a party threshold can't be resolved.
+/// Resolve the **start-gate** quorum for a coordinator run: how many peers must
+/// connect before the workflow leaves `WaitingForPeers`. `None` means "require
+/// every expected peer" — the original behaviour — and is also the safe,
+/// no-regression fallback whenever a party threshold can't be resolved.
+///
+/// This only governs when the workflow *starts*; the per-step signing gate
+/// still waits for every expected peer (see `WorkflowState::peer_threshold`).
 async fn resolve_peer_threshold(
     kind: WorkflowKind,
     dec_party_id: Option<&CantonId>,
@@ -129,13 +135,16 @@ async fn resolve_peer_threshold(
     match kind {
         // Onboarding defines the party's owner set, so every invitee must take
         // part. DARs is a file distribution — the coordinator serves chunks to
-        // each peer, so finishing at a quorum would cut off a peer that's still
-        // downloading and leave it without the package; it keeps requiring all
-        // selected peers. Both therefore require the full set.
-        WorkflowKind::Onboarding | WorkflowKind::Dars => None,
-        // Operate on an existing M-of-N party: only a quorum of owners is needed
-        // to authorise the topology/ledger change, so an absent owner no longer
-        // stalls the run.
+        // each peer, so it must wait for all selected peers regardless. AddParty
+        // brings in a brand-new member who cannot be skipped (`invitees` carries
+        // them), and ChangeThreshold has every remaining member sign with no
+        // exclusions. All four therefore require the full set even to start.
+        WorkflowKind::Onboarding
+        | WorkflowKind::Dars
+        | WorkflowKind::AddParty
+        | WorkflowKind::ChangeThreshold => None,
+        // Operate on an existing M-of-N party: a quorum of owners is enough to
+        // begin, so a slow/absent owner no longer blocks the workflow's start.
         WorkflowKind::Kick | WorkflowKind::Contracts => {
             let party_id = dec_party_id?;
             let m = lookup_party_threshold(db, party_id).await?;
@@ -146,7 +155,9 @@ async fn resolve_peer_threshold(
 
 /// Read the decentralized party's signing threshold `M` from the local cache
 /// (`dec_parties`). Returns `None` if the party isn't cached or the stored
-/// value is unusable, in which case the caller requires every expected peer.
+/// value is unusable (missing, non-positive, or out of range), in which case
+/// the caller requires every expected peer. `M` is a meaningful M-of-N
+/// threshold only when `>= 1`, so a cached `0` is treated as invalid.
 async fn lookup_party_threshold(db: &SqlitePool, party_id: &CantonId) -> Option<usize> {
     let party_id_str = party_id.to_string();
     let parties = match SchemaRead::get_dec_parties_by_prefix(db, &party_id.prefix).await {
@@ -163,8 +174,8 @@ async fn lookup_party_threshold(db: &SqlitePool, party_id: &CantonId) -> Option<
         .find(|p| p.party_id == party_id_str)
         .map(|p| p.threshold)?;
     match usize::try_from(threshold) {
-        Ok(m) => Some(m),
-        Err(_) => {
+        Ok(m) if m >= 1 => Some(m),
+        _ => {
             tracing::warn!(
                 "Dec party {party_id_str} has invalid threshold {threshold}; requiring all peers"
             );

--- a/crates/decman/src/noise/server.rs
+++ b/crates/decman/src/noise/server.rs
@@ -97,6 +97,82 @@ impl ActiveWorkflow {
     }
 }
 
+/// Peers that must act before a coordinator workflow advances, given the
+/// decentralized party's signing threshold `m` (the total number of signers
+/// required, *including* the coordinator) and the number of `expected_peers`
+/// (which never includes the coordinator).
+///
+/// The coordinator always participates and contributes one signature itself,
+/// so `m - 1` peer signatures complete the quorum. The result is clamped to at
+/// least one peer — a coordinator-only quorum is never tripped by a peer
+/// connect/complete event, so it would hang the wait — and to at most the
+/// peers actually available.
+fn peers_for_party_threshold(m: usize, expected_peers: usize) -> usize {
+    if expected_peers == 0 {
+        return 0;
+    }
+    m.saturating_sub(1).clamp(1, expected_peers)
+}
+
+/// Resolve the peer quorum for a coordinator run. `None` means "require every
+/// expected peer" — the original behaviour — and is also the safe, no-regression
+/// fallback whenever a party threshold can't be resolved.
+async fn resolve_peer_threshold(
+    kind: WorkflowKind,
+    dec_party_id: Option<&CantonId>,
+    db: &SqlitePool,
+    expected_peers: usize,
+) -> Option<usize> {
+    if expected_peers == 0 {
+        return None;
+    }
+    match kind {
+        // Onboarding defines the party's owner set, so every invitee must take
+        // part. DARs is a file distribution — the coordinator serves chunks to
+        // each peer, so finishing at a quorum would cut off a peer that's still
+        // downloading and leave it without the package; it keeps requiring all
+        // selected peers. Both therefore require the full set.
+        WorkflowKind::Onboarding | WorkflowKind::Dars => None,
+        // Operate on an existing M-of-N party: only a quorum of owners is needed
+        // to authorise the topology/ledger change, so an absent owner no longer
+        // stalls the run.
+        WorkflowKind::Kick | WorkflowKind::Contracts => {
+            let party_id = dec_party_id?;
+            let m = lookup_party_threshold(db, party_id).await?;
+            Some(peers_for_party_threshold(m, expected_peers))
+        }
+    }
+}
+
+/// Read the decentralized party's signing threshold `M` from the local cache
+/// (`dec_parties`). Returns `None` if the party isn't cached or the stored
+/// value is unusable, in which case the caller requires every expected peer.
+async fn lookup_party_threshold(db: &SqlitePool, party_id: &CantonId) -> Option<usize> {
+    let party_id_str = party_id.to_string();
+    let parties = match SchemaRead::get_dec_parties_by_prefix(db, &party_id.prefix).await {
+        Ok(parties) => parties,
+        Err(e) => {
+            tracing::warn!(
+                "Could not read dec party threshold for {party_id_str}: {e}; requiring all peers"
+            );
+            return None;
+        }
+    };
+    let threshold = parties
+        .into_iter()
+        .find(|p| p.party_id == party_id_str)
+        .map(|p| p.threshold)?;
+    match usize::try_from(threshold) {
+        Ok(m) => Some(m),
+        Err(_) => {
+            tracing::warn!(
+                "Dec party {party_id_str} has invalid threshold {threshold}; requiring all peers"
+            );
+            None
+        }
+    }
+}
+
 impl<S: WorkflowStep + 'static> NoiseServer<S> {
     /// Create a new Noise server
     ///
@@ -190,6 +266,20 @@ impl<S: WorkflowStep + 'static> NoiseServer<S> {
             .cloned()
             .collect();
 
+        // How many peers must connect / complete a peer-gated step before the
+        // workflow advances. Onboarding keeps requiring every invitee (it
+        // defines the party's owner set); the post-onboarding workflows operate
+        // on an existing M-of-N party, so a quorum is enough and an absent owner
+        // no longer stalls them. `None` => require all (also the safe fallback
+        // when a party threshold can't be resolved).
+        let peer_threshold = resolve_peer_threshold(
+            S::kind(),
+            persisted.as_ref().and_then(|run| run.dec_party_id.as_ref()),
+            &db,
+            expected_peers.len(),
+        )
+        .await;
+
         // Resume-aware construction: if an InProgress workflow_runs row already
         // exists for `instance_name` (we restarted mid-flight), re-hydrate the
         // state machine from its persisted `current_step` + already-completed
@@ -212,6 +302,7 @@ impl<S: WorkflowStep + 'static> NoiseServer<S> {
                             step,
                             expected_peers,
                             run.completed_peers,
+                            peer_threshold,
                         )
                     }
                     None => {
@@ -221,11 +312,23 @@ impl<S: WorkflowStep + 'static> NoiseServer<S> {
                             run.current_step,
                             kind = std::any::type_name::<S>()
                         );
-                        WorkflowState::new(db, instance_name, initial_step, expected_peers)
+                        WorkflowState::new(
+                            db,
+                            instance_name,
+                            initial_step,
+                            expected_peers,
+                            peer_threshold,
+                        )
                     }
                 }
             }
-            _ => WorkflowState::new(db, instance_name, initial_step, expected_peers),
+            _ => WorkflowState::new(
+                db,
+                instance_name,
+                initial_step,
+                expected_peers,
+                peer_threshold,
+            ),
         };
 
         Ok(Self {
@@ -605,5 +708,28 @@ mod tests {
             WorkflowKind::Onboarding,
             "acme-creation"
         ));
+    }
+
+    #[test]
+    fn party_threshold_subtracts_the_coordinators_own_signature() {
+        // 2-of-3 party (coordinator + 2 peers): coordinator signs itself, so a
+        // single peer signature completes the quorum.
+        assert_eq!(peers_for_party_threshold(2, 2), 1);
+        // 3-of-4 party (coordinator + 3 peers): need two more peers.
+        assert_eq!(peers_for_party_threshold(3, 3), 2);
+        // 3-of-5 / unanimous 4-of-4 etc. still resolve to M-1 peers.
+        assert_eq!(peers_for_party_threshold(4, 4), 3);
+    }
+
+    #[test]
+    fn party_threshold_is_clamped_into_range() {
+        // M = 1 (coordinator alone suffices) would resolve to 0 peers, which a
+        // peer event could never trip — clamp up to 1 so the wait can complete.
+        assert_eq!(peers_for_party_threshold(1, 3), 1);
+        // A threshold larger than the peers available is clamped down to all of
+        // them, reproducing the original require-all behaviour.
+        assert_eq!(peers_for_party_threshold(9, 2), 2);
+        // No peers at all => nothing to wait for.
+        assert_eq!(peers_for_party_threshold(5, 0), 0);
     }
 }

--- a/crates/decman/src/server/handlers/workflows.rs
+++ b/crates/decman/src/server/handlers/workflows.rs
@@ -2665,13 +2665,8 @@ async fn send_dars_invites(
 /// run of `kind` via [`pick_coordinator_run`] (deterministic lowest
 /// instance_name), so `/{kind}/status` and `/{kind}/cancel` always act on the
 /// same instance. Callers that know which run they mean should use
-/// `POST /workflows/{instance}/cancel`.
-///
-/// When no run of `kind` is registered in memory, the UI may still list one as
-/// InProgress off a persisted coordinator row — a run whose task exited without
-/// marking the row terminal, or one a restart's recovery failed to restore.
-/// Fall back to cancelling that row (see [`cancel_persisted_run`]) so a stuck
-/// run is never uncancellable.
+/// `POST /workflows/{instance}/cancel`. With no in-memory run, falls back to the
+/// persisted row (see [`cancel_persisted_run`]) so a stuck run stays cancellable.
 async fn cancel_workflow_state(
     data: &web::Data<AppState>,
     label: &str,
@@ -2683,12 +2678,8 @@ async fn cancel_workflow_state(
     cancel_persisted_run(data, label, kind).await
 }
 
-/// Cancel a coordinator run that has a persisted `inprogress` row but no live
-/// in-memory [`WorkflowInstance`] — there is no task to abort, so we cannot go
-/// through [`cancel_instance`]. Best-effort notifies the peers the row recorded
-/// (the in-memory invitee list is gone with the instance, so use the row's
-/// `expected_peers`), then flips the row to Cancelled so the feed reflects it.
-/// Returns 409 when no such row exists.
+/// Cancel a run with a persisted `inprogress` row but no in-memory instance
+/// (nothing to abort): notify the row's peers, flip it to Cancelled, 409 if none.
 async fn cancel_persisted_run(
     data: &web::Data<AppState>,
     label: &str,
@@ -2725,9 +2716,7 @@ async fn cancel_persisted_run(
         tracing::warn!("send_cancel_invites failed during {label} cancel: {e}");
     }
 
-    // Flip the persisted coordinator row to Cancelled so the feed reflects it.
-    // On a write failure the row stays InProgress and recovery may resume it, so
-    // surface 500 for the operator to retry against consistent state.
+    // On write failure the row stays InProgress (recovery may resume it) — 500.
     if let Err(e) = mark_run_status(
         &data.db,
         &run.instance_name,

--- a/crates/decman/src/server/handlers/workflows.rs
+++ b/crates/decman/src/server/handlers/workflows.rs
@@ -2666,17 +2666,95 @@ async fn send_dars_invites(
 /// instance_name), so `/{kind}/status` and `/{kind}/cancel` always act on the
 /// same instance. Callers that know which run they mean should use
 /// `POST /workflows/{instance}/cancel`.
+///
+/// When no run of `kind` is registered in memory, the UI may still list one as
+/// InProgress off a persisted coordinator row — a run whose task exited without
+/// marking the row terminal, or one a restart's recovery failed to restore.
+/// Fall back to cancelling that row (see [`cancel_persisted_run`]) so a stuck
+/// run is never uncancellable.
 async fn cancel_workflow_state(
     data: &web::Data<AppState>,
     label: &str,
     kind: WorkflowKind,
 ) -> HttpResponse {
-    let Some(instance) = pick_coordinator_run(data, kind) else {
-        return HttpResponse::Conflict().json(ErrorResponse {
-            error: format!("No {label} workflow in progress"),
-        });
+    if let Some(instance) = pick_coordinator_run(data, kind) {
+        return cancel_instance(data, &instance, label).await;
+    }
+    cancel_persisted_run(data, label, kind).await
+}
+
+/// Cancel a coordinator run that has a persisted `inprogress` row but no live
+/// in-memory [`WorkflowInstance`] — there is no task to abort, so we cannot go
+/// through [`cancel_instance`]. Best-effort notifies the peers the row recorded
+/// (the in-memory invitee list is gone with the instance, so use the row's
+/// `expected_peers`), then flips the row to Cancelled so the feed reflects it.
+/// Returns 409 when no such row exists.
+async fn cancel_persisted_run(
+    data: &web::Data<AppState>,
+    label: &str,
+    kind: WorkflowKind,
+) -> HttpResponse {
+    let run = match data
+        .db
+        .get_active_workflow_run(kind, WorkflowRole::Coordinator)
+        .await
+    {
+        Ok(Some(run)) => run,
+        Ok(None) => {
+            return HttpResponse::Conflict().json(ErrorResponse {
+                error: format!("No {label} workflow in progress"),
+            });
+        }
+        Err(e) => {
+            tracing::error!("Failed to load persisted {label} run for cancel: {e:#}");
+            return HttpResponse::InternalServerError().json(ErrorResponse {
+                error: format!("Failed to cancel {label} workflow (database error) — try again"),
+            });
+        }
     };
-    cancel_instance(data, &instance, label).await
+
+    if !run.expected_peers.is_empty()
+        && let Err(e) = send_cancel_invites(
+            &data.config,
+            &data.db,
+            &run.expected_peers,
+            &run.instance_name,
+        )
+        .await
+    {
+        tracing::warn!("send_cancel_invites failed during {label} cancel: {e}");
+    }
+
+    // Flip the persisted coordinator row to Cancelled so the feed reflects it.
+    // On a write failure the row stays InProgress and recovery may resume it, so
+    // surface 500 for the operator to retry against consistent state.
+    if let Err(e) = mark_run_status(
+        &data.db,
+        &run.instance_name,
+        WorkflowProgress::Cancelled,
+        None,
+    )
+    .await
+    {
+        tracing::error!(
+            "Failed to persist cancel for stuck {label} run {}: {e:#}",
+            run.instance_name
+        );
+        return HttpResponse::InternalServerError().json(ErrorResponse {
+            error: format!(
+                "Failed to cancel {label} workflow (database error); the run is still \
+                 active — try again"
+            ),
+        });
+    }
+
+    tracing::info!(
+        "{label} workflow {} cancelled off the persisted row",
+        run.instance_name
+    );
+    HttpResponse::Ok().json(MessageResponse {
+        message: format!("{label} workflow cancelled"),
+    })
 }
 
 /// Cancel exactly one registered coordinator run: abort its task, notify its

--- a/crates/decman/src/server/mod.rs
+++ b/crates/decman/src/server/mod.rs
@@ -286,6 +286,33 @@ pub(crate) async fn respawn_coordinator(
         return;
     }
 
+    // Recovery-window guard: this row was loaded as InProgress, but between then
+    // and registering the in-memory instance a per-kind cancel could have hit
+    // the persisted-row cancel path (`cancel_persisted_run`, reached only while
+    // no instance is registered) and flipped it to Cancelled. Re-read the status
+    // and skip resuming if it's no longer InProgress, so we don't resurrect a run
+    // the operator just cancelled. (The initial-start path is already safe:
+    // `register_and_persist` registers the instance before it persists the row.)
+    match SchemaRead::get_workflow_run(&db, &instance_name).await {
+        Ok(Some(r)) if r.status == WorkflowProgress::InProgress => {}
+        Ok(Some(r)) => {
+            tracing::info!(
+                "respawn_coordinator: {instance_name} is now {:?}, not resuming",
+                r.status
+            );
+            return;
+        }
+        Ok(None) => {
+            tracing::warn!("respawn_coordinator: {instance_name} row vanished; not resuming");
+            return;
+        }
+        Err(e) => {
+            tracing::warn!(
+                "respawn_coordinator: status re-check failed for {instance_name}: {e}; resuming anyway"
+            );
+        }
+    }
+
     let instance = WorkflowInstance::new(instance_name.clone(), kind, WorkflowRole::Coordinator);
     *instance.http.invited_peers.write().await = run.expected_peers.clone();
     *instance.http.status.write().await = WorkflowProgress::InProgress;

--- a/crates/decman/src/workflow/contracts/coordinator.rs
+++ b/crates/decman/src/workflow/contracts/coordinator.rs
@@ -77,6 +77,14 @@ async fn run_workflow(
     let instance_name = config.instance_name.clone();
     let dec_party_id = config.decentralized_party_id.clone();
 
+    // 1-of-N party: the coordinator's own signature already meets the threshold,
+    // so no peer signatures are required. The peer gates (WaitingForPeers /
+    // SignSubmissions) would otherwise wait for a peer that may never connect;
+    // the coordinator advances them itself below. Any other threshold (or an
+    // unresolved one) falls back to the normal peer wait.
+    let coordinator_only =
+        crate::noise::server::lookup_party_threshold(&db, &dec_party_id).await == Some(1);
+
     // Auth handle for the decentralized party. We deliberately fetch a fresh
     // token at each ledger-touching step rather than caching one snapshot up
     // front: a workflow can sit in `WaitingForPeers` for an arbitrarily long
@@ -91,6 +99,11 @@ async fn run_workflow(
 
         match current_step {
             ContractsStep::WaitingForPeers => {
+                if coordinator_only {
+                    workflow_state
+                        .advance_step_if(ContractsStep::WaitingForPeers)
+                        .await;
+                }
                 tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
             }
             ContractsStep::PrepareSubmissions => {
@@ -122,6 +135,13 @@ async fn run_workflow(
                 sign_submissions(&node_config, &db, &instance_name, &dec_party_id)
                     .await
                     .context("Failed to sign submissions")?;
+                if coordinator_only {
+                    // Coordinator's signature (just produced) already meets M=1;
+                    // advance without waiting for peer signatures.
+                    workflow_state
+                        .advance_step_if(ContractsStep::SignSubmissions)
+                        .await;
+                }
                 tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
             }
             ContractsStep::ExecuteSubmissions => {

--- a/crates/decman/src/workflow/state.rs
+++ b/crates/decman/src/workflow/state.rs
@@ -61,17 +61,23 @@ pub struct WorkflowState<S> {
     current_step: RwLock<S>,
     /// Expected peer IDs
     expected_peers: HashSet<CantonId>,
-    /// How many expected peers must connect / complete a peer-gated step
-    /// before the workflow advances.
+    /// How many expected peers must connect before the workflow leaves the
+    /// initial `WaitingForPeers` step (the **start** gate only).
     ///
-    /// `None` means *all* expected peers are required (the original
-    /// behaviour, kept for onboarding — which defines the party's owner set,
-    /// so every invitee must take part). `Some(k)` advances as soon as `k`
-    /// peers have acted, so an operation on an existing M-of-N party proceeds
-    /// on a quorum instead of stalling on an absent owner. `k` is the number
-    /// of *peers* needed: the coordinator always participates itself, so for a
-    /// party threshold `M` this is `M - 1` (resolved and clamped by the
-    /// caller in `NoiseServer::new`).
+    /// `None` means *all* expected peers must connect first (the original
+    /// behaviour). `Some(k)` starts the workflow as soon as `k` peers have
+    /// connected, so it no longer blocks on a slow/absent owner before the
+    /// coordinator begins — `k` is the number of *peers* needed, and since the
+    /// coordinator participates itself a party threshold `M` resolves to
+    /// `M - 1` (computed and clamped by the caller in `NoiseServer::new`).
+    ///
+    /// This deliberately does **not** lower the per-step signing gate
+    /// (`peer_completed`): a peer-gated step still waits for every expected
+    /// peer. Advancing the signing step at a bare quorum means the coordinator
+    /// would call `execute_submission_and_wait_for_transaction` with only a
+    /// quorum of signatures, and Canton's finalization never completes — the
+    /// run hangs (reproduced as a 240s contracts timeout in CI). Gathering all
+    /// signatures keeps finalization identical to the require-all path.
     peer_threshold: Option<usize>,
     /// Peers that have connected (transient — not persisted, recoverable
     /// via Noise reconnect after a restart)
@@ -160,15 +166,19 @@ impl<S: WorkflowStep + 'static> WorkflowState<S> {
         *self.current_step.read().await
     }
 
-    /// Number of expected peers that must connect / complete the current step
-    /// before the workflow advances. `peer_threshold` is `None` for workflows
-    /// that require every invitee (onboarding); otherwise it is the resolved,
-    /// pre-clamped quorum size. Never exceeds the expected-peer count, so a
-    /// `>=` comparison against it is equivalent to the original `== all` check
-    /// when `None`.
-    fn peers_required(&self) -> usize {
+    /// Number of expected peers that must connect before the workflow leaves
+    /// `WaitingForPeers`. `None` (and the no-peer case) require all expected
+    /// peers; otherwise the threshold is clamped into `[1, total]`. Clamping
+    /// up to 1 is load-bearing: the gate is only ever evaluated from a peer
+    /// connect event, so a `0` requirement could never be tripped and would
+    /// hang the wait — `[1, total]` keeps it reachable and never above the
+    /// peers that can actually connect.
+    fn start_peers_required(&self) -> usize {
         let total = self.expected_peers.len();
-        self.peer_threshold.map_or(total, |k| k.min(total))
+        match self.peer_threshold {
+            Some(k) if total > 0 => k.clamp(1, total),
+            _ => total,
+        }
     }
 
     pub async fn store_peer_data(&self, peer_id: CantonId, data: Vec<u8>) {
@@ -191,11 +201,11 @@ impl<S: WorkflowStep + 'static> WorkflowState<S> {
     }
 
     pub async fn peer_connected(&self, peer_id: CantonId) {
-        // Guard against non-expected peers. The auto-advance gate below counts
-        // connections against `peers_required()`, so counting a peer that isn't
-        // in the expected set (stale, duplicate, or re-onboarded) could trip the
-        // gate with the wrong peers — advancing the workflow toward a quorum it
-        // didn't actually reach. Expected peers behave exactly as before.
+        // Guard against non-expected peers. The start gate below counts
+        // connections against `start_peers_required()`, so counting a peer that
+        // isn't in the expected set (stale, duplicate, or re-onboarded) could
+        // trip the gate with the wrong peers — starting the workflow before the
+        // intended quorum is present. Expected peers behave exactly as before.
         if !self.expected_peers.contains(&peer_id) {
             tracing::warn!(
                 "ignoring connect from unexpected peer {peer_id} (not in expected set for {})",
@@ -212,7 +222,7 @@ impl<S: WorkflowStep + 'static> WorkflowState<S> {
         }
 
         let connected_count = connected.len();
-        let required = self.peers_required();
+        let required = self.start_peers_required();
         let total_count = self.expected_peers.len();
         tracing::info!(
             "Peer connected: {peer_id} ({connected_count}/{total_count}, need {required} to start)"
@@ -234,11 +244,11 @@ impl<S: WorkflowStep + 'static> WorkflowState<S> {
     }
 
     pub async fn peer_completed(&self, peer_id: CantonId) {
-        // Guard against non-expected peers. The auto-advance gate below counts
-        // completions against `peers_required()`, so counting a peer that isn't
-        // in the expected set (stale, duplicate, or re-onboarded) could trip the
-        // gate with the wrong peers — advancing the workflow toward a quorum it
-        // didn't actually reach. Expected peers behave exactly as before.
+        // Guard against non-expected peers. The auto-advance gate below uses
+        // `expected_peers.len()` as the total, so counting a peer that isn't in
+        // the expected set (stale, duplicate, or re-onboarded) could trip the
+        // gate without all expected peers having acted — advancing the workflow
+        // with a missing signature. Expected peers behave exactly as before.
         if !self.expected_peers.contains(&peer_id) {
             tracing::warn!(
                 "ignoring step completion from unexpected peer {peer_id} (not in expected set for {})",
@@ -252,12 +262,13 @@ impl<S: WorkflowStep + 'static> WorkflowState<S> {
 
         let current = self.current_step.read().await;
         let completed_count = completed.len();
-        let required = self.peers_required();
+        // The signing gate requires EVERY expected peer — see `peer_threshold`.
+        // The start-gate quorum deliberately does not apply here: executing a
+        // step with only a quorum of signatures stalls Canton finalization.
         let total_count = self.expected_peers.len();
         let step_name = format!("{current:?}");
         tracing::info!(
-            "Peer completed step {step_name}: {peer_id} \
-             ({completed_count}/{total_count}, need {required})"
+            "Peer completed step {step_name}: {peer_id} ({completed_count}/{total_count})"
         );
 
         // Persist the new completed-peers set. Failures here are logged
@@ -267,7 +278,7 @@ impl<S: WorkflowStep + 'static> WorkflowState<S> {
         let completed_vec: Vec<CantonId> = completed.iter().cloned().collect();
         self.persist_step_progress(*current, completed_vec).await;
 
-        if current.requires_peers() && completed_count >= required {
+        if current.requires_peers() && completed_count == total_count {
             drop(current);
             drop(completed);
             self.advance_step().await;
@@ -612,9 +623,10 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
-    async fn peer_completed_advances_at_threshold(pool: SqlitePool) {
-        // Same quorum-of-one setup, but for a peer-gated step: one completion is
-        // enough to advance even though a second peer was invited.
+    async fn signing_gate_still_requires_all_peers_despite_start_threshold(pool: SqlitePool) {
+        // The start threshold must NOT lower the per-step signing gate: even
+        // with `Some(1)`, a peer-gated step waits for every expected peer so
+        // the coordinator gathers all signatures before executing.
         let state = WorkflowState::new(
             pool,
             "test-run".to_string(),
@@ -624,26 +636,29 @@ mod tests {
         );
 
         state.peer_completed(peer(1)).await;
-        assert_eq!(state.current_step().await, TestStep::Done);
-    }
-
-    #[sqlx::test(migrator = "MIGRATOR")]
-    async fn threshold_above_peer_count_clamps_to_all(pool: SqlitePool) {
-        // A threshold larger than the available peers is clamped to the peer
-        // count, so the gate behaves like the require-all path: the first
-        // completion must not advance, only the last one does.
-        let state = WorkflowState::new(
-            pool,
-            "test-run".to_string(),
-            TestStep::Sign,
-            vec![peer(1), peer(2)],
-            Some(5),
-        );
-
-        state.peer_completed(peer(1)).await;
         assert_eq!(state.current_step().await, TestStep::Sign);
 
         state.peer_completed(peer(2)).await;
         assert_eq!(state.current_step().await, TestStep::Done);
+    }
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn start_threshold_above_peer_count_clamps_to_all(pool: SqlitePool) {
+        // A start threshold larger than the available peers clamps to the peer
+        // count, so the start gate behaves like require-all: the first connect
+        // must not start the workflow, only the last one does.
+        let state = WorkflowState::new(
+            pool,
+            "test-run".to_string(),
+            TestStep::WaitPeers,
+            vec![peer(1), peer(2)],
+            Some(5),
+        );
+
+        state.peer_connected(peer(1)).await;
+        assert_eq!(state.current_step().await, TestStep::WaitPeers);
+
+        state.peer_connected(peer(2)).await;
+        assert_eq!(state.current_step().await, TestStep::Sign);
     }
 }

--- a/crates/decman/src/workflow/state.rs
+++ b/crates/decman/src/workflow/state.rs
@@ -61,23 +61,24 @@ pub struct WorkflowState<S> {
     current_step: RwLock<S>,
     /// Expected peer IDs
     expected_peers: HashSet<CantonId>,
-    /// How many expected peers must connect before the workflow leaves the
-    /// initial `WaitingForPeers` step (the **start** gate only).
+    /// The workflow's peer quorum: the minimum number of expected peers that
+    /// must take part before a peer-gated step advances.
     ///
-    /// `None` means *all* expected peers must connect first (the original
-    /// behaviour). `Some(k)` starts the workflow as soon as `k` peers have
-    /// connected, so it no longer blocks on a slow/absent owner before the
-    /// coordinator begins — `k` is the number of *peers* needed, and since the
-    /// coordinator participates itself a party threshold `M` resolves to
-    /// `M - 1` (computed and clamped by the caller in `NoiseServer::new`).
+    /// `None` means *all* expected peers are required (the original behaviour,
+    /// used by Onboarding — which defines the party's owner set — and DARs —
+    /// which must reach every selected node). `Some(k)` is a quorum of `k`
+    /// peers: since the coordinator participates itself, a party threshold `M`
+    /// resolves to `M - 1` peers (computed and clamped by the caller in
+    /// `NoiseServer::new`).
     ///
-    /// This deliberately does **not** lower the per-step signing gate
-    /// (`peer_completed`): a peer-gated step still waits for every expected
-    /// peer. Advancing the signing step at a bare quorum means the coordinator
-    /// would call `execute_submission_and_wait_for_transaction` with only a
-    /// quorum of signatures, and Canton's finalization never completes — the
-    /// run hangs (reproduced as a 240s contracts timeout in CI). Gathering all
-    /// signatures keeps finalization identical to the require-all path.
+    /// Both gates use it:
+    /// * **start** (`peer_connected` / `WaitingForPeers`): begin once `k` peers
+    ///   connect, so a slow/absent owner doesn't block the start.
+    /// * **signing** (`peer_completed` / `requires_peers`): advance once every
+    ///   *connected* peer has completed AND at least `k` have. So the happy
+    ///   path (all invited peers present) still gathers every signature — Canton
+    ///   finalization is identical to require-all — an absent (never-connected)
+    ///   peer is skipped, and we never execute below the M-of-N quorum.
     peer_threshold: Option<usize>,
     /// Peers that have connected (transient — not persisted, recoverable
     /// via Noise reconnect after a restart)
@@ -166,19 +167,40 @@ impl<S: WorkflowStep + 'static> WorkflowState<S> {
         *self.current_step.read().await
     }
 
-    /// Number of expected peers that must connect before the workflow leaves
-    /// `WaitingForPeers`. `None` (and the no-peer case) require all expected
-    /// peers; otherwise the threshold is clamped into `[1, total]`. Clamping
-    /// up to 1 is load-bearing: the gate is only ever evaluated from a peer
-    /// connect event, so a `0` requirement could never be tripped and would
-    /// hang the wait — `[1, total]` keeps it reachable and never above the
-    /// peers that can actually connect.
-    fn start_peers_required(&self) -> usize {
+    /// The workflow's peer quorum: the minimum number of expected peers that
+    /// must act before a peer-gated step advances. `None` (and the no-peer
+    /// case) require all expected peers; otherwise the threshold is clamped
+    /// into `[1, total]`. Clamping up to 1 is load-bearing: the gates are only
+    /// ever evaluated from a peer event, so a `0` requirement could never be
+    /// tripped and would hang the wait — `[1, total]` keeps it reachable and
+    /// never above the peers that can actually act.
+    fn peers_quorum(&self) -> usize {
         let total = self.expected_peers.len();
         match self.peer_threshold {
             Some(k) if total > 0 => k.clamp(1, total),
             _ => total,
         }
+    }
+
+    /// Whether a peer-gated step may advance, given how many peers have
+    /// completed it. Both conditions must hold:
+    ///
+    /// 1. `completed_count >= peers_quorum()` — never advance (and so never
+    ///    execute) below the M-of-N quorum.
+    /// 2. `completed_count >= connected_peers.len()` — every peer that
+    ///    connected to this run has also completed. Connected peers are the
+    ///    ones that will actually send a signature, so waiting for all of them
+    ///    makes the happy path advance with EVERY present peer's signature
+    ///    (matching the require-all path). Since `completed ⊆ connected`, this
+    ///    is reached as soon as the last connected peer acts.
+    ///
+    /// An invited peer that never connects is not in `connected_peers`, so it
+    /// cannot hold the gate open once the present quorum has signed. For the
+    /// require-all case (`peers_quorum() == total`), condition (1) already
+    /// forces every expected peer and (2) is redundant.
+    async fn signing_gate_satisfied(&self, completed_count: usize) -> bool {
+        let connected_count = self.connected_peers.read().await.len();
+        completed_count >= self.peers_quorum() && completed_count >= connected_count
     }
 
     pub async fn store_peer_data(&self, peer_id: CantonId, data: Vec<u8>) {
@@ -222,7 +244,7 @@ impl<S: WorkflowStep + 'static> WorkflowState<S> {
         }
 
         let connected_count = connected.len();
-        let required = self.start_peers_required();
+        let required = self.peers_quorum();
         let total_count = self.expected_peers.len();
         tracing::info!(
             "Peer connected: {peer_id} ({connected_count}/{total_count}, need {required} to start)"
@@ -244,11 +266,11 @@ impl<S: WorkflowStep + 'static> WorkflowState<S> {
     }
 
     pub async fn peer_completed(&self, peer_id: CantonId) {
-        // Guard against non-expected peers. The auto-advance gate below uses
-        // `expected_peers.len()` as the total, so counting a peer that isn't in
-        // the expected set (stale, duplicate, or re-onboarded) could trip the
-        // gate without all expected peers having acted — advancing the workflow
-        // with a missing signature. Expected peers behave exactly as before.
+        // Guard against non-expected peers. The signing gate below counts
+        // completions against the peer quorum and the connected set, so counting
+        // a peer that isn't in the expected set (stale, duplicate, or
+        // re-onboarded) could trip the gate with the wrong peers — advancing the
+        // workflow with a missing signature. Expected peers behave as before.
         if !self.expected_peers.contains(&peer_id) {
             tracing::warn!(
                 "ignoring step completion from unexpected peer {peer_id} (not in expected set for {})",
@@ -262,9 +284,6 @@ impl<S: WorkflowStep + 'static> WorkflowState<S> {
 
         let current = self.current_step.read().await;
         let completed_count = completed.len();
-        // The signing gate requires EVERY expected peer — see `peer_threshold`.
-        // The start-gate quorum deliberately does not apply here: executing a
-        // step with only a quorum of signatures stalls Canton finalization.
         let total_count = self.expected_peers.len();
         let step_name = format!("{current:?}");
         tracing::info!(
@@ -278,7 +297,10 @@ impl<S: WorkflowStep + 'static> WorkflowState<S> {
         let completed_vec: Vec<CantonId> = completed.iter().cloned().collect();
         self.persist_step_progress(*current, completed_vec).await;
 
-        if current.requires_peers() && completed_count == total_count {
+        // Advance once every connected peer has completed and the quorum is met
+        // — see `peer_threshold` / `signing_gate_satisfied`. An absent peer that
+        // never connected does not hold this open.
+        if current.requires_peers() && self.signing_gate_satisfied(completed_count).await {
             drop(current);
             drop(completed);
             self.advance_step().await;
@@ -623,10 +645,11 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
-    async fn signing_gate_still_requires_all_peers_despite_start_threshold(pool: SqlitePool) {
-        // The start threshold must NOT lower the per-step signing gate: even
-        // with `Some(1)`, a peer-gated step waits for every expected peer so
-        // the coordinator gathers all signatures before executing.
+    async fn signing_gate_waits_for_all_connected_peers(pool: SqlitePool) {
+        // Happy path: when both invited peers are present (connected), the
+        // signing gate waits for BOTH to sign even though the quorum is 1 — so
+        // the coordinator gathers every present peer's signature before
+        // executing (matching the require-all path / green main).
         let state = WorkflowState::new(
             pool,
             "test-run".to_string(),
@@ -634,6 +657,52 @@ mod tests {
             vec![peer(1), peer(2)],
             Some(1),
         );
+
+        // Sign is not a waiting step, so connecting just records participation.
+        state.peer_connected(peer(1)).await;
+        state.peer_connected(peer(2)).await;
+
+        state.peer_completed(peer(1)).await;
+        assert_eq!(state.current_step().await, TestStep::Sign);
+
+        state.peer_completed(peer(2)).await;
+        assert_eq!(state.current_step().await, TestStep::Done);
+    }
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn signing_gate_skips_absent_peer_at_quorum(pool: SqlitePool) {
+        // The fix for the production hang: with a quorum of 1 and peer(2)
+        // absent (never connected), the signing step advances once the present
+        // quorum (peer(1)) has signed, instead of looping forever.
+        let state = WorkflowState::new(
+            pool,
+            "test-run".to_string(),
+            TestStep::Sign,
+            vec![peer(1), peer(2)],
+            Some(1),
+        );
+
+        // Only peer(1) connects; peer(2) never accepts/connects.
+        state.peer_connected(peer(1)).await;
+
+        state.peer_completed(peer(1)).await;
+        assert_eq!(state.current_step().await, TestStep::Done);
+    }
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn require_all_signing_gate_unchanged_with_connections(pool: SqlitePool) {
+        // `None` (Onboarding/DARs) still requires every expected peer even when
+        // all are connected: the quorum floor equals the total.
+        let state = WorkflowState::new(
+            pool,
+            "test-run".to_string(),
+            TestStep::Sign,
+            vec![peer(1), peer(2)],
+            None,
+        );
+
+        state.peer_connected(peer(1)).await;
+        state.peer_connected(peer(2)).await;
 
         state.peer_completed(peer(1)).await;
         assert_eq!(state.current_step().await, TestStep::Sign);

--- a/crates/decman/src/workflow/state.rs
+++ b/crates/decman/src/workflow/state.rs
@@ -61,6 +61,18 @@ pub struct WorkflowState<S> {
     current_step: RwLock<S>,
     /// Expected peer IDs
     expected_peers: HashSet<CantonId>,
+    /// How many expected peers must connect / complete a peer-gated step
+    /// before the workflow advances.
+    ///
+    /// `None` means *all* expected peers are required (the original
+    /// behaviour, kept for onboarding — which defines the party's owner set,
+    /// so every invitee must take part). `Some(k)` advances as soon as `k`
+    /// peers have acted, so an operation on an existing M-of-N party proceeds
+    /// on a quorum instead of stalling on an absent owner. `k` is the number
+    /// of *peers* needed: the coordinator always participates itself, so for a
+    /// party threshold `M` this is `M - 1` (resolved and clamped by the
+    /// caller in `NoiseServer::new`).
+    peer_threshold: Option<usize>,
     /// Peers that have connected (transient — not persisted, recoverable
     /// via Noise reconnect after a restart)
     connected_peers: RwLock<HashSet<CantonId>>,
@@ -82,12 +94,14 @@ impl<S: WorkflowStep + 'static> WorkflowState<S> {
         instance_name: String,
         initial_step: S,
         expected_peers: Vec<CantonId>,
+        peer_threshold: Option<usize>,
     ) -> Arc<Self> {
         Arc::new(Self {
             db,
             instance_name,
             current_step: RwLock::new(initial_step),
             expected_peers: expected_peers.into_iter().collect(),
+            peer_threshold,
             connected_peers: RwLock::new(HashSet::new()),
             completed_peers: RwLock::new(HashSet::new()),
             peer_data: RwLock::new(HashMap::new()),
@@ -105,12 +119,14 @@ impl<S: WorkflowStep + 'static> WorkflowState<S> {
         current_step: S,
         expected_peers: Vec<CantonId>,
         completed_peers: Vec<CantonId>,
+        peer_threshold: Option<usize>,
     ) -> Arc<Self> {
         Arc::new(Self {
             db,
             instance_name,
             current_step: RwLock::new(current_step),
             expected_peers: expected_peers.into_iter().collect(),
+            peer_threshold,
             connected_peers: RwLock::new(HashSet::new()),
             completed_peers: RwLock::new(completed_peers.into_iter().collect()),
             peer_data: RwLock::new(HashMap::new()),
@@ -144,6 +160,17 @@ impl<S: WorkflowStep + 'static> WorkflowState<S> {
         *self.current_step.read().await
     }
 
+    /// Number of expected peers that must connect / complete the current step
+    /// before the workflow advances. `peer_threshold` is `None` for workflows
+    /// that require every invitee (onboarding); otherwise it is the resolved,
+    /// pre-clamped quorum size. Never exceeds the expected-peer count, so a
+    /// `>=` comparison against it is equivalent to the original `== all` check
+    /// when `None`.
+    fn peers_required(&self) -> usize {
+        let total = self.expected_peers.len();
+        self.peer_threshold.map_or(total, |k| k.min(total))
+    }
+
     pub async fn store_peer_data(&self, peer_id: CantonId, data: Vec<u8>) {
         let mut peer_data = self.peer_data.write().await;
         peer_data.insert(peer_id, data);
@@ -164,11 +191,11 @@ impl<S: WorkflowStep + 'static> WorkflowState<S> {
     }
 
     pub async fn peer_connected(&self, peer_id: CantonId) {
-        // Guard against non-expected peers. The auto-advance gate below uses
-        // `expected_peers.len()` as the total, so counting a peer that isn't in
-        // the expected set (stale, duplicate, or re-onboarded) could trip the
-        // gate without all expected peers having acted — advancing the workflow
-        // with a missing signature. Expected peers behave exactly as before.
+        // Guard against non-expected peers. The auto-advance gate below counts
+        // connections against `peers_required()`, so counting a peer that isn't
+        // in the expected set (stale, duplicate, or re-onboarded) could trip the
+        // gate with the wrong peers — advancing the workflow toward a quorum it
+        // didn't actually reach. Expected peers behave exactly as before.
         if !self.expected_peers.contains(&peer_id) {
             tracing::warn!(
                 "ignoring connect from unexpected peer {peer_id} (not in expected set for {})",
@@ -185,10 +212,13 @@ impl<S: WorkflowStep + 'static> WorkflowState<S> {
         }
 
         let connected_count = connected.len();
+        let required = self.peers_required();
         let total_count = self.expected_peers.len();
-        tracing::info!("Peer connected: {peer_id} ({connected_count}/{total_count})");
+        tracing::info!(
+            "Peer connected: {peer_id} ({connected_count}/{total_count}, need {required} to start)"
+        );
 
-        if connected_count == total_count {
+        if connected_count >= required {
             let current = self.current_step.read().await;
             if current.is_waiting_for_peers() {
                 drop(current);
@@ -204,11 +234,11 @@ impl<S: WorkflowStep + 'static> WorkflowState<S> {
     }
 
     pub async fn peer_completed(&self, peer_id: CantonId) {
-        // Guard against non-expected peers. The auto-advance gate below uses
-        // `expected_peers.len()` as the total, so counting a peer that isn't in
-        // the expected set (stale, duplicate, or re-onboarded) could trip the
-        // gate without all expected peers having acted — advancing the workflow
-        // with a missing signature. Expected peers behave exactly as before.
+        // Guard against non-expected peers. The auto-advance gate below counts
+        // completions against `peers_required()`, so counting a peer that isn't
+        // in the expected set (stale, duplicate, or re-onboarded) could trip the
+        // gate with the wrong peers — advancing the workflow toward a quorum it
+        // didn't actually reach. Expected peers behave exactly as before.
         if !self.expected_peers.contains(&peer_id) {
             tracing::warn!(
                 "ignoring step completion from unexpected peer {peer_id} (not in expected set for {})",
@@ -222,10 +252,12 @@ impl<S: WorkflowStep + 'static> WorkflowState<S> {
 
         let current = self.current_step.read().await;
         let completed_count = completed.len();
+        let required = self.peers_required();
         let total_count = self.expected_peers.len();
         let step_name = format!("{current:?}");
         tracing::info!(
-            "Peer completed step {step_name}: {peer_id} ({completed_count}/{total_count})"
+            "Peer completed step {step_name}: {peer_id} \
+             ({completed_count}/{total_count}, need {required})"
         );
 
         // Persist the new completed-peers set. Failures here are logged
@@ -235,7 +267,7 @@ impl<S: WorkflowStep + 'static> WorkflowState<S> {
         let completed_vec: Vec<CantonId> = completed.iter().cloned().collect();
         self.persist_step_progress(*current, completed_vec).await;
 
-        if current.requires_peers() && completed_count == total_count {
+        if current.requires_peers() && completed_count >= required {
             drop(current);
             drop(completed);
             self.advance_step().await;
@@ -426,6 +458,7 @@ mod tests {
             "test-run".to_string(),
             TestStep::Sign,
             vec![peer(1), peer(2)],
+            None,
         );
 
         state.peer_completed(peer(1)).await;
@@ -442,6 +475,7 @@ mod tests {
             "test-run".to_string(),
             TestStep::WaitPeers,
             vec![peer(1)],
+            None,
         );
 
         // WaitPeers does not require peers, so a completion must not advance it.
@@ -456,6 +490,7 @@ mod tests {
             "test-run".to_string(),
             TestStep::WaitPeers,
             vec![peer(1), peer(2)],
+            None,
         );
 
         state.peer_connected(peer(1)).await;
@@ -471,7 +506,13 @@ mod tests {
 
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn peer_connected_does_not_advance_when_not_waiting(pool: SqlitePool) {
-        let state = WorkflowState::new(pool, "test-run".to_string(), TestStep::Sign, vec![peer(1)]);
+        let state = WorkflowState::new(
+            pool,
+            "test-run".to_string(),
+            TestStep::Sign,
+            vec![peer(1)],
+            None,
+        );
 
         // Sign is not a waiting step, so a connect must not advance it.
         state.peer_connected(peer(1)).await;
@@ -485,6 +526,7 @@ mod tests {
             "test-run".to_string(),
             TestStep::Sign,
             vec![peer(1), peer(2)],
+            None,
         );
 
         state.peer_completed(peer(1)).await;
@@ -507,6 +549,7 @@ mod tests {
             "test-run".to_string(),
             TestStep::WaitPeers,
             vec![peer(1), peer(2)],
+            None,
         );
 
         state.peer_connected(peer(1)).await;
@@ -529,6 +572,7 @@ mod tests {
             TestStep::Sign,
             vec![peer(1), peer(2)],
             vec![peer(1)],
+            None,
         );
 
         state.peer_completed(peer(2)).await;
@@ -537,10 +581,69 @@ mod tests {
 
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn advance_step_at_terminal_is_noop(pool: SqlitePool) {
-        let state = WorkflowState::new(pool, "test-run".to_string(), TestStep::Done, vec![peer(1)]);
+        let state = WorkflowState::new(
+            pool,
+            "test-run".to_string(),
+            TestStep::Done,
+            vec![peer(1)],
+            None,
+        );
 
         // Done has no successor, so advancing is a no-op.
         state.advance_step().await;
+        assert_eq!(state.current_step().await, TestStep::Done);
+    }
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn peer_connected_advances_at_threshold(pool: SqlitePool) {
+        // Two peers expected but only one needed (e.g. a 2-of-3 party where the
+        // coordinator provides the other signature): the waiting step must
+        // advance on the first connect, without the second peer.
+        let state = WorkflowState::new(
+            pool,
+            "test-run".to_string(),
+            TestStep::WaitPeers,
+            vec![peer(1), peer(2)],
+            Some(1),
+        );
+
+        state.peer_connected(peer(1)).await;
+        assert_eq!(state.current_step().await, TestStep::Sign);
+    }
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn peer_completed_advances_at_threshold(pool: SqlitePool) {
+        // Same quorum-of-one setup, but for a peer-gated step: one completion is
+        // enough to advance even though a second peer was invited.
+        let state = WorkflowState::new(
+            pool,
+            "test-run".to_string(),
+            TestStep::Sign,
+            vec![peer(1), peer(2)],
+            Some(1),
+        );
+
+        state.peer_completed(peer(1)).await;
+        assert_eq!(state.current_step().await, TestStep::Done);
+    }
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn threshold_above_peer_count_clamps_to_all(pool: SqlitePool) {
+        // A threshold larger than the available peers is clamped to the peer
+        // count, so the gate behaves like the require-all path: the first
+        // completion must not advance, only the last one does.
+        let state = WorkflowState::new(
+            pool,
+            "test-run".to_string(),
+            TestStep::Sign,
+            vec![peer(1), peer(2)],
+            Some(5),
+        );
+
+        state.peer_completed(peer(1)).await;
+        assert_eq!(state.current_step().await, TestStep::Sign);
+
+        state.peer_completed(peer(2)).await;
         assert_eq!(state.current_step().await, TestStep::Done);
     }
 }

--- a/crates/decman/src/workflow/state.rs
+++ b/crates/decman/src/workflow/state.rs
@@ -160,11 +160,30 @@ impl<S: WorkflowStep + 'static> WorkflowState<S> {
         }
     }
 
-    /// Advance once the quorum has completed AND every *connected* peer has — a
-    /// peer that never connects can't hold the gate open once the quorum signs.
-    async fn signing_gate_satisfied(&self, completed_count: usize) -> bool {
-        let connected_count = self.connected_peers.read().await.len();
-        completed_count >= self.peers_quorum() && completed_count >= connected_count
+    /// Re-evaluate the current step's peer gate and advance if it is satisfied.
+    /// Called on every peer poll and completion (not just the triggering event),
+    /// so a gate that became satisfiable without a fresh event — e.g. a quorum
+    /// restored from the persisted row after a restart — still advances the next
+    /// time a peer polls. Advancing goes through [`Self::advance_step_if`], so
+    /// concurrent callers can't double-advance.
+    async fn maybe_advance(&self) {
+        let cur = *self.current_step.read().await;
+        let quorum = self.peers_quorum();
+        let ready = if cur.is_waiting_for_peers() {
+            self.connected_peers.read().await.len() >= quorum
+        } else if cur.requires_peers() {
+            // Advance as soon as the quorum has signed. M signatures satisfy an
+            // M-of-N party, so we do NOT also wait for every *connected* peer: a
+            // peer that connected but then never signs (crash, refusal, or a
+            // straggler) must not hold the gate open. Waiting on the connected
+            // set is what hung the run in the connect-then-stall case.
+            self.completed_peers.read().await.len() >= quorum
+        } else {
+            false
+        };
+        if ready {
+            self.advance_step_if(cur).await;
+        }
     }
 
     pub async fn store_peer_data(&self, peer_id: CantonId, data: Vec<u8>) {
@@ -195,29 +214,22 @@ impl<S: WorkflowStep + 'static> WorkflowState<S> {
             return;
         }
 
-        let mut connected = self.connected_peers.write().await;
-
-        let is_new = connected.insert(peer_id.clone());
-        if !is_new {
-            return;
-        }
-
-        let connected_count = connected.len();
-        let required = self.peers_quorum();
-        let total_count = self.expected_peers.len();
-        tracing::info!(
-            "Peer connected: {peer_id} ({connected_count}/{total_count}, need {required} to start)"
-        );
-
-        if connected_count >= required {
-            let current = self.current_step.read().await;
-            if current.is_waiting_for_peers() {
-                let observed = *current;
-                drop(current);
-                drop(connected);
-                self.advance_step_if(observed).await;
+        {
+            let mut connected = self.connected_peers.write().await;
+            if connected.insert(peer_id.clone()) {
+                tracing::info!(
+                    "Peer connected: {peer_id} ({}/{}, need {} to start)",
+                    connected.len(),
+                    self.expected_peers.len(),
+                    self.peers_quorum()
+                );
             }
         }
+        // Re-evaluate on every poll, not just the first connect: peers keep
+        // polling while they wait, so this re-checks a gate that became
+        // satisfiable without a fresh event (e.g. a quorum restored after a
+        // restart).
+        self.maybe_advance().await;
     }
 
     pub async fn current_command(&self) -> Option<MessageType> {
@@ -234,30 +246,23 @@ impl<S: WorkflowStep + 'static> WorkflowState<S> {
             return;
         }
 
-        let mut completed = self.completed_peers.write().await;
-        completed.insert(peer_id.clone());
-
-        let current = self.current_step.read().await;
-        let completed_count = completed.len();
-        let total_count = self.expected_peers.len();
-        let step_name = format!("{current:?}");
-        tracing::info!(
-            "Peer completed step {step_name}: {peer_id} ({completed_count}/{total_count})"
-        );
-
-        // Persist the new completed-peers set. Failures here are logged
-        // but don't abort the workflow — on a future restart the recovery path
-        // would just re-issue the command, which steps are designed to no-op
-        // when the artefact already exists.
-        let completed_vec: Vec<CantonId> = completed.iter().cloned().collect();
-        self.persist_step_progress(*current, completed_vec).await;
-
-        if current.requires_peers() && self.signing_gate_satisfied(completed_count).await {
-            let observed = *current;
-            drop(current);
-            drop(completed);
-            self.advance_step_if(observed).await;
+        {
+            let mut completed = self.completed_peers.write().await;
+            completed.insert(peer_id.clone());
+            let current = *self.current_step.read().await;
+            let completed_vec: Vec<CantonId> = completed.iter().cloned().collect();
+            tracing::info!(
+                "Peer completed step {current:?}: {peer_id} ({}/{})",
+                completed_vec.len(),
+                self.expected_peers.len()
+            );
+            // Persist the new completed-peers set. Failures here are logged but
+            // don't abort the workflow — on a future restart the recovery path
+            // re-issues the command, which steps are designed to no-op when the
+            // artefact already exists.
+            self.persist_step_progress(current, completed_vec).await;
         }
+        self.maybe_advance().await;
     }
 
     /// Unconditional advance, used by the coordinator loop which drives its own
@@ -612,8 +617,11 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
-    async fn signing_gate_waits_for_all_connected_peers(pool: SqlitePool) {
-        // quorum 1, but both connected → wait for both to sign (not just one).
+    async fn signing_gate_advances_at_quorum_despite_connected_non_signer(pool: SqlitePool) {
+        // Regression (#207): quorum 1, both peers connect, but peer(2) never
+        // signs (connect-then-stall — crash or refusal). The run must still
+        // advance once the quorum (peer(1)) has signed; a connected-but-silent
+        // peer must not hold the gate open. M signatures satisfy an M-of-N party.
         let state = WorkflowState::new(
             pool,
             "test-run".to_string(),
@@ -623,12 +631,29 @@ mod tests {
         );
 
         state.peer_connected(peer(1)).await;
-        state.peer_connected(peer(2)).await;
+        state.peer_connected(peer(2)).await; // connects, then stalls forever
 
         state.peer_completed(peer(1)).await;
-        assert_eq!(state.current_step().await, TestStep::Sign);
+        assert_eq!(state.current_step().await, TestStep::Done);
+    }
 
-        state.peer_completed(peer(2)).await;
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn signing_gate_reevaluated_on_poll_after_restart(pool: SqlitePool) {
+        // Regression (#207): the quorum was met before a restart (peer(1)
+        // completed) but the advance never happened. On resume no fresh
+        // completion arrives — the completed peer only re-polls — so the gate
+        // must be re-evaluated on that poll rather than hanging.
+        let state = WorkflowState::from_persisted(
+            pool,
+            "test-run".to_string(),
+            TestStep::Sign,
+            vec![peer(1), peer(2)],
+            vec![peer(1)], // restored: peer(1) already completed pre-restart
+            Some(1),
+        );
+
+        // A bare poll (no new completion) must trip the already-met gate.
+        state.peer_connected(peer(1)).await;
         assert_eq!(state.current_step().await, TestStep::Done);
     }
 

--- a/crates/decman/src/workflow/state.rs
+++ b/crates/decman/src/workflow/state.rs
@@ -276,8 +276,9 @@ impl<S: WorkflowStep + 'static> WorkflowState<S> {
     /// per-connection tasks, so with quorum < total two of them can observe the
     /// same gate open at once; without this check-then-act guard both would
     /// advance and skip a step. The CAS re-check under the write lock makes the
-    /// second call a no-op.
-    async fn advance_step_if(&self, expected: S) {
+    /// second call a no-op. Also used by a coordinator loop to self-advance a
+    /// peer gate that no peer event will ever trip (the 1-of-N solo case).
+    pub async fn advance_step_if(&self, expected: S) {
         let mut current = self.current_step.write().await;
         if *current != expected {
             return;

--- a/crates/decman/src/workflow/state.rs
+++ b/crates/decman/src/workflow/state.rs
@@ -61,24 +61,7 @@ pub struct WorkflowState<S> {
     current_step: RwLock<S>,
     /// Expected peer IDs
     expected_peers: HashSet<CantonId>,
-    /// The workflow's peer quorum: the minimum number of expected peers that
-    /// must take part before a peer-gated step advances.
-    ///
-    /// `None` means *all* expected peers are required (the original behaviour,
-    /// used by Onboarding — which defines the party's owner set — and DARs —
-    /// which must reach every selected node). `Some(k)` is a quorum of `k`
-    /// peers: since the coordinator participates itself, a party threshold `M`
-    /// resolves to `M - 1` peers (computed and clamped by the caller in
-    /// `NoiseServer::new`).
-    ///
-    /// Both gates use it:
-    /// * **start** (`peer_connected` / `WaitingForPeers`): begin once `k` peers
-    ///   connect, so a slow/absent owner doesn't block the start.
-    /// * **signing** (`peer_completed` / `requires_peers`): advance once every
-    ///   *connected* peer has completed AND at least `k` have. So the happy
-    ///   path (all invited peers present) still gathers every signature — Canton
-    ///   finalization is identical to require-all — an absent (never-connected)
-    ///   peer is skipped, and we never execute below the M-of-N quorum.
+    /// Peer quorum for both gates; `None` requires all expected peers.
     peer_threshold: Option<usize>,
     /// Peers that have connected (transient — not persisted, recoverable
     /// via Noise reconnect after a restart)
@@ -167,13 +150,8 @@ impl<S: WorkflowStep + 'static> WorkflowState<S> {
         *self.current_step.read().await
     }
 
-    /// The workflow's peer quorum: the minimum number of expected peers that
-    /// must act before a peer-gated step advances. `None` (and the no-peer
-    /// case) require all expected peers; otherwise the threshold is clamped
-    /// into `[1, total]`. Clamping up to 1 is load-bearing: the gates are only
-    /// ever evaluated from a peer event, so a `0` requirement could never be
-    /// tripped and would hang the wait — `[1, total]` keeps it reachable and
-    /// never above the peers that can actually act.
+    /// `None`/no-peer → all; else clamped into `[1, total]` (the `>= 1` matters:
+    /// gates fire on peer events, so a `0` requirement would never trip).
     fn peers_quorum(&self) -> usize {
         let total = self.expected_peers.len();
         match self.peer_threshold {
@@ -182,22 +160,8 @@ impl<S: WorkflowStep + 'static> WorkflowState<S> {
         }
     }
 
-    /// Whether a peer-gated step may advance, given how many peers have
-    /// completed it. Both conditions must hold:
-    ///
-    /// 1. `completed_count >= peers_quorum()` — never advance (and so never
-    ///    execute) below the M-of-N quorum.
-    /// 2. `completed_count >= connected_peers.len()` — every peer that
-    ///    connected to this run has also completed. Connected peers are the
-    ///    ones that will actually send a signature, so waiting for all of them
-    ///    makes the happy path advance with EVERY present peer's signature
-    ///    (matching the require-all path). Since `completed ⊆ connected`, this
-    ///    is reached as soon as the last connected peer acts.
-    ///
-    /// An invited peer that never connects is not in `connected_peers`, so it
-    /// cannot hold the gate open once the present quorum has signed. For the
-    /// require-all case (`peers_quorum() == total`), condition (1) already
-    /// forces every expected peer and (2) is redundant.
+    /// Advance once the quorum has completed AND every *connected* peer has — a
+    /// peer that never connects can't hold the gate open once the quorum signs.
     async fn signing_gate_satisfied(&self, completed_count: usize) -> bool {
         let connected_count = self.connected_peers.read().await.len();
         completed_count >= self.peers_quorum() && completed_count >= connected_count
@@ -223,11 +187,6 @@ impl<S: WorkflowStep + 'static> WorkflowState<S> {
     }
 
     pub async fn peer_connected(&self, peer_id: CantonId) {
-        // Guard against non-expected peers. The start gate below counts
-        // connections against `start_peers_required()`, so counting a peer that
-        // isn't in the expected set (stale, duplicate, or re-onboarded) could
-        // trip the gate with the wrong peers — starting the workflow before the
-        // intended quorum is present. Expected peers behave exactly as before.
         if !self.expected_peers.contains(&peer_id) {
             tracing::warn!(
                 "ignoring connect from unexpected peer {peer_id} (not in expected set for {})",
@@ -266,11 +225,6 @@ impl<S: WorkflowStep + 'static> WorkflowState<S> {
     }
 
     pub async fn peer_completed(&self, peer_id: CantonId) {
-        // Guard against non-expected peers. The signing gate below counts
-        // completions against the peer quorum and the connected set, so counting
-        // a peer that isn't in the expected set (stale, duplicate, or
-        // re-onboarded) could trip the gate with the wrong peers — advancing the
-        // workflow with a missing signature. Expected peers behave as before.
         if !self.expected_peers.contains(&peer_id) {
             tracing::warn!(
                 "ignoring step completion from unexpected peer {peer_id} (not in expected set for {})",
@@ -297,9 +251,6 @@ impl<S: WorkflowStep + 'static> WorkflowState<S> {
         let completed_vec: Vec<CantonId> = completed.iter().cloned().collect();
         self.persist_step_progress(*current, completed_vec).await;
 
-        // Advance once every connected peer has completed and the quorum is met
-        // — see `peer_threshold` / `signing_gate_satisfied`. An absent peer that
-        // never connected does not hold this open.
         if current.requires_peers() && self.signing_gate_satisfied(completed_count).await {
             drop(current);
             drop(completed);
@@ -629,9 +580,7 @@ mod tests {
 
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn peer_connected_advances_at_threshold(pool: SqlitePool) {
-        // Two peers expected but only one needed (e.g. a 2-of-3 party where the
-        // coordinator provides the other signature): the waiting step must
-        // advance on the first connect, without the second peer.
+        // quorum 1 of 2: the first connect starts the workflow.
         let state = WorkflowState::new(
             pool,
             "test-run".to_string(),
@@ -646,10 +595,7 @@ mod tests {
 
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn signing_gate_waits_for_all_connected_peers(pool: SqlitePool) {
-        // Happy path: when both invited peers are present (connected), the
-        // signing gate waits for BOTH to sign even though the quorum is 1 — so
-        // the coordinator gathers every present peer's signature before
-        // executing (matching the require-all path / green main).
+        // quorum 1, but both connected → wait for both to sign (not just one).
         let state = WorkflowState::new(
             pool,
             "test-run".to_string(),
@@ -658,7 +604,6 @@ mod tests {
             Some(1),
         );
 
-        // Sign is not a waiting step, so connecting just records participation.
         state.peer_connected(peer(1)).await;
         state.peer_connected(peer(2)).await;
 
@@ -671,9 +616,7 @@ mod tests {
 
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn signing_gate_skips_absent_peer_at_quorum(pool: SqlitePool) {
-        // The fix for the production hang: with a quorum of 1 and peer(2)
-        // absent (never connected), the signing step advances once the present
-        // quorum (peer(1)) has signed, instead of looping forever.
+        // quorum 1, peer(2) never connects → peer(1) signing is enough.
         let state = WorkflowState::new(
             pool,
             "test-run".to_string(),
@@ -682,7 +625,6 @@ mod tests {
             Some(1),
         );
 
-        // Only peer(1) connects; peer(2) never accepts/connects.
         state.peer_connected(peer(1)).await;
 
         state.peer_completed(peer(1)).await;
@@ -691,8 +633,6 @@ mod tests {
 
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn require_all_signing_gate_unchanged_with_connections(pool: SqlitePool) {
-        // `None` (Onboarding/DARs) still requires every expected peer even when
-        // all are connected: the quorum floor equals the total.
         let state = WorkflowState::new(
             pool,
             "test-run".to_string(),
@@ -713,9 +653,6 @@ mod tests {
 
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn start_threshold_above_peer_count_clamps_to_all(pool: SqlitePool) {
-        // A start threshold larger than the available peers clamps to the peer
-        // count, so the start gate behaves like require-all: the first connect
-        // must not start the workflow, only the last one does.
         let state = WorkflowState::new(
             pool,
             "test-run".to_string(),

--- a/crates/decman/src/workflow/state.rs
+++ b/crates/decman/src/workflow/state.rs
@@ -212,9 +212,10 @@ impl<S: WorkflowStep + 'static> WorkflowState<S> {
         if connected_count >= required {
             let current = self.current_step.read().await;
             if current.is_waiting_for_peers() {
+                let observed = *current;
                 drop(current);
                 drop(connected);
-                self.advance_step().await;
+                self.advance_step_if(observed).await;
             }
         }
     }
@@ -252,31 +253,48 @@ impl<S: WorkflowStep + 'static> WorkflowState<S> {
         self.persist_step_progress(*current, completed_vec).await;
 
         if current.requires_peers() && self.signing_gate_satisfied(completed_count).await {
+            let observed = *current;
             drop(current);
             drop(completed);
-            self.advance_step().await;
+            self.advance_step_if(observed).await;
         }
     }
 
+    /// Unconditional advance, used by the coordinator loop which drives its own
+    /// non-peer steps sequentially (one task, no self-race).
     pub async fn advance_step(&self) {
         let mut current = self.current_step.write().await;
-        let mut completed = self.completed_peers.write().await;
+        self.advance_locked(&mut current).await;
+    }
 
+    /// Advance only if the machine is still on `expected`. Peer events run on
+    /// per-connection tasks, so with quorum < total two of them can observe the
+    /// same gate open at once; without this check-then-act guard both would
+    /// advance and skip a step. The CAS re-check under the write lock makes the
+    /// second call a no-op.
+    async fn advance_step_if(&self, expected: S) {
+        let mut current = self.current_step.write().await;
+        if *current != expected {
+            return;
+        }
+        self.advance_locked(&mut current).await;
+    }
+
+    /// Shared advance body; caller holds the `current_step` write lock.
+    /// Does NOT flip status to Completed — the spawning task does that via
+    /// `mark_run_completed` once `start_coordinator` returns (doing it here
+    /// triggers the artifact cleanup before the post-workflow PARTY_ID read and
+    /// re-marks the run Failed).
+    async fn advance_locked(&self, current: &mut S) {
+        let mut completed = self.completed_peers.write().await;
         if let Some(next_step) = current.next() {
-            let current_name = format!("{current:?}");
-            let next_name = format!("{next_step:?}");
-            tracing::info!("Advancing workflow: {current_name} -> {next_name}");
+            tracing::info!("Advancing workflow: {:?} -> {next_step:?}", *current);
             *current = next_step;
             completed.clear();
             self.persist_step_progress(next_step, Vec::new()).await;
         } else {
             tracing::info!("Workflow complete!");
         }
-        // Do NOT flip status to Completed here — the spawning task does that
-        // via `mark_run_completed` once `start_coordinator` returns. Doing it
-        // inside the state machine triggers the workflow_artifacts cleanup
-        // before the post-workflow PARTY_ID read (onboarding) and re-marks
-        // the run as Failed.
     }
 
     /// Mark the run as Failed with an error message. Used when a workflow
@@ -665,6 +683,30 @@ mod tests {
         assert_eq!(state.current_step().await, TestStep::WaitPeers);
 
         state.peer_connected(peer(2)).await;
+        assert_eq!(state.current_step().await, TestStep::Sign);
+    }
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn advance_step_if_only_advances_from_expected(pool: SqlitePool) {
+        let state = WorkflowState::new(
+            pool,
+            "test-run".to_string(),
+            TestStep::WaitPeers,
+            vec![peer(1)],
+            None,
+        );
+
+        // Stale "from" (a step we're already past / not on): no-op. This is the
+        // CAS guard that stops two concurrent peer events from double-advancing.
+        state.advance_step_if(TestStep::Sign).await;
+        assert_eq!(state.current_step().await, TestStep::WaitPeers);
+
+        // Matching "from": advances exactly one step.
+        state.advance_step_if(TestStep::WaitPeers).await;
+        assert_eq!(state.current_step().await, TestStep::Sign);
+
+        // A second call with the now-stale "from" must not advance again.
+        state.advance_step_if(TestStep::WaitPeers).await;
         assert_eq!(state.current_step().await, TestStep::Sign);
     }
 }

--- a/crates/decman/tests/common/db.rs
+++ b/crates/decman/tests/common/db.rs
@@ -40,10 +40,54 @@ async fn open_rw(path: &Path) -> anyhow::Result<SqlitePool> {
     let opts = SqliteConnectOptions::new()
         .filename(path)
         .read_only(false)
-        .create_if_missing(false);
+        .create_if_missing(false)
+        // Tolerate brief contention if the owning process happens to write
+        // (`inject_inprogress_coordinator_run` runs against a live node).
+        .busy_timeout(std::time::Duration::from_secs(10));
     SqlitePool::connect_with(opts)
         .await
         .with_context(|| format!("opening sqlite (rw) at {}", path.display()))
+}
+
+/// Chaos/test-only: insert a synthetic `inprogress` coordinator `workflow_runs`
+/// row directly, reproducing the divergence a restart / failed startup-recovery
+/// leaves behind — the persisted row says InProgress (so `GET /workflows` and
+/// the UI list it) while the in-memory `<Kind>WorkflowState` is Idle (the app
+/// never started this run). That is exactly the state in which the per-kind
+/// cancel must fall back to the persisted row instead of reporting "no workflow
+/// in progress". The row is intentionally minimal (no peers, no dec party, `{}`
+/// config) — cancel doesn't parse the config and treats the invitee broadcast
+/// as best-effort. Safe against a live node because the test runs it when no
+/// workflow is active, so the app isn't writing `workflow_runs`.
+pub async fn inject_inprogress_coordinator_run(
+    db_path: &Path,
+    kind: &str,
+    instance_name: &str,
+    current_step: &str,
+) -> anyhow::Result<()> {
+    let pool = open_rw(db_path).await?;
+    let result = sqlx::query(
+        "INSERT INTO workflow_runs (
+            instance_name, kind, role, status, current_step, step_index, step_total,
+            config_json, coordinator_pubkey, expected_peers_json, completed_peers_json,
+            dec_party_id, error, dismissed, created_at, updated_at
+         ) VALUES (?1, ?2, 'Coordinator', 'inprogress', ?3, 2, 5,
+                   '{}', NULL, '[]', '[]', NULL, NULL, 0,
+                   strftime('%s','now'), strftime('%s','now'))",
+    )
+    .bind(instance_name)
+    .bind(kind)
+    .bind(current_step)
+    .execute(&pool)
+    .await
+    .context("inject_inprogress_coordinator_run")?;
+    pool.close().await;
+    anyhow::ensure!(
+        result.rows_affected() == 1,
+        "expected to insert exactly 1 inprogress row for {instance_name}, affected {}",
+        result.rows_affected()
+    );
+    Ok(())
 }
 
 /// Chaos-only failure injection: flip a `workflow_runs` row to `failed`,

--- a/crates/decman/tests/common/phases/cancel_stuck_contracts.rs
+++ b/crates/decman/tests/common/phases/cancel_stuck_contracts.rs
@@ -1,0 +1,67 @@
+//! Regression for the uncancellable stuck workflow: a contracts run that the
+//! UI lists as "in progress" (a persisted `workflow_runs` row) must be
+//! cancellable even when the in-memory `<Kind>WorkflowState` is Idle — the
+//! divergence a node restart / failed startup-recovery leaves behind.
+//!
+//! We reproduce that divergence directly: inject an `inprogress` Contracts
+//! coordinator row into P1's DB that the running node has no in-memory state
+//! for. Before the fix, POST /contracts/cancel gated on the in-memory status
+//! and returned 409 "No Contracts workflow in progress" (exactly the operator's
+//! report). With the fix, cancel falls back to the persisted row, so it returns
+//! 200 and the row becomes `cancelled`.
+
+use std::time::Duration;
+
+use anyhow::Context;
+use serde_json::json;
+use tokio::time::sleep;
+use tracing::info;
+
+use crate::common::{Fixture, chaos, db, types::WorkflowRunsResponse};
+
+pub async fn run(f: &mut Fixture) -> anyhow::Result<()> {
+    info!("Phase: cancel_stuck_contracts");
+    chaos::ensure_nodes_healthy(f).await?;
+
+    let instance = chaos::fresh_prefix("stuck-contracts");
+    let p1_db = f.db_path(1);
+
+    // Reproduce "DB says InProgress, in-memory is Idle": a coordinator row P1
+    // never started in memory (as if a restart's recovery failed to restore it).
+    db::inject_inprogress_coordinator_run(&p1_db, "Contracts", &instance, "SignSubmissions")
+        .await
+        .context("inject stuck contracts run")?;
+
+    // Sanity: the feed / UI lists it as in progress (this is the card the
+    // operator sees with a CANCEL WORKFLOW button).
+    let runs: WorkflowRunsResponse = f.get_json(f.p1.http, "/workflows").await?;
+    anyhow::ensure!(
+        runs.runs
+            .iter()
+            .any(|w| w.instance_name == instance && w.status == "inprogress"),
+        "injected run not visible as inprogress in /workflows"
+    );
+
+    // The fix: cancel must succeed off the persisted row (pre-fix this 409'd
+    // with "No Contracts workflow in progress").
+    let (status, body) = f
+        .post_expect_status(f.p1.http, "/contracts/cancel", &json!({}))
+        .await?;
+    anyhow::ensure!(
+        status.as_u16() == 200,
+        "/contracts/cancel returned {status}: {body} (expected 200 for a stuck/recovered run)"
+    );
+
+    // The persisted row must now be cancelled.
+    sleep(Duration::from_secs(2)).await;
+    let row_status = db::workflow_run_status(&p1_db, &instance, "Coordinator").await?;
+    anyhow::ensure!(
+        row_status.as_deref() == Some("cancelled"),
+        "stuck run not cancelled in DB (status={row_status:?})"
+    );
+    info!("stuck contracts run cancelled via the persisted row");
+
+    // Clean up so it doesn't linger in the feed.
+    chaos::dismiss_p1(f, &instance).await;
+    Ok(())
+}

--- a/crates/decman/tests/common/phases/contracts_quorum_completes.rs
+++ b/crates/decman/tests/common/phases/contracts_quorum_completes.rs
@@ -1,0 +1,140 @@
+//! Threshold/quorum regression: a contracts workflow must COMPLETE when only a
+//! quorum of peers accept, instead of looping forever at the signing step.
+//!
+//! Reproduces the production hang: on a 2-of-3 party the coordinator + one peer
+//! are a signing quorum (M = 2). We invite both P2 and P3 but have only P2
+//! accept; P3 stays up but never accepts (the "absent owner" of the bug report).
+//! The coordinator's start gate advances on the connected quorum, and — with the
+//! fix — the signing gate advances once every *connected* peer (just P2) has
+//! signed, so the run reaches `completed`. Before the fix it hung at
+//! `SignSubmissions` waiting for P3 forever.
+//!
+//! This also empirically answers whether an M-of-N interactive submission
+//! finalizes on a quorum of signatures (coordinator + P2): if it didn't, the
+//! coordinator would stall in ExecuteSubmissions and this phase would time out.
+//!
+//! Depends on `deploy_gov_core` having run (reuses the member parties it set on
+//! the fixture). Runs in the chaos block so the stale, never-accepted P3 invite
+//! can't interfere with the happy-path contracts phases.
+
+use std::time::{Duration, Instant};
+
+use anyhow::Context;
+use serde_json::{Value, json};
+use tokio::time::sleep;
+use tracing::info;
+
+use crate::common::{
+    Fixture, TestTarget, chaos,
+    http::probe_workflow_status,
+    invitations::{post_accept_invitation, probe_pending_invitation},
+    types::DecentralizedPartiesResponse,
+};
+
+pub async fn run(f: &mut Fixture) -> anyhow::Result<()> {
+    info!("Phase: contracts_quorum_completes");
+    chaos::ensure_nodes_healthy(f).await?;
+
+    let party_id = f.party_id()?.to_string();
+    let p1m = f
+        .p1_member_party
+        .clone()
+        .context("p1 member party missing (deploy_gov_core must run first)")?;
+    let p2m = f
+        .p2_member_party
+        .clone()
+        .context("p2 member party missing")?;
+    let p3m = f
+        .p3_member_party
+        .clone()
+        .context("p3 member party missing")?;
+
+    // Re-fetch the party's participant uids (same as deploy_gov_core).
+    let parties: DecentralizedPartiesResponse =
+        f.get_json(f.p1.http, "/decentralized-parties").await?;
+    let party = parties
+        .parties
+        .into_iter()
+        .find(|p| p.party_id == party_id)
+        .with_context(|| format!("party {party_id} not found"))?;
+    let uids: Vec<String> = party
+        .participants
+        .iter()
+        .map(|p| p.participant_uid.clone())
+        .collect();
+    anyhow::ensure!(
+        uids.len() == 3,
+        "expected 3 participants, got {}",
+        uids.len()
+    );
+
+    let operator_party = match f.target {
+        TestTarget::Localnet => p1m.clone(),
+        TestTarget::Devnet => f
+            .operator_party
+            .clone()
+            .context("operator_party not set on devnet")?,
+    };
+
+    // Deploy a SECOND GovernanceRules (no contract key → additive, no conflict
+    // with the one deploy_gov_core created), inviting both P2 and P3.
+    let req = json!({
+        "decentralized_party_id": party_id,
+        "participant_ids": uids,
+        "participant_parties": [&p1m, &p2m, &p3m],
+        "operator_party": operator_party,
+        "contracts": [{
+            "id": "governance-rules-quorum",
+            "name": "GovernanceRules",
+            "package_id": "#governance-core-v1",
+            "module_name": "Governance.Rules",
+            "entity_name": "GovernanceRules",
+            "fields": [
+                {"type": "decentralized_party"},
+                {"type": "party_set", "parties": [&p1m, &p2m, &p3m]},
+                {"type": "int64", "value": 2},
+                {"type": "rel_time", "microseconds": 1800000000_i64},
+                {"type": "none"},
+            ],
+        }],
+    });
+    let _: Value = f
+        .post_json(f.p1.http, "/contracts", &req)
+        .await
+        .context("POST /contracts")?;
+
+    // Only P2 accepts. P3 stays up but never accepts — the absent owner.
+    let p2_inv = chaos::wait_for_invite(f, f.p2.http, "Contracts", Duration::from_secs(60)).await?;
+    post_accept_invitation(f, f.p2.http, &p2_inv)
+        .await
+        .context("accept Contracts on P2")?;
+    info!("P2 accepted; P3 deliberately left un-accepted (the absent owner)");
+
+    // The coordinator must reach `completed` on the quorum (coordinator + P2),
+    // without P3. Poll /contracts/status until terminal or 240s.
+    let deadline = Instant::now() + Duration::from_secs(240);
+    loop {
+        if let Some(res) =
+            probe_workflow_status(&*f, f.p1.http, "/contracts/status", "contracts").await
+        {
+            res?; // Ok(()) => completed; Err => failed (surfaces the message)
+            break;
+        }
+        anyhow::ensure!(
+            Instant::now() < deadline,
+            "contracts workflow did not complete at quorum within 240s (P3 absent) — \
+             the signing gate likely still waits for all peers, or the quorum submission \
+             did not finalize"
+        );
+        sleep(Duration::from_secs(2)).await;
+    }
+    info!("contracts workflow completed at quorum with P3 absent");
+
+    // Best-effort: clear P3's stale, never-accepted invite so it doesn't linger.
+    if let Some(id) = probe_pending_invitation(f, f.p3.http, "Contracts").await {
+        let _ = f
+            .post_expect_status(f.p3.http, "/invitations/decline", &json!({ "id": id }))
+            .await;
+    }
+    Ok(())
+}

--- a/crates/decman/tests/common/phases/mod.rs
+++ b/crates/decman/tests/common/phases/mod.rs
@@ -3,10 +3,12 @@
 pub mod add_party;
 pub mod add_party_edge_cases;
 pub mod cancel_cascades;
+pub mod cancel_stuck_contracts;
 pub mod check_peer_dars;
 pub mod concurrent_cross_workflows;
 pub mod concurrent_sibling_cancel;
 pub mod concurrent_sibling_decline;
+pub mod contracts_quorum_completes;
 pub mod create_dec_party;
 pub mod deploy_gov_core;
 pub mod dismiss_failed_cleans_artifacts;

--- a/crates/decman/tests/governance_workflows.rs
+++ b/crates/decman/tests/governance_workflows.rs
@@ -130,6 +130,11 @@ async fn governance_workflows_e2e() -> anyhow::Result<()> {
     phases::retry_coordinator_broadcast::run(&mut f).await?; // G3
     phases::dismiss_failed_cleans_artifacts::run(&mut f).await?; // G4
     phases::generate_keys_idempotent::run(&mut f).await?; // G7
+    // Threshold/quorum coverage (the fix for the signing-step hang + the
+    // uncancellable stuck run). Run here, after the happy-path contracts
+    // phases, so the quorum phase's never-accepted P3 invite can't interfere.
+    phases::contracts_quorum_completes::run(&mut f).await?;
+    phases::cancel_stuck_contracts::run(&mut f).await?;
     // G8 (peer 3-strikes abort) is intentionally NOT run. The
     // `peer_3_strikes_abort` phase is an unimplemented stub: exercising it
     // needs a raw-Noise-frame injection harness to feed a peer three

--- a/crates/decman/tests/governance_workflows.rs
+++ b/crates/decman/tests/governance_workflows.rs
@@ -100,6 +100,14 @@ async fn governance_workflows_e2e() -> anyhow::Result<()> {
     phases::generic_vote::run(&mut f).await?;
     phases::notification_feed::run(&mut f).await?;
     phases::owner_key_resilience::run(&mut f).await?;
+    // Threshold/quorum coverage (signing-step hang fix + uncancellable stuck
+    // run). Runs after the happy-path contracts/governance phases (so the extra
+    // GovernanceRules deploy + workflow rows can't perturb their assertions) but
+    // BEFORE `kick`, which removes a participant: the quorum case needs the
+    // intact 3-member party (2 peers — one accepts, one stays absent). Both
+    // phases clean up after themselves.
+    phases::contracts_quorum_completes::run(&mut f).await?;
+    phases::cancel_stuck_contracts::run(&mut f).await?;
     phases::kick::run(&mut f).await?;
     // Add-party edge cases must run while P3 is still OUT of the party
     // (validation 400s/409s, decline cascade, cancel cascade) — both
@@ -130,11 +138,6 @@ async fn governance_workflows_e2e() -> anyhow::Result<()> {
     phases::retry_coordinator_broadcast::run(&mut f).await?; // G3
     phases::dismiss_failed_cleans_artifacts::run(&mut f).await?; // G4
     phases::generate_keys_idempotent::run(&mut f).await?; // G7
-    // Threshold/quorum coverage (the fix for the signing-step hang + the
-    // uncancellable stuck run). Run here, after the happy-path contracts
-    // phases, so the quorum phase's never-accepted P3 invite can't interfere.
-    phases::contracts_quorum_completes::run(&mut f).await?;
-    phases::cancel_stuck_contracts::run(&mut f).await?;
     // G8 (peer 3-strikes abort) is intentionally NOT run. The
     // `peer_3_strikes_abort` phase is an unimplemented stub: exercising it
     // needs a raw-Noise-frame injection harness to feed a peer three


### PR DESCRIPTION
## Problem

When a coordinator runs a workflow it invited peers to, the **start** gate (`WaitingForPeers`) only advanced once *every* invited peer connected (`connected_count == total_count`), and the per-step **signing** gate likewise waited for every invited peer. A single slow/absent owner blocked the workflow — even though a decentralized party is **M-of-N** and a quorum is enough.

## Fix

`WorkflowState` gains `peer_threshold: Option<usize>`, applied to **both** peer-gated steps:

- **Start gate** (`peer_connected` / `WaitingForPeers`): begin once `M − 1` peers connect (the coordinator is the Mth signer).
- **Signing gate** (`peer_completed` → `maybe_advance`): advance as soon as the quorum has signed (`completed_peers ≥ quorum`). We do **not** additionally wait for every *connected* peer — a peer that connects but then never signs (crash, refusal, or a straggler) must not hold the gate open. `M` signatures satisfy an `M`-of-`N` party, so the coordinator submits with the present quorum's signatures. An invited owner who never connects isn't in `connected_peers` either, so it likewise can't hold the gate open.
- `None` (and the no-peer case) → require **all** expected peers (original behaviour); otherwise clamped into `[1, total]`.

`NoiseServer::new` resolves the start quorum once, keyed by workflow kind:

| Workflow | Start quorum | Why |
|---|---|---|
| **Kick / Contracts** | `M − 1` peers | Existing M-of-N party. `M` is read from the `dec_parties` cache; `M − 1` peers because the coordinator participates itself. A cached threshold `< 1` or an unresolved party falls back to `None` (require all). |
| **Onboarding / AddParty / DARs / ChangeThreshold** | all (`None`) | Onboarding/AddParty define or extend the owner set (a new member can't be skipped); DARs serves file chunks to each peer; ChangeThreshold has every remaining member sign. All wait for the full set. |

## Scope: the threshold governs both *starting* and *signing*

Finalization succeeds at a quorum because the party is **M-of-N at the topology level**: onboarding sets `PartyToParticipant.threshold` (the confirmation threshold) and `DecentralizedNamespaceDefinition.threshold` to `M` (majority default `ceil(N/2)`, operator-overridable — via #231, now on `main`). Canton finalizes on `M` participant confirmations, so a quorum submission commits rather than hanging.

> **Earlier hang, now resolved:** a first cut lowered the signing gate on an **N-of-N** party and stayed `InProgress` at `ExecuteSubmissions` — Canton needed all N confirmations. The fix is the M-of-N topology from #231, not a require-all signing gate.

**Legacy parties:** a party onboarded before #231 has `PartyToParticipant.threshold = N` and will not finalize at a quorum until its threshold is lowered with the `ChangeThreshold` workflow — a one-time operational migration per existing party, not a code change here.

## Review comments

All three Copilot comments addressed and threads resolved: start quorum clamped to `[1, total]`; cached party threshold of `0` treated as invalid (require-all fallback); doc corrected for the `0-peers ⇒ 0-required` case.

## Tests

- **Unit:** start-gate threshold + clamp-to-all in `state.rs`; the signing gate advances on the connected quorum but never below `M`; start-quorum arithmetic in `noise/server.rs`.
- **e2e (`contracts_quorum_completes`):** 2-of-3 party, one owner (P3) never accepts, the run must reach `completed` — proves the quorum submission finalizes on a live network. Green in CI ([run 28659055210](https://github.com/DLC-link/decentralization-manager/actions/runs/28659055210)); log: *"contracts workflow completed at quorum with P3 absent."*
- **e2e (`cancel_stuck_contracts`):** a persisted `inprogress` coordinator row with no in-memory state (e.g. after a restart) is cancellable off the row.
- `cargo fmt` + `cargo clippy --all-targets --all-features -- -D warnings` pass clean; full e2e validated by CI.

