### PR TITLE
fix(sync): scope party query to local participant

### DIFF
--- a/src/server/handlers/parties.rs
+++ b/src/server/handlers/parties.rs
@@ -622,6 +622,38 @@ pub async fn store_parties_to_db(
     Commitable::commit(tx).await
 }
 
+/// Build the `list_party_to_participant` request used to discover this node's
+/// decentralized parties.
+///
+/// `filter_participant` is always set to this node's participant id so the query
+/// is scoped to parties hosted here. Without it the synchronizer returns every
+/// party-to-participant mapping on the whole network, which on mainnet exceeds
+/// the gRPC decode limit. We only ever care about decentralized parties this
+/// node hosts, and every party we co-own lists our participant as a host, so the
+/// scope loses nothing. An optional party-id `prefix_filter` narrows on top.
+fn build_party_to_participant_request(
+    synchronizer_id: &str,
+    prefix_filter: Option<&str>,
+    participant_id: &str,
+) -> ListPartyToParticipantRequest {
+    ListPartyToParticipantRequest {
+        base_query: Some(BaseQuery {
+            store: Some(StoreId {
+                store: Some(store_id::Store::Synchronizer(Synchronizer {
+                    kind: Some(synchronizer::Kind::PhysicalId(synchronizer_id.to_string())),
+                })),
+            }),
+            proposals: false,
+            operation: 0,
+            time_query: Some(base_query::TimeQuery::HeadState(())),
+            filter_signed_key: String::new(),
+            protocol_version: None,
+        }),
+        filter_party: prefix_filter.unwrap_or_default().to_string(),
+        filter_participant: participant_id.to_string(),
+    }
+}
+
 /// Fetch decentralized parties from Canton topology and ledger APIs
 pub async fn fetch_decentralized_parties(
     config: &NodeConfig,
@@ -681,30 +713,14 @@ pub async fn fetch_decentralized_parties(
         .await?
         .into_inner();
 
-    // Query P2P mappings, scoped to parties hosted on this participant. Without
-    // `filter_participant` this returns every party-to-participant mapping on the
-    // synchronizer (the entire network), which on mainnet exceeds the gRPC decode
-    // limit. We only ever care about decentralized parties this node hosts, and
-    // every party we co-own lists our participant as a host, so scoping here loses
-    // nothing while bounding the response to what this node manages. The optional
-    // party prefix filter still composes on top.
+    // Query P2P mappings, scoped to parties hosted on this participant — see
+    // `build_party_to_participant_request` for why the participant filter matters.
     let p2p_response = topology_client
-        .list_party_to_participant(tonic::Request::new(ListPartyToParticipantRequest {
-            base_query: Some(BaseQuery {
-                store: Some(StoreId {
-                    store: Some(store_id::Store::Synchronizer(Synchronizer {
-                        kind: Some(synchronizer::Kind::PhysicalId(synchronizer_id.clone())),
-                    })),
-                }),
-                proposals: false,
-                operation: 0,
-                time_query: Some(base_query::TimeQuery::HeadState(())),
-                filter_signed_key: String::new(),
-                protocol_version: None,
-            }),
-            filter_party: prefix_filter.unwrap_or_default().to_string(),
-            filter_participant: config.participant_id().to_string(),
-        }))
+        .list_party_to_participant(tonic::Request::new(build_party_to_participant_request(
+            &synchronizer_id,
+            prefix_filter,
+            &config.participant_id().to_string(),
+        )))
         .await?
         .into_inner();
 
@@ -1239,5 +1255,31 @@ mod tests {
             peer_error_kind_from_noise_err(&err),
             PeerErrorKind::Other
         ));
+    }
+
+    #[test]
+    fn party_to_participant_request_scopes_to_local_participant() {
+        // The core of the mainnet fix: with no prefix filter the request must
+        // still be scoped to this participant, so it doesn't scan every party
+        // on the synchronizer and overflow the gRPC decode limit.
+        let request =
+            build_party_to_participant_request("sync::physical", None, "participant::abc123");
+
+        assert_eq!(request.filter_participant, "participant::abc123");
+        assert_eq!(request.filter_party, "");
+    }
+
+    #[test]
+    fn party_to_participant_request_composes_prefix_with_participant() {
+        // A caller-supplied party prefix must narrow on top of the participant
+        // scope, not replace it.
+        let request = build_party_to_participant_request(
+            "sync::physical",
+            Some("alice"),
+            "participant::abc123",
+        );
+
+        assert_eq!(request.filter_participant, "participant::abc123");
+        assert_eq!(request.filter_party, "alice");
     }
 }

