### PR TITLE
fix(deps): bump quinn-proto to 0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2924,9 +2924,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
## What this PR does

**Old behavior**
`Cargo.lock` pinned `quinn-proto` 0.11.14. On 2026-06-22, RUSTSEC-2026-0185 was published against it — a high-severity (7.5) remote memory-exhaustion bug (unbounded out-of-order QUIC stream reassembly). CI's Cargo Audit check now fails on every branch.

**New behavior**
`quinn-proto` is bumped to 0.11.15 (the fixed release). Cargo Audit passes again.

**The change that enables it**
- `cargo update -p quinn-proto --precise 0.11.15` — a lockfile-only patch bump (version + checksum), no other dependency moves.

**Caveats**
- **No actual runtime exposure in this binary.** `quinn-proto` enters the lockfile only via `reqwest`'s optional `http3` feature, which this workspace does not enable — `cargo tree -i quinn-proto` resolves to nothing for our build graph, so the crate is never compiled or linked. The bump silences the (correct) lockfile-presence finding from `cargo audit`; it does not patch a reachable code path here.

## Details

**Verification**
- `cargo audit` clean after the bump (was: `1 vulnerability found` — RUSTSEC-2026-0185).
- Diff is `Cargo.lock` only, 2 lines (version + checksum); no source/API change.

---
Advisory: [RUSTSEC-2026-0185](https://rustsec.org/advisories/RUSTSEC-2026-0185) · Surfaced during the code review of #213 (its Cargo Audit check tripped on this newly-published advisory, unrelated to that PR's changes).
