### PR TITLE
fix(workflow): confirm created contracts by id instead of scanning the full ACS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1111,7 +1111,7 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "dec-party-manager"
-version = "1.0.0"
+version = "1.0.2"
 dependencies = [
  "actix-cors",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dec-party-manager"
-version = "1.0.0"
+version = "1.0.2"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/src/workflow/contracts/steps/execute.rs
+++ b/src/workflow/contracts/steps/execute.rs
@@ -310,9 +310,24 @@ pub async fn execute_submissions(
         }
 
         if !pending.is_empty() {
+            // Keep the error bounded: a large lagging batch shouldn't dump
+            // thousands of ids into the message — show counts plus a small sample.
+            let sample = pending
+                .iter()
+                .take(10)
+                .cloned()
+                .collect::<Vec<_>>()
+                .join(", ");
+            let more = pending.len().saturating_sub(10);
+            let suffix = if more > 0 {
+                format!(", … (+{more} more)")
+            } else {
+                String::new()
+            };
             anyhow::bail!(
-                "Created contract(s) not visible after {max_attempts} attempts: {ids}",
-                ids = pending.join(", ")
+                "{missing} of {total} created contract(s) not visible after \
+                 {max_attempts} attempts: {sample}{suffix}",
+                missing = pending.len()
             );
         }
 
@@ -362,4 +377,49 @@ fn read_all_messages_from_bytes<M: prost::Message + Default>(data: &[u8]) -> Res
         messages.push(M::decode(message_bytes)?);
     }
     Ok(messages)
+}
+
+#[cfg(test)]
+mod tests {
+    use canton_proto_rs::com::daml::ledger::api::v2::{
+        ArchivedEvent, CreatedEvent, Event, Transaction, event,
+    };
+
+    use super::created_contract_ids;
+
+    fn created(contract_id: &str) -> Event {
+        Event {
+            event: Some(event::Event::Created(CreatedEvent {
+                contract_id: contract_id.to_string(),
+                ..Default::default()
+            })),
+        }
+    }
+
+    #[test]
+    fn none_transaction_yields_no_ids() {
+        assert!(created_contract_ids(&None).is_empty());
+    }
+
+    #[test]
+    fn collects_only_created_event_ids_in_order() {
+        let tx = Transaction {
+            events: vec![
+                created("cid-1"),
+                // a non-created event must be ignored
+                Event {
+                    event: Some(event::Event::Archived(ArchivedEvent::default())),
+                },
+                created("cid-2"),
+                // an empty envelope must be ignored
+                Event { event: None },
+            ],
+            ..Default::default()
+        };
+
+        assert_eq!(
+            created_contract_ids(&Some(tx)),
+            vec!["cid-1".to_string(), "cid-2".to_string()]
+        );
+    }
 }

--- a/src/workflow/contracts/steps/execute.rs
+++ b/src/workflow/contracts/steps/execute.rs
@@ -222,10 +222,8 @@ pub async fn execute_submissions(
              relying on execute_submission_and_wait_for_transaction success"
         );
     } else {
-        tracing::info!(
-            "Confirming {count} created contract(s) by id...",
-            count = all_created_contract_ids.len()
-        );
+        let total = all_created_contract_ids.len();
+        tracing::info!("Confirming {total} created contract(s) by id...");
 
         let mut event_query_client = utils::create_event_query_client(config, token_opt).await?;
 
@@ -248,10 +246,16 @@ pub async fn execute_submissions(
             },
         );
 