--- a/src/server/handlers/parties.rs
+++ b/src/server/handlers/parties.rs
@@ -681,7 +681,13 @@ pub async fn fetch_decentralized_parties(
         .await?
         .into_inner();
 
-    // Query P2P mappings with optional party prefix filter
+    // Query P2P mappings, scoped to parties hosted on this participant. Without
+    // `filter_participant` this returns every party-to-participant mapping on the
+    // synchronizer (the entire network), which on mainnet exceeds the gRPC decode
+    // limit. We only ever care about decentralized parties this node hosts, and
+    // every party we co-own lists our participant as a host, so scoping here loses
+    // nothing while bounding the response to what this node manages. The optional
+    // party prefix filter still composes on top.
     let p2p_response = topology_client
         .list_party_to_participant(tonic::Request::new(ListPartyToParticipantRequest {
             base_query: Some(BaseQuery {
@@ -697,7 +703,7 @@ pub async fn fetch_decentralized_parties(
                 protocol_version: None,
             }),
             filter_party: prefix_filter.unwrap_or_default().to_string(),
-            filter_participant: String::new(),
+            filter_participant: config.participant_id().to_string(),
         }))
         .await?
         .into_inner();


### PR DESCRIPTION
## Problem

On mainnet startup the background Canton sync fails:

```
WARN dec_party_manager::server: Background Canton sync failed on startup:
code: 'Operation was attempted past the valid range',
message: "Error, decoded message length too large: found 567575367 bytes, the limit is: 536870912 bytes"
```

567,575,367 bytes (~541 MiB) exceeds the 512 MiB gRPC decode cap (536,870,912 = 512×1024×1024).

## Root cause

`fetch_decentralized_parties` issues `list_party_to_participant` with **both** `filter_party` and `filter_participant` empty, so the synchronizer returns **every party-to-participant mapping on the entire network** in one gRPC message.

This does **not** scale with the number of *decentralized* parties — it scales with *total* parties on the synchronizer. That's why devnet (far more dec parties, but a tiny total party population) is fine, while mainnet's Global Synchronizer (~50 dec parties but hundreds of thousands of network parties) overflows the cap. The neighbouring `list_decentralized_namespace_definition` call is bounded by dec-party count and is unaffected.

The team already hit this same unfiltered scan in another path (`list_my_owner_keys`, #149) and refactored around it; this call site was left as-is.

The topology read API has no pagination (only prefix filters), so raising the cap is a band-aid that already failed once.

## Fix

Scope the query to parties hosted on this participant:

```rust
filter_participant: config.participant_id().to_string(),
```

This tool only ever cares about dec parties this node hosts, and every party we co-own lists our participant as a host (the code immediately below already relies on `self_uid` appearing in the participant list), so scoping loses nothing while bounding the response to what this node manages. The optional party-prefix filter still composes on top. The 512 MiB cap stays as a safety net but is no longer load-bearing.

## Verification

- `cargo clippy --all-targets` — clean
- `cargo fmt -- --check` — clean

**Reviewer note:** the fix rests on Canton's `filter_participant` prefix-match including a mapping when our participant is one of several hosts (the normal multi-host dec-party case). This is standard Canton behaviour and matches how the repo already uses `filter_party` prefix filters, but is worth a sanity check against a real node before mainnet.