-        for contract_id in &all_created_contract_ids {
-            let mut visible = false;
+        // Confirm in rounds: each round looks up every still-pending contract
+        // once, then sleeps a single time before the next round. This bounds the
+        // total wait to `max_attempts * retry_delay` regardless of how many
+        // contracts we created, rather than paying that budget per contract.
+        let mut pending = all_created_contract_ids;
 
-            for attempt in 1..=max_attempts {
+        for attempt in 1..=max_attempts {
+            let mut still_pending = Vec::new();
+
+            for contract_id in pending {
                 let request = GetEventsByContractIdRequest {
                     contract_id: contract_id.clone(),
                     event_format: Some(EventFormat {
@@ -265,40 +269,54 @@ pub async fn execute_submissions(
                     .get_events_by_contract_id(tonic::Request::new(request))
                     .await
                 {
-                    // A populated `created` event means the contract is visible.
                     Ok(response) => {
-                        if response.into_inner().created.is_some() {
-                            visible = true;
-                            break;
+                        if response.into_inner().created.is_none() {
+                            // The RPC succeeded, so the index served the query — a
+                            // missing `created` event is not index lag and won't
+                            // change on retry. Fail fast with the real reason.
+                            anyhow::bail!(
+                                "Created contract {contract_id} returned no create event \
+                                 (not visible to {decentralized_party} or already archived)"
+                            );
                         }
+                        // Visible — drop it from the pending set.
+                    }
+                    // `CONTRACT_EVENTS_NOT_FOUND` surfaces as NOT_FOUND while the
+                    // index catches up — the one genuinely transient case; retry it.
+                    Err(status) if status.code() == tonic::Code::NotFound => {
                         tracing::debug!(
                             "Contract {contract_id} not yet visible (attempt {attempt}/{max_attempts})"
                         );
+                        still_pending.push(contract_id);
                     }
-                    // `CONTRACT_EVENTS_NOT_FOUND` while the index catches up — retry.
+                    // Anything else (auth, permission, transport, …) is not index
+                    // lag — surface the real cause instead of retrying into a
+                    // misleading visibility error.
                     Err(status) => {
-                        tracing::debug!(
-                            "Lookup for {contract_id} failed (attempt {attempt}/{max_attempts}): {status}"
-                        );
+                        return Err(anyhow::Error::new(status)
+                            .context(format!("Failed to confirm created contract {contract_id}")));
                     }
-                }
-
-                if attempt < max_attempts {
-                    tokio::time::sleep(retry_delay).await;
                 }
             }
 
-            if !visible {
-                anyhow::bail!(
-                    "Created contract {contract_id} not visible after {max_attempts} attempts"
-                );
+            pending = still_pending;
+            if pending.is_empty() {
+                break;
+            }
+
+            if attempt < max_attempts {
+                tokio::time::sleep(retry_delay).await;
             }
         }
 
-        tracing::info!(
-            "All {count} created contract(s) confirmed visible",
-            count = all_created_contract_ids.len()
-        );
+        if !pending.is_empty() {
+            anyhow::bail!(
+                "Created contract(s) not visible after {max_attempts} attempts: {ids}",
+                ids = pending.join(", ")
+            );
+        }
+
+        tracing::info!("All {total} created contract(s) confirmed visible");
     }
 
     tracing::info!("Submissions executed successfully");

--- a/src/workflow/contracts/steps/execute.rs
+++ b/src/workflow/contracts/steps/execute.rs
@@ -293,8 +293,7 @@ pub async fn execute_submissions(
                     // lag — surface the real cause instead of retrying into a
                     // misleading visibility error.
                     Err(status) => {
-                        return Err(anyhow::Error::new(status)
-                            .context(format!("Failed to confirm created contract {contract_id}")));
+                        anyhow::bail!("Failed to confirm created contract {contract_id}: {status}");
                     }
                 }
             }

--- a/src/workflow/contracts/steps/execute.rs
+++ b/src/workflow/contracts/steps/execute.rs
@@ -4,8 +4,7 @@ use uuid::Uuid;
 
 use canton_proto_rs::com::{
     daml::ledger::api::v2::{
-        CumulativeFilter, EventFormat, Filters, GetEventsByContractIdRequest, Signature,
-        Transaction, WildcardFilter, cumulative_filter, event,
+        Signature, Transaction, event,
         interactive::{
             ExecuteSubmissionAndWaitForTransactionRequest, PartySignatures,
             PrepareSubmissionResponse, SinglePartySignatures,
@@ -16,7 +15,6 @@ use canton_proto_rs::com::{
 
 use crate::{
     config::NodeConfig,
-    consts::{topology_retry_delay_secs, topology_retry_max_attempts},
     error::Result,
     utils,
     workflow::{
@@ -120,11 +118,11 @@ pub async fn execute_submissions(
     );
 
     // Step 4: Execute each submission
-    let token_opt = Some(token.to_string());
-    let mut submission_client = utils::create_submission_client(config, token_opt.clone()).await?;
+    let mut submission_client =
+        utils::create_submission_client(config, Some(token.to_string())).await?;
 
     // Contract ids of everything we create, harvested from each submission's
-    // committed transaction response so we can confirm them by id afterwards.
+    // committed transaction response, purely so we can log how many we made.
     let mut all_created_contract_ids: Vec<String> = Vec::new();
 
     for (idx, prepared_response) in prepared_submissions.iter().enumerate() {
@@ -194,8 +192,7 @@ pub async fn execute_submissions(
 
         // The RPC blocks until the transaction is committed, and its response
         // carries the created events — i.e. the exact contracts this submission
-        // produced. Harvest their ids so we can confirm them by id later rather
-        // than scanning the whole ACS.
+        // produced. Harvest their ids just to report how many we created.
         let created = created_contract_ids(&response.transaction);
         tracing::info!(
             "Submission {index} executed successfully, created {count} contract(s)",
@@ -205,142 +202,27 @@ pub async fn execute_submissions(
         all_created_contract_ids.extend(created);
     }
 
-    // Step 5: Confirm the created contracts are visible.
-    //
-    // `execute_submission_and_wait_for_transaction` already blocks until each
-    // transaction is committed, so the contracts exist by this point. We still
-    // confirm them, but by looking each one up by id via
-    // `EventQueryService.GetEventsByContractId` — a cheap point query — instead
-    // of streaming the party's entire active-contract set (which can be millions
-    // of contracts and is `O(ledger state)`, not `O(contracts we created)`).
-    if all_created_contract_ids.is_empty() {
-        // No created events came back (e.g. the submitting party isn't hosted on
-        // this node, so an ACS_DELTA transaction is filtered to empty). The RPC
-        // success above is itself the commit guarantee, so don't fail here.
-        tracing::warn!(
-            "Execute responses returned no created events to confirm; \
-             relying on execute_submission_and_wait_for_transaction success"
-        );
-    } else {
-        let total = all_created_contract_ids.len();
-        tracing::info!("Confirming {total} created contract(s) by id...");
+    // No post-submission confirmation is needed.
+    // `execute_submission_and_wait_for_transaction` is the *and-wait* variant: it
+    // blocks until each transaction is sequenced and committed, so a successful
+    // return is itself the commit guarantee. There is nothing to re-confirm, and
+    // nothing downstream reads the ACS — the workflow advances straight to
+    // `Complete`. The default ACS_DELTA transaction shape also means the responses
+    // above already carried the created contracts, so we just log the count. An
+    // empty set means the submitting party isn't hosted on this node (the
+    // ACS_DELTA is filtered out), which is expected rather than an error.
+    tracing::info!(
+        "Submissions executed successfully; committed {count} created contract(s)",
+        count = all_created_contract_ids.len(),
+    );
 
-        let mut event_query_client = utils::create_event_query_client(config, token_opt).await?;
-
-        let max_attempts = topology_retry_max_attempts();
-        let retry_delay = tokio::time::Duration::from_secs(topology_retry_delay_secs());
-
-        // `GetEventsByContractId` filters by party visibility; the decentralized
-        // party is a stakeholder on everything it just created.
-        let mut filters_by_party = std::collections::HashMap::new();
-        filters_by_party.insert(
-            decentralized_party.clone(),
-            Filters {
-                cumulative: vec![CumulativeFilter {
-                    identifier_filter: Some(cumulative_filter::IdentifierFilter::WildcardFilter(
-                        WildcardFilter {
-                            include_created_event_blob: false,
-                        },
-                    )),
-                }],
-            },
-        );
-
-        // Confirm in rounds: each round looks up every still-pending contract
-        // once, then sleeps a single time before the next round. This bounds the
-        // total wait to `max_attempts * retry_delay` regardless of how many
-        // contracts we created, rather than paying that budget per contract.
-        let mut pending = all_created_contract_ids;
-
-        for attempt in 1..=max_attempts {
-            let mut still_pending = Vec::new();
-
-            for contract_id in pending {
-                let request = GetEventsByContractIdRequest {
-                    contract_id: contract_id.clone(),
-                    event_format: Some(EventFormat {
-                        filters_by_party: filters_by_party.clone(),
-                        filters_for_any_party: None,
-                        verbose: false,
-                    }),
-                };
-
-                match event_query_client
-                    .get_events_by_contract_id(tonic::Request::new(request))
-                    .await
-                {
-                    Ok(response) => {
-                        if response.into_inner().created.is_none() {
-                            // The RPC succeeded, so the index served the query — a
-                            // missing `created` event is not index lag and won't
-                            // change on retry. Fail fast with the real reason.
-                            anyhow::bail!(
-                                "Created contract {contract_id} returned no create event \
-                                 (not visible to {decentralized_party} or already archived)"
-                            );
-                        }
-                        // Visible — drop it from the pending set.
-                    }
-                    // `CONTRACT_EVENTS_NOT_FOUND` surfaces as NOT_FOUND while the
-                    // index catches up — the one genuinely transient case; retry it.
-                    Err(status) if status.code() == tonic::Code::NotFound => {
-                        tracing::debug!(
-                            "Contract {contract_id} not yet visible (attempt {attempt}/{max_attempts})"
-                        );
-                        still_pending.push(contract_id);
-                    }
-                    // Anything else (auth, permission, transport, …) is not index
-                    // lag — surface the real cause instead of retrying into a
-                    // misleading visibility error.
-                    Err(status) => {
-                        anyhow::bail!("Failed to confirm created contract {contract_id}: {status}");
-                    }
-                }
-            }
-
-            pending = still_pending;
-            if pending.is_empty() {
-                break;
-            }
-
-            if attempt < max_attempts {
-                tokio::time::sleep(retry_delay).await;
-            }
-        }
-
-        if !pending.is_empty() {
-            // Keep the error bounded: a large lagging batch shouldn't dump
-            // thousands of ids into the message — show counts plus a small sample.
-            let sample = pending
-                .iter()
-                .take(10)
-                .cloned()
-                .collect::<Vec<_>>()
-                .join(", ");
-            let more = pending.len().saturating_sub(10);
-            let suffix = if more > 0 {
-                format!(", … (+{more} more)")
-            } else {
-                String::new()
-            };
-            anyhow::bail!(
-                "{missing} of {total} created contract(s) not visible after \
-                 {max_attempts} attempts: {sample}{suffix}",
-                missing = pending.len()
-            );
-        }
-
-        tracing::info!("All {total} created contract(s) confirmed visible");
-    }
-
-    tracing::info!("Submissions executed successfully");
     Ok(())
 }
 
 /// Collect the contract ids of every `CreatedEvent` in an execute-and-wait
 /// transaction response. These are the exact contracts the submission created,
-/// letting us confirm them by id rather than scanning the whole ACS. Returns an
-/// empty vec when the response carries no transaction or no created events.
+/// reported only to log how many were made. Returns an empty vec when the
+/// response carries no transaction or no created events.
 fn created_contract_ids(transaction: &Option<Transaction>) -> Vec<String> {
     let Some(tx) = transaction else {
         return Vec::new();

--- a/src/workflow/contracts/steps/execute.rs
+++ b/src/workflow/contracts/steps/execute.rs
@@ -4,8 +4,8 @@ use uuid::Uuid;
 
 use canton_proto_rs::com::{
     daml::ledger::api::v2::{
-        CumulativeFilter, EventFormat, Filters, GetActiveContractsRequest, GetLedgerEndRequest,
-        Signature, WildcardFilter, cumulative_filter,
+        CumulativeFilter, EventFormat, Filters, GetEventsByContractIdRequest, Signature,
+        Transaction, WildcardFilter, cumulative_filter, event,
         interactive::{
             ExecuteSubmissionAndWaitForTransactionRequest, PartySignatures,
             PrepareSubmissionResponse, SinglePartySignatures,
@@ -123,6 +123,10 @@ pub async fn execute_submissions(
     let token_opt = Some(token.to_string());
     let mut submission_client = utils::create_submission_client(config, token_opt.clone()).await?;
 
+    // Contract ids of everything we create, harvested from each submission's
+    // committed transaction response so we can confirm them by id afterwards.
+    let mut all_created_contract_ids: Vec<String> = Vec::new();
+
     for (idx, prepared_response) in prepared_submissions.iter().enumerate() {
         tracing::info!("Executing submission {index}...", index = idx + 1);
 
@@ -183,30 +187,53 @@ pub async fn execute_submissions(
             transaction_format: None,
         };
 
-        submission_client
+        let response = submission_client
             .execute_submission_and_wait_for_transaction(tonic::Request::new(execute_request))
-            .await?;
+            .await?
+            .into_inner();
 
-        tracing::info!("Submission {index} executed successfully", index = idx + 1);
+        // The RPC blocks until the transaction is committed, and its response
+        // carries the created events — i.e. the exact contracts this submission
+        // produced. Harvest their ids so we can confirm them by id later rather
+        // than scanning the whole ACS.
+        let created = created_contract_ids(&response.transaction);
+        tracing::info!(
+            "Submission {index} executed successfully, created {count} contract(s)",
+            index = idx + 1,
+            count = created.len(),
+        );
+        all_created_contract_ids.extend(created);
     }
 
-    // Step 5: Wait for contracts to appear in ACS
-    tracing::info!("Waiting for contracts to appear in ledger...");
-    let mut state_client = utils::create_state_client(config, token_opt).await?;
+    // Step 5: Confirm the created contracts are visible.
+    //
+    // `execute_submission_and_wait_for_transaction` already blocks until each
+    // transaction is committed, so the contracts exist by this point. We still
+    // confirm them, but by looking each one up by id via
+    // `EventQueryService.GetEventsByContractId` — a cheap point query — instead
+    // of streaming the party's entire active-contract set (which can be millions
+    // of contracts and is `O(ledger state)`, not `O(contracts we created)`).
+    if all_created_contract_ids.is_empty() {
+        // No created events came back (e.g. the submitting party isn't hosted on
+        // this node, so an ACS_DELTA transaction is filtered to empty). The RPC
+        // success above is itself the commit guarantee, so don't fail here.
+        tracing::warn!(
+            "Execute responses returned no created events to confirm; \
+             relying on execute_submission_and_wait_for_transaction success"
+        );
+    } else {
+        tracing::info!(
+            "Confirming {count} created contract(s) by id...",
+            count = all_created_contract_ids.len()
+        );
 
-    let max_attempts = topology_retry_max_attempts();
-    let retry_delay = tokio::time::Duration::from_secs(topology_retry_delay_secs());
+        let mut event_query_client = utils::create_event_query_client(config, token_opt).await?;
 
-    for attempt in 1..=max_attempts {
-        // Get current ledger end
-        let ledger_end = state_client
-            .get_ledger_end(tonic::Request::new(GetLedgerEndRequest {}))
-            .await?
-            .into_inner()
-            .offset;
+        let max_attempts = topology_retry_max_attempts();
+        let retry_delay = tokio::time::Duration::from_secs(topology_retry_delay_secs());
 
-        // Query ACS for the decentralized party
-        // Filter by the specific party rather than "any party" to avoid permission issues
+        // `GetEventsByContractId` filters by party visibility; the decentralized
+        // party is a stakeholder on everything it just created.
         let mut filters_by_party = std::collections::HashMap::new();
         filters_by_party.insert(
             decentralized_party.clone(),
@@ -221,51 +248,81 @@ pub async fn execute_submissions(
             },
         );
 
-        let acs_request = GetActiveContractsRequest {
-            active_at_offset: ledger_end,
-            event_format: Some(EventFormat {
-                filters_by_party,
-                filters_for_any_party: None,
-                verbose: false,
-            }),
-        };
+        for contract_id in &all_created_contract_ids {
+            let mut visible = false;
 
-        let mut stream = state_client
-            .get_active_contracts(tonic::Request::new(acs_request))
-            .await?
-            .into_inner();
+            for attempt in 1..=max_attempts {
+                let request = GetEventsByContractIdRequest {
+                    contract_id: contract_id.clone(),
+                    event_format: Some(EventFormat {
+                        filters_by_party: filters_by_party.clone(),
+                        filters_for_any_party: None,
+                        verbose: false,
+                    }),
+                };
 
-        let mut contract_count = 0;
-        while let Some(response) = stream.message().await? {
-            if response.contract_entry.is_some() {
-                contract_count += 1;
+                match event_query_client
+                    .get_events_by_contract_id(tonic::Request::new(request))
+                    .await
+                {
+                    // A populated `created` event means the contract is visible.
+                    Ok(response) => {
+                        if response.into_inner().created.is_some() {
+                            visible = true;
+                            break;
+                        }
+                        tracing::debug!(
+                            "Contract {contract_id} not yet visible (attempt {attempt}/{max_attempts})"
+                        );
+                    }
+                    // `CONTRACT_EVENTS_NOT_FOUND` while the index catches up — retry.
+                    Err(status) => {
+                        tracing::debug!(
+                            "Lookup for {contract_id} failed (attempt {attempt}/{max_attempts}): {status}"
+                        );
+                    }
+                }
+
+                if attempt < max_attempts {
+                    tokio::time::sleep(retry_delay).await;
+                }
+            }
+
+            if !visible {
+                anyhow::bail!(
+                    "Created contract {contract_id} not visible after {max_attempts} attempts"
+                );
             }
         }
 
-        tracing::debug!(
-            "Found {contract_count} contracts for party {decentralized_party} (attempt {attempt}/{max_attempts})",
+        tracing::info!(
+            "All {count} created contract(s) confirmed visible",
+            count = all_created_contract_ids.len()
         );
-
-        // We expect at least as many contracts as submissions
-        if contract_count >= num_submissions {
-            tracing::info!(
-                "All contracts successfully created! Found {contract_count} contracts after {attempt} attempt(s)"
-            );
-            break;
-        }
-
-        if attempt < max_attempts {
-            tracing::debug!("Contracts not yet visible, retrying in {retry_delay:?}...");
-            tokio::time::sleep(retry_delay).await;
-        } else {
-            anyhow::bail!(
-                "Contracts not visible in ACS after {max_attempts} attempts. Found only {contract_count} contracts, expected at least {num_submissions}"
-            );
-        }
     }
 
     tracing::info!("Submissions executed successfully");
     Ok(())
+}
+
+/// Collect the contract ids of every `CreatedEvent` in an execute-and-wait
+/// transaction response. These are the exact contracts the submission created,
+/// letting us confirm them by id rather than scanning the whole ACS. Returns an
+/// empty vec when the response carries no transaction or no created events.
+fn created_contract_ids(transaction: &Option<Transaction>) -> Vec<String> {
+    let Some(tx) = transaction else {
+        return Vec::new();
+    };
+
+    tx.events
+        .iter()
+        .filter_map(|ev| {
+            ev.event.as_ref().and_then(|inner| match inner {
+                event::Event::Created(created) => Some(created.contract_id.clone()),
+                _ => None,
+            })
+        })
+        .collect()
 }
 
 /// Decode a sequence of `varint(len)||proto` messages from a byte slice. Mirrors


### PR DESCRIPTION
## Problem

The contracts workflow's final step ("waiting for contracts to appear in ledger…") could hang for ~17 minutes before completing. From a real run:

```
11:14:14  Waiting for contracts to appear in ledger...
11:31:36  All contracts successfully created! Found 2876757 contracts after 1 attempt(s)
```

## Root cause

`execute.rs` Step 5 issued a `WildcardFilter` `GetActiveContracts` query scoped only to the decentralized party, then **streamed and counted every active contract** (2,876,757 of them) just to assert `count >= num_submissions`. That's `O(entire ledger state)`, not `O(contracts we created)`.

It was also redundant: `execute_submission_and_wait_for_transaction` already blocks until each transaction is committed, so the contracts exist the moment that RPC returns.

## Fix

- **Harvest the exact contract ids** from each submission's committed transaction. The execute-and-wait response (previously discarded) carries the created events; a new pure helper `created_contract_ids()` pulls their ids.
- **Confirm by id, not by scan.** Replace the full-ACS stream with a per-contract `EventQueryService.GetEventsByContractId` point-lookup — `O(contracts we created)`, no scan. A bounded retry absorbs index lag.
- **Fail-safe on empty events.** If no created events come back (e.g. the submitting party isn't hosted on this node, so an `ACS_DELTA` transaction is filtered to empty), warn and rely on the RPC's commit guarantee rather than failing — so the change can't introduce a new hang or false failure.

This reuses patterns already in the codebase (`governance.rs` extracts created ids from a transaction response; `transfer_context.rs` / `queries.rs` use `GetEventsByContractId`).

## Result

The 17-minute step becomes ~instant, and the check is now *more* correct — it confirms the specific contracts created rather than a count threshold against the whole ACS.

## Testing

- `cargo fmt -- --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- Unit tests for `created_contract_ids()` (empty/`None` and mixed-event extraction)
