### PR TITLE
feat(cli): frontend parity for workflows, governance, and composers

### DIFF
--- a/crates/decman-cli/src/api.rs
+++ b/crates/decman-cli/src/api.rs
@@ -830,6 +830,28 @@ impl DecmanClient {
         self.post("/auth/test", None)
     }
 
+    /// Grant actAs/readAs rights on a party's member and dec parties, using an
+    /// admin (ParticipantAdmin) client. The secret is not stored server-side.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if login or the request fails, or the API rejects it.
+    pub fn grant_rights(
+        &mut self,
+        dec_party_id: &str,
+        admin_client_id: &str,
+        admin_client_secret: &str,
+    ) -> Result<()> {
+        self.post(
+            "/auth/grant-rights",
+            Some(json!({
+                "dec_party_id": dec_party_id,
+                "admin_client_id": admin_client_id,
+                "admin_client_secret": admin_client_secret,
+            })),
+        )
+    }
+
     /// Fetch the on-ledger governance state for a party (threshold, members,
     /// action timeout). `None` when the party has no governance rules contract.
     ///

--- a/crates/decman-cli/src/api.rs
+++ b/crates/decman-cli/src/api.rs
@@ -345,6 +345,31 @@ struct OperatorInfoResponse {
     party_id: String,
 }
 
+/// A fully-detailed configured peer, for the network-config editor (the
+/// merged [`PeerView`] drops `public_key` / `party`, which editing needs).
+#[derive(Clone, Debug, Deserialize)]
+pub struct PeerEntry {
+    #[serde(default)]
+    pub participant_id: String,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub address: String,
+    #[serde(default)]
+    pub port: u16,
+    #[serde(default)]
+    pub public_key: String,
+    #[serde(default)]
+    pub party: Option<String>,
+}
+
+/// `/network-config` response with the full peer fields.
+#[derive(Debug, Deserialize)]
+struct NetworkPeersResponse {
+    #[serde(default)]
+    peers: Vec<PeerEntry>,
+}
+
 /// Configured package ids for a party, from `/packages` (only the fields the
 /// CLI needs for contract deployment).
 #[derive(Clone, Debug, Deserialize)]
@@ -962,6 +987,27 @@ impl DecmanClient {
     pub fn fetch_operator_info(&mut self) -> Result<String> {
         let response: OperatorInfoResponse = self.get_json("/operator-info")?;
         Ok(response.party_id)
+    }
+
+    /// Fetch the configured peers with their full fields (for editing).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if login or the request fails, the API returns a
+    /// non-success status, or the response cannot be parsed.
+    pub fn fetch_network_peers(&mut self) -> Result<Vec<PeerEntry>> {
+        let response: NetworkPeersResponse = self.get_json("/network-config")?;
+        Ok(response.peers)
+    }
+
+    /// Replace the configured peer list. `peers` must be a JSON array of peer
+    /// objects (the endpoint takes a bare array, not an envelope).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if login or the request fails, or the API rejects it.
+    pub fn save_network_peers(&mut self, peers: Value) -> Result<()> {
+        self.post("/network-config", Some(peers))
     }
 
     /// Fetch the configured package ids for a party.

--- a/crates/decman-cli/src/api.rs
+++ b/crates/decman-cli/src/api.rs
@@ -345,6 +345,41 @@ struct OperatorInfoResponse {
     party_id: String,
 }
 
+/// Per-party IdP configuration, from `GET /party-config/{id}` (secrets are
+/// returned only as `has_*` flags).
+#[derive(Clone, Debug, Deserialize)]
+pub struct PartyConfigView {
+    #[serde(default)]
+    pub member_party_id: Option<String>,
+    #[serde(default)]
+    pub user_id: Option<String>,
+    #[serde(default)]
+    pub keycloak_url: String,
+    #[serde(default)]
+    pub keycloak_realm: String,
+    #[serde(default)]
+    pub keycloak_client_id: String,
+    #[serde(default)]
+    pub has_client_secret: bool,
+    #[serde(default)]
+    pub auth0_domain: Option<String>,
+    #[serde(default)]
+    pub auth0_audience: Option<String>,
+    #[serde(default)]
+    pub auth0_client_id: Option<String>,
+    #[serde(default)]
+    pub has_auth0_client_secret: bool,
+}
+
+/// Result of `POST /party-config/discover-member-party`.
+#[derive(Clone, Debug, Deserialize)]
+pub struct DiscoverResult {
+    #[serde(default)]
+    pub user_id: String,
+    #[serde(default)]
+    pub primary_party: Option<String>,
+}
+
 /// A fully-detailed configured peer, for the network-config editor (the
 /// merged [`PeerView`] drops `public_key` / `party`, which editing needs).
 #[derive(Clone, Debug, Deserialize)]
@@ -989,6 +1024,45 @@ impl DecmanClient {
         Ok(response.party_id)
     }
 
+    /// Fetch the per-party IdP configuration for a dec party.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if login or the request fails, the API returns a
+    /// non-success status, or the response cannot be parsed.
+    pub fn fetch_party_config(&mut self, dec_party_id: &str) -> Result<PartyConfigView> {
+        // `::` is path-safe and actix decodes the segment, so no encoding needed.
+        self.get_json(&format!("/party-config/{dec_party_id}"))
+    }
+
+    /// Save the per-party IdP configuration. `body` is the full
+    /// `PartyConfigRequest` (an absent secret keeps the existing one).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if login or the request fails, or the API rejects it.
+    pub fn save_party_config(&mut self, body: Value) -> Result<()> {
+        self.put("/party-config", body)
+    }
+
+    /// Discover the member party for the given IdP credentials.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if login or the request fails, the API returns a
+    /// non-success status, or the response cannot be parsed.
+    pub fn discover_member_party(&mut self, body: Value) -> Result<DiscoverResult> {
+        let response = self.post_raw("/party-config/discover-member-party", Some(&body))?;
+        let status = response.status();
+        if !status.is_success() {
+            let text = response.text().unwrap_or_default();
+            bail!("discover-member-party failed ({status}): {text}");
+        }
+        response
+            .json()
+            .context("failed to parse discover-member-party response")
+    }
+
     /// Fetch the configured peers with their full fields (for editing).
     ///
     /// # Errors
@@ -1329,6 +1403,39 @@ impl DecmanClient {
         }
         if let Some(body) = body {
             request = request.json(body);
+        }
+        request
+            .send()
+            .with_context(|| format!("request to {url} failed"))
+    }
+
+    /// PUT `path` with a JSON body, authenticating on first use and retrying
+    /// once on `401`, then failing on any non-success status.
+    fn put(&mut self, path: &str, body: Value) -> Result<()> {
+        if !self.authenticated {
+            self.authenticate()?;
+        }
+        let mut response = self.send_put(path, &body)?;
+        if response.status() == StatusCode::UNAUTHORIZED {
+            self.authenticated = false;
+            self.token = None;
+            self.authenticate()?;
+            response = self.send_put(path, &body)?;
+        }
+        let status = response.status();
+        if !status.is_success() {
+            let text = response.text().unwrap_or_default();
+            bail!("decman API {path} returned {status}: {text}");
+        }
+        Ok(())
+    }
+
+    /// Send a `PUT {base_url}{path}` with a JSON body and the bearer token.
+    fn send_put(&self, path: &str, body: &Value) -> Result<Response> {
+        let url = format!("{base}{path}", base = self.base_url);
+        let mut request = self.http.put(&url).json(body);
+        if let Some(token) = &self.token {
+            request = request.bearer_auth(token);
         }
         request
             .send()

--- a/crates/decman-cli/src/api.rs
+++ b/crates/decman-cli/src/api.rs
@@ -5,7 +5,7 @@ use anyhow::{Context, Result, bail};
 use common::types::{
     AuditLogEntry, AuthConfigResponse, ConnectionStatus, DecentralizedParty, ParticipantStatus,
     ParticipantsStatusResponse, PeerPackageComparison, PendingInvitation, VettedPackageInfo,
-    WorkflowInfo, WorkflowRun,
+    WorkflowInfo, WorkflowKind, WorkflowRun,
 };
 use reqwest::StatusCode;
 use reqwest::blocking::{Client, Response};
@@ -279,6 +279,252 @@ struct HoldingsResponse {
     holdings: Vec<Holding>,
 }
 
+/// A single confirmation on a pending governance action.
+#[derive(Clone, Debug, Deserialize)]
+pub struct GovConfirmation {
+    #[serde(default)]
+    pub contract_id: String,
+    #[serde(default)]
+    pub confirming_party: String,
+    #[serde(default)]
+    pub expires_at: i64,
+}
+
+/// A pending off-chain governance action (vault / core-self), grouped by hash.
+#[derive(Clone, Debug, Deserialize)]
+pub struct GovAction {
+    /// The `ActionType` payload, echoed back verbatim on confirm / execute.
+    #[serde(default)]
+    pub action: Value,
+    #[serde(default)]
+    pub confirmations: Vec<GovConfirmation>,
+    #[serde(default)]
+    pub confirmation_count: i64,
+    #[serde(default)]
+    pub can_execute: bool,
+}
+
+/// A pending on-chain (core-domain) governance proposal.
+#[derive(Clone, Debug, Deserialize)]
+pub struct DomainGovAction {
+    #[serde(default)]
+    pub proposal_cid: String,
+    #[serde(default)]
+    pub action_label: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub confirmations: Vec<GovConfirmation>,
+    #[serde(default)]
+    pub confirmation_count: i64,
+    #[serde(default)]
+    pub can_execute: bool,
+    #[serde(default)]
+    pub orphaned: bool,
+}
+
+/// `/governance/confirmations` response: pending actions awaiting signatures.
+#[derive(Clone, Debug, Deserialize)]
+pub struct GovernanceConfirmations {
+    #[serde(default)]
+    pub actions: Vec<GovAction>,
+    #[serde(default)]
+    pub domain_actions: Vec<DomainGovAction>,
+    #[serde(default)]
+    pub threshold: i32,
+    #[serde(default)]
+    pub rules_contract_id: Option<String>,
+    #[serde(default)]
+    pub member_party_id: Option<String>,
+}
+
+/// `/operator-info` response: this node's operator party id.
+#[derive(Debug, Deserialize)]
+struct OperatorInfoResponse {
+    #[serde(default)]
+    party_id: String,
+}
+
+/// Configured package ids for a party, from `/packages` (only the fields the
+/// CLI needs for contract deployment).
+#[derive(Clone, Debug, Deserialize)]
+pub struct PackageConfig {
+    #[serde(default)]
+    pub governance_core: Option<String>,
+}
+
+/// A governance member discovered from peers, from `/governance/known-members`.
+#[derive(Clone, Debug, Deserialize)]
+pub struct KnownMember {
+    #[serde(default)]
+    pub participant_uid: String,
+    #[serde(default)]
+    pub member_party_id: Option<String>,
+}
+
+/// `/governance/known-members` response envelope.
+#[derive(Debug, Deserialize)]
+struct KnownMembersResponse {
+    #[serde(default)]
+    members: Vec<KnownMember>,
+}
+
+/// Arguments for [`DecmanClient::execute_action`]. `disclosed` carries any
+/// `(contract_id, base64_blob)` pairs the action needs at execution time
+/// (empty for most actions; deployment actions need their rules-contract blob).
+pub struct ExecuteParams {
+    pub action: Value,
+    pub confirmation_cids: Vec<String>,
+    pub governance_type: String,
+    pub proposal_cid: Option<String>,
+    pub disclosed: Vec<(String, String)>,
+}
+
+/// On-ledger governance state for a party, from `/governance/state`.
+#[derive(Clone, Debug, Deserialize)]
+pub struct GovState {
+    #[serde(default)]
+    pub members: Vec<String>,
+    #[serde(default)]
+    pub threshold: i32,
+    #[serde(default)]
+    pub action_confirmation_timeout_microseconds: Option<i64>,
+    #[serde(default)]
+    pub out_of_date: bool,
+}
+
+/// `/governance/state` response envelope (`state` is null when no rules
+/// contract exists for the party).
+#[derive(Debug, Deserialize)]
+struct GovStateResponse {
+    #[serde(default)]
+    state: Option<GovState>,
+}
+
+/// One on-chain governance audit entry, from `/governance/chain-audit`.
+#[derive(Clone, Debug, Deserialize)]
+pub struct ChainAuditEntry {
+    #[serde(default)]
+    pub timestamp: i64,
+    #[serde(default)]
+    pub event_type: String,
+    #[serde(default)]
+    pub governance_type: String,
+    #[serde(default)]
+    pub action_summary: String,
+    #[serde(default)]
+    pub choice: Option<String>,
+}
+
+/// `/governance/chain-audit` response envelope.
+#[derive(Debug, Deserialize)]
+struct ChainAuditResponse {
+    #[serde(default)]
+    entries: Vec<ChainAuditEntry>,
+}
+
+/// One directed missing edge from the onboarding mesh pre-flight: peer `from`
+/// does not have `to` configured (`mesh_hole`), or the coordinator could not
+/// reach `to` at all (`unreachable_from_coordinator`).
+#[derive(Debug, Deserialize)]
+struct MeshEdge {
+    #[serde(default)]
+    from: String,
+    #[serde(default)]
+    to: String,
+    #[serde(default)]
+    kind: Option<String>,
+}
+
+/// The `422` body returned when onboarding's mesh pre-flight fails.
+#[derive(Debug, Deserialize)]
+struct MeshErrorResponse {
+    #[serde(default)]
+    error: String,
+    #[serde(default)]
+    missing_edges: Vec<MeshEdge>,
+}
+
+/// Render a mesh pre-flight failure as actionable, multi-line remediation
+/// guidance, mirroring the web frontend's onboarding error panel.
+fn format_mesh_error(mesh: &MeshErrorResponse) -> String {
+    let mut out = if mesh.error.is_empty() {
+        "Peers are not fully meshed.".to_owned()
+    } else {
+        mesh.error.clone()
+    };
+    if !mesh.missing_edges.is_empty() {
+        out.push_str("\n\nMissing connections:");
+        for edge in &mesh.missing_edges {
+            let hint = match edge.kind.as_deref() {
+                Some("unreachable_from_coordinator") => {
+                    format!("coordinator can't reach {to}", to = short_id(&edge.to))
+                }
+                _ => format!(
+                    "on {from}, add {to} as a peer",
+                    from = short_id(&edge.from),
+                    to = short_id(&edge.to)
+                ),
+            };
+            out.push_str(&format!("\n • {hint}"));
+        }
+    }
+    out
+}
+
+/// The human-readable prefix of a Canton id (the segment before `::`).
+fn short_id(id: &str) -> &str {
+    id.split("::").next().unwrap_or(id)
+}
+
+/// Per-party authentication status, from `/auth/status`. Internally tagged on
+/// the wire under `status`.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(tag = "status", rename_all = "lowercase")]
+pub enum AuthStatusKind {
+    Authenticated,
+    Mock,
+    Failed {
+        #[serde(default)]
+        error: String,
+    },
+    Notconfigured,
+}
+
+/// Which ledger rights this node holds for a party's member and dec parties.
+#[derive(Clone, Debug, Deserialize)]
+pub struct AuthRights {
+    #[serde(default)]
+    pub member_party_act_as: bool,
+    #[serde(default)]
+    pub member_party_read_as: bool,
+    #[serde(default)]
+    pub dec_party_act_as: bool,
+    #[serde(default)]
+    pub dec_party_read_as: bool,
+}
+
+/// Authentication status for a single decentralized party.
+#[derive(Clone, Debug, Deserialize)]
+pub struct PartyAuthStatus {
+    #[serde(default)]
+    pub dec_party_id: String,
+    #[serde(default)]
+    pub member_party_id: Option<String>,
+    #[serde(default)]
+    pub user_id: Option<String>,
+    pub status: AuthStatusKind,
+    #[serde(default)]
+    pub rights: Option<AuthRights>,
+}
+
+/// `/auth/status` response envelope.
+#[derive(Debug, Deserialize)]
+struct AuthStatusResponse {
+    #[serde(default)]
+    parties: Vec<PartyAuthStatus>,
+}
+
 /// Resolved OAuth2 target after discovery / overrides are applied.
 struct AuthTarget {
     token_url: String,
@@ -467,6 +713,78 @@ impl DecmanClient {
         )
     }
 
+    /// Start onboarding a new decentralized party with the given prefix and
+    /// peer participant ids.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if login or the request fails, or the API rejects it.
+    /// A `422` mesh pre-flight failure is parsed into actionable remediation
+    /// hints (which peers are unreachable or missing from each other's config).
+    pub fn start_onboarding(&mut self, prefix: &str, peer_ids: &[String]) -> Result<()> {
+        let body = json!({ "party_id_prefix": prefix, "peer_ids": peer_ids });
+        let response = self.post_raw("/onboarding", Some(&body))?;
+        let status = response.status();
+        if status.is_success() {
+            return Ok(());
+        }
+        let text = response.text().unwrap_or_default();
+        if status == StatusCode::UNPROCESSABLE_ENTITY
+            && let Ok(mesh) = serde_json::from_str::<MeshErrorResponse>(&text)
+        {
+            bail!("{}", format_mesh_error(&mesh));
+        }
+        bail!("onboarding failed ({status}): {text}");
+    }
+
+    /// Kick a participant from a decentralized party, setting the new threshold.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if login or the request fails, or the API rejects it.
+    pub fn kick_participant(
+        &mut self,
+        party_id: &str,
+        participant_id: &str,
+        new_threshold: i32,
+        previous_threshold: i32,
+    ) -> Result<()> {
+        self.post(
+            "/kick",
+            Some(json!({
+                "decentralized_party_id": party_id,
+                "participant_id": participant_id,
+                "new_threshold": new_threshold,
+                "previous_threshold": previous_threshold,
+            })),
+        )
+    }
+
+    /// Cancel an in-progress workflow run (coordinator side). The cancel
+    /// endpoint is selected by the run's [`WorkflowKind`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if login or the request fails, or the API rejects it.
+    pub fn cancel_workflow(&mut self, kind: WorkflowKind) -> Result<()> {
+        let path = match kind {
+            WorkflowKind::Onboarding => "/onboarding/cancel",
+            WorkflowKind::Kick => "/kick/cancel",
+            WorkflowKind::Contracts => "/contracts/cancel",
+            WorkflowKind::Dars => "/dars/cancel",
+        };
+        self.post(path, None)
+    }
+
+    /// Retry a failed workflow run (coordinator side) by instance name.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if login or the request fails, or the API rejects it.
+    pub fn retry_workflow(&mut self, instance_name: &str) -> Result<()> {
+        self.post(&format!("/workflows/{instance_name}/retry"), None)
+    }
+
     /// Fetch the governance audit log for a party (newest entries).
     ///
     /// # Errors
@@ -489,6 +807,229 @@ impl DecmanClient {
         let response: HoldingsResponse =
             self.get_json_query("/holdings", &[("party_id", party_id)])?;
         Ok(response.holdings)
+    }
+
+    /// Fetch the per-party authentication status (rights + IdP status).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if login or the request fails, the API returns a
+    /// non-success status, or the response cannot be parsed.
+    pub fn fetch_auth_status(&mut self) -> Result<Vec<PartyAuthStatus>> {
+        let response: AuthStatusResponse = self.get_json("/auth/status")?;
+        Ok(response.parties)
+    }
+
+    /// Re-test credentials for all parties (the backend re-mints tokens and
+    /// re-checks rights). The refreshed state is read back via `auth/status`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if login or the request fails, or the API rejects it.
+    pub fn test_auth(&mut self) -> Result<()> {
+        self.post("/auth/test", None)
+    }
+
+    /// Fetch the on-ledger governance state for a party (threshold, members,
+    /// action timeout). `None` when the party has no governance rules contract.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if login or the request fails, the API returns a
+    /// non-success status, or the response cannot be parsed.
+    pub fn fetch_governance_state(&mut self, party_id: &str) -> Result<Option<GovState>> {
+        let response: GovStateResponse =
+            self.get_json_query("/governance/state", &[("party_id", party_id)])?;
+        Ok(response.state)
+    }
+
+    /// Fetch the pending governance confirmations (off-chain actions and
+    /// on-chain domain proposals) for a party.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if login or the request fails, the API returns a
+    /// non-success status, or the response cannot be parsed.
+    pub fn fetch_governance(&mut self, party_id: &str) -> Result<GovernanceConfirmations> {
+        self.get_json_query("/governance/confirmations", &[("party_id", party_id)])
+    }
+
+    /// Add this node's confirmation to a governance action. `proposal_cid` is
+    /// set for on-chain (`core_domain`) proposals.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if login or the request fails, or the API rejects it.
+    pub fn confirm_action(
+        &mut self,
+        party_id: &str,
+        rules_contract_id: &str,
+        action: &Value,
+        governance_type: &str,
+        proposal_cid: Option<&str>,
+    ) -> Result<()> {
+        let mut body = json!({
+            "party_id": party_id,
+            "rules_contract_id": rules_contract_id,
+            "action": action,
+            "governance_type": governance_type,
+        });
+        if let Some(cid) = proposal_cid {
+            body["proposal_cid"] = json!(cid);
+        }
+        self.post("/governance/confirm", Some(body))
+    }
+
+    /// Execute a governance action once its threshold is met.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if login or the request fails, or the API rejects it.
+    pub fn execute_action(
+        &mut self,
+        party_id: &str,
+        rules_contract_id: &str,
+        execute: &ExecuteParams,
+    ) -> Result<()> {
+        let disclosed_json: Vec<Value> = execute
+            .disclosed
+            .iter()
+            .map(|(cid, blob)| json!({ "contract_id": cid, "blob": blob }))
+            .collect();
+        let mut body = json!({
+            "party_id": party_id,
+            "rules_contract_id": rules_contract_id,
+            "action": execute.action,
+            "confirmation_cids": execute.confirmation_cids,
+            "disclosed_contracts": disclosed_json,
+            "governance_type": execute.governance_type,
+        });
+        if let Some(cid) = &execute.proposal_cid {
+            body["proposal_cid"] = json!(cid);
+        }
+        self.post("/governance/execute", Some(body))
+    }
+
+    /// Propose a new on-chain (`core_domain`) governance action.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if login or the request fails, or the API rejects it.
+    pub fn propose_action(
+        &mut self,
+        party_id: &str,
+        rules_contract_id: &str,
+        proposal: &Value,
+    ) -> Result<()> {
+        self.post(
+            "/governance/propose",
+            Some(json!({
+                "party_id": party_id,
+                "rules_contract_id": rules_contract_id,
+                "proposal": proposal,
+            })),
+        )
+    }
+
+    /// Fetch the operator party id for this node.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if login or the request fails, the API returns a
+    /// non-success status, or the response cannot be parsed.
+    pub fn fetch_operator_info(&mut self) -> Result<String> {
+        let response: OperatorInfoResponse = self.get_json("/operator-info")?;
+        Ok(response.party_id)
+    }
+
+    /// Fetch the configured package ids for a party.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if login or the request fails, the API returns a
+    /// non-success status, or the response cannot be parsed.
+    pub fn fetch_packages(&mut self, party_id: &str) -> Result<PackageConfig> {
+        self.get_json_query("/packages", &[("party_id", party_id)])
+    }
+
+    /// Fetch the governance members known for a party (participant uid → member
+    /// party id), used to prefill the member set when deploying governance core.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if login or the request fails, the API returns a
+    /// non-success status, or the response cannot be parsed.
+    pub fn fetch_known_members(&mut self, party_id: &str) -> Result<Vec<KnownMember>> {
+        let response: KnownMembersResponse =
+            self.get_json_query("/governance/known-members", &[("party_id", party_id)])?;
+        Ok(response.members)
+    }
+
+    /// Start the contracts-deployment workflow for a party.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if login or the request fails, or the API rejects it.
+    pub fn deploy_contracts(&mut self, body: Value) -> Result<()> {
+        self.post("/contracts", Some(body))
+    }
+
+    /// Revoke this node's own confirmation on a governance action.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if login or the request fails, or the API rejects it.
+    pub fn cancel_confirmation(
+        &mut self,
+        party_id: &str,
+        confirmation_cid: &str,
+        governance_type: &str,
+    ) -> Result<()> {
+        self.post(
+            "/governance/cancel",
+            Some(json!({
+                "party_id": party_id,
+                "confirmation_cid": confirmation_cid,
+                "governance_type": governance_type,
+            })),
+        )
+    }
+
+    /// Expire a stale confirmation on a governance action.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if login or the request fails, or the API rejects it.
+    pub fn expire_confirmation(
+        &mut self,
+        party_id: &str,
+        rules_contract_id: &str,
+        confirmation_cid: &str,
+        governance_type: &str,
+    ) -> Result<()> {
+        self.post(
+            "/governance/expire",
+            Some(json!({
+                "party_id": party_id,
+                "rules_contract_id": rules_contract_id,
+                "confirmation_cid": confirmation_cid,
+                "governance_type": governance_type,
+            })),
+        )
+    }
+
+    /// Fetch the on-chain governance audit trail for a party (newest first).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if login or the request fails, the API returns a
+    /// non-success status, or the response cannot be parsed.
+    pub fn fetch_chain_audit(&mut self, party_id: &str) -> Result<Vec<ChainAuditEntry>> {
+        let response: ChainAuditResponse = self.get_json_query(
+            "/governance/chain-audit",
+            &[("party_id", party_id), ("limit", "200")],
+        )?;
+        Ok(response.entries)
     }
 
     /// GET `path` as JSON (no query params).
@@ -680,21 +1221,28 @@ impl DecmanClient {
             .with_context(|| format!("request to {url} failed"))
     }
 
-    /// POST `path` with an optional JSON body, discarding the success body.
-    /// Authenticates on first use and re-authenticates once on `401`.
-    fn post(&mut self, path: &str, body: Option<Value>) -> Result<()> {
+    /// POST `path` with an optional JSON body, returning the raw response.
+    /// Authenticates on first use and re-authenticates once on `401`, so the
+    /// caller can inspect non-success statuses (e.g. a 422 with a typed body).
+    fn post_raw(&mut self, path: &str, body: Option<&Value>) -> Result<Response> {
         if !self.authenticated {
             self.authenticate()?;
         }
 
-        let mut response = self.send_post(path, body.as_ref())?;
+        let mut response = self.send_post(path, body)?;
         if response.status() == StatusCode::UNAUTHORIZED {
             self.authenticated = false;
             self.token = None;
             self.authenticate()?;
-            response = self.send_post(path, body.as_ref())?;
+            response = self.send_post(path, body)?;
         }
+        Ok(response)
+    }
 
+    /// POST `path` with an optional JSON body, discarding the success body and
+    /// failing on any non-success status.
+    fn post(&mut self, path: &str, body: Option<Value>) -> Result<()> {
+        let response = self.post_raw(path, body.as_ref())?;
         let status = response.status();
         if !status.is_success() {
             let body = response.text().unwrap_or_default();
@@ -756,6 +1304,49 @@ mod tests {
     #[test]
     fn party_name_is_the_canton_id_prefix() {
         assert_eq!(party_name(&party("cbtc-network")), "cbtc-network");
+    }
+
+    #[test]
+    fn short_id_takes_the_prefix() {
+        assert_eq!(short_id("alpha::1220deadbeef"), "alpha");
+        assert_eq!(short_id("nocolon"), "nocolon");
+    }
+
+    #[test]
+    fn format_mesh_error_renders_remediation_hints() {
+        // Arrange — one coordinator-reachability gap and one peer mesh hole.
+        let mesh = MeshErrorResponse {
+            error: "Could not verify a full peer mesh.".to_owned(),
+            missing_edges: vec![
+                MeshEdge {
+                    from: "coord::1220ab".to_owned(),
+                    to: "peerB::1220cd".to_owned(),
+                    kind: Some("unreachable_from_coordinator".to_owned()),
+                },
+                MeshEdge {
+                    from: "peerA::1220ef".to_owned(),
+                    to: "peerB::1220cd".to_owned(),
+                    kind: Some("mesh_hole".to_owned()),
+                },
+            ],
+        };
+
+        // Act
+        let out = format_mesh_error(&mesh);
+
+        // Assert — the server message plus per-edge, short-id remediation.
+        assert!(out.contains("Could not verify a full peer mesh."));
+        assert!(out.contains("coordinator can't reach peerB"));
+        assert!(out.contains("on peerA, add peerB as a peer"));
+    }
+
+    #[test]
+    fn format_mesh_error_falls_back_without_an_error_message() {
+        let mesh = MeshErrorResponse {
+            error: String::new(),
+            missing_edges: Vec::new(),
+        };
+        assert_eq!(format_mesh_error(&mesh), "Peers are not fully meshed.");
     }
 
     #[test]

--- a/crates/decman-cli/src/app.rs
+++ b/crates/decman-cli/src/app.rs
@@ -2152,6 +2152,8 @@ impl App {
             KeyCode::Char('g') => self.open_governance(),
             // Deploy governance-core contracts for this party.
             KeyCode::Char('D') => self.open_deploy(),
+            // Configure / log in this party's IdP credentials.
+            KeyCode::Char('a') => self.open_party_login(),
             _ => {}
         }
     }
@@ -2702,6 +2704,16 @@ impl App {
                 .requests
                 .send(Request::ChainAudit(party.party_id.to_string()));
             self.overlay = Overlay::Busy("Loading on-chain audit…".to_owned());
+        }
+    }
+
+    /// Open the IdP config / login editor for the party in the detail view.
+    fn open_party_login(&mut self) {
+        if let Some(party) = self.detail.as_ref() {
+            let _ = self
+                .requests
+                .send(Request::PartyConfig(party.party_id.to_string()));
+            self.overlay = Overlay::Busy("Loading party configuration…".to_owned());
         }
     }
 

--- a/crates/decman-cli/src/app.rs
+++ b/crates/decman-cli/src/app.rs
@@ -1075,20 +1075,32 @@ fn party_config_body(form: &PartyConfigForm) -> Value {
 }
 
 /// Build the discover-member-party body from the form's active provider fields.
+/// A blank secret is omitted entirely (the server models it as `Option`, so an
+/// empty string would deserialize to `Some("")` and break authentication).
 fn discover_body(form: &PartyConfigForm) -> Value {
     match form.mode {
-        IdpMode::Keycloak => json!({
-            "keycloak_url": form.kc_url.trim(),
-            "keycloak_realm": form.kc_realm.trim(),
-            "keycloak_client_id": form.kc_client_id.trim(),
-            "keycloak_client_secret": form.kc_secret,
-        }),
-        IdpMode::Auth0 => json!({
-            "auth0_domain": form.auth0_domain.trim(),
-            "auth0_audience": form.auth0_audience.trim(),
-            "auth0_client_id": form.auth0_client_id.trim(),
-            "auth0_client_secret": form.auth0_secret,
-        }),
+        IdpMode::Keycloak => {
+            let mut body = json!({
+                "keycloak_url": form.kc_url.trim(),
+                "keycloak_realm": form.kc_realm.trim(),
+                "keycloak_client_id": form.kc_client_id.trim(),
+            });
+            if !form.kc_secret.is_empty() {
+                body["keycloak_client_secret"] = json!(form.kc_secret);
+            }
+            body
+        }
+        IdpMode::Auth0 => {
+            let mut body = json!({
+                "auth0_domain": form.auth0_domain.trim(),
+                "auth0_audience": form.auth0_audience.trim(),
+                "auth0_client_id": form.auth0_client_id.trim(),
+            });
+            if !form.auth0_secret.is_empty() {
+                body["auth0_client_secret"] = json!(form.auth0_secret);
+            }
+            body
+        }
     }
 }
 

--- a/crates/decman-cli/src/app.rs
+++ b/crates/decman-cli/src/app.rs
@@ -119,6 +119,11 @@ pub enum Request {
     ChainAudit(String),
     AuthStatus,
     TestAuth,
+    GrantRights {
+        dec_party_id: String,
+        client_id: String,
+        client_secret: String,
+    },
     Governance {
         party_id: String,
         party_name: String,
@@ -299,6 +304,17 @@ pub struct GovActionRequest {
     rules_contract_id: String,
 }
 
+/// The grant-rights form: an admin client id + secret used to grant act/read
+/// rights for one party. The secret is sent once and not stored.
+pub struct GrantForm {
+    pub dec_party_id: String,
+    pub party_name: String,
+    pub client_id: String,
+    pub client_secret: String,
+    /// 0 = client id, 1 = secret, 2 = submit row.
+    pub cursor: usize,
+}
+
 /// A modal overlay drawn above the main UI.
 pub enum Overlay {
     None,
@@ -341,8 +357,10 @@ pub enum Overlay {
     /// Per-party authentication status and rights.
     Auth {
         parties: Vec<PartyAuthStatus>,
-        scroll: u16,
+        selected: usize,
     },
+    /// The grant-rights form for a selected party.
+    GrantRights(Box<GrantForm>),
     /// The governance approvals list for a party (confirm / execute / revoke).
     Governance(Box<GovView>),
     /// The action / proposal type picker.
@@ -598,6 +616,16 @@ fn handle_request(client: &mut DecmanClient, request: Request) -> Update {
         Request::TestAuth => Update::AuthStatus(
             client
                 .test_auth()
+                .and_then(|()| client.fetch_auth_status())
+                .map_err(err),
+        ),
+        Request::GrantRights {
+            dec_party_id,
+            client_id,
+            client_secret,
+        } => Update::AuthStatus(
+            client
+                .grant_rights(&dec_party_id, &client_id, &client_secret)
                 .and_then(|()| client.fetch_auth_status())
                 .map_err(err),
         ),
@@ -1229,9 +1257,15 @@ impl App {
                     }
                 }
                 Update::AuthStatus(result) => {
-                    if matches!(self.overlay, Overlay::Busy(_) | Overlay::Auth { .. }) {
+                    if matches!(
+                        self.overlay,
+                        Overlay::Busy(_) | Overlay::Auth { .. } | Overlay::GrantRights(_)
+                    ) {
                         self.overlay = match result {
-                            Ok(parties) => Overlay::Auth { parties, scroll: 0 },
+                            Ok(parties) => Overlay::Auth {
+                                parties,
+                                selected: 0,
+                            },
                             Err(error) => Overlay::Message(error),
                         };
                     }
@@ -1352,6 +1386,8 @@ impl App {
             OpenComposer,
             SubmitComposer,
             SubmitDeploy,
+            OpenGrant,
+            SubmitGrant,
         }
 
         let mut act = Act::None;
@@ -1420,11 +1456,44 @@ impl App {
                 }
                 _ => {}
             },
-            Overlay::Auth { scroll, .. } => match key.code {
+            Overlay::Auth { parties, selected } => match key.code {
                 KeyCode::Esc | KeyCode::Char('q') => act = Act::Close,
                 KeyCode::Char('t') => act = Act::TestAuth,
-                KeyCode::Up | KeyCode::Char('k') => *scroll = scroll.saturating_sub(1),
-                KeyCode::Down | KeyCode::Char('j') => *scroll = scroll.saturating_add(1),
+                KeyCode::Char('g') => act = Act::OpenGrant,
+                KeyCode::Up | KeyCode::Char('k') => *selected = selected.saturating_sub(1),
+                KeyCode::Down | KeyCode::Char('j') if *selected + 1 < parties.len() => {
+                    *selected += 1;
+                }
+                _ => {}
+            },
+            Overlay::GrantRights(form) => match key.code {
+                KeyCode::Esc => act = Act::Close,
+                KeyCode::Up => form.cursor = form.cursor.saturating_sub(1),
+                KeyCode::Down | KeyCode::Tab => {
+                    if form.cursor < 2 {
+                        form.cursor += 1;
+                    }
+                }
+                KeyCode::Enter if form.cursor >= 2 => act = Act::SubmitGrant,
+                KeyCode::Enter => {
+                    if form.cursor < 2 {
+                        form.cursor += 1;
+                    }
+                }
+                KeyCode::Char(c) => match form.cursor {
+                    0 => form.client_id.push(c),
+                    1 => form.client_secret.push(c),
+                    _ => {}
+                },
+                KeyCode::Backspace => match form.cursor {
+                    0 => {
+                        form.client_id.pop();
+                    }
+                    1 => {
+                        form.client_secret.pop();
+                    }
+                    _ => {}
+                },
                 _ => {}
             },
             Overlay::Governance(view) => match key.code {
@@ -1517,6 +1586,8 @@ impl App {
             Act::OpenComposer => self.open_composer(),
             Act::SubmitComposer => self.submit_composer(),
             Act::SubmitDeploy => self.submit_deploy(),
+            Act::OpenGrant => self.open_grant(),
+            Act::SubmitGrant => self.submit_grant(),
         }
     }
 
@@ -1844,6 +1915,58 @@ impl App {
     fn run_auth_test(&mut self) {
         let _ = self.requests.send(Request::TestAuth);
         self.overlay = Overlay::Busy("Testing authentication…".to_owned());
+    }
+
+    /// Open the grant-rights form for the party selected in the auth overlay.
+    fn open_grant(&mut self) {
+        let form = {
+            let Overlay::Auth { parties, selected } = &self.overlay else {
+                return;
+            };
+            parties.get(*selected).map(|party| GrantForm {
+                dec_party_id: party.dec_party_id.clone(),
+                party_name: party
+                    .dec_party_id
+                    .split("::")
+                    .next()
+                    .unwrap_or(&party.dec_party_id)
+                    .to_owned(),
+                client_id: String::new(),
+                client_secret: String::new(),
+                cursor: 0,
+            })
+        };
+        if let Some(form) = form {
+            self.overlay = Overlay::GrantRights(Box::new(form));
+        }
+    }
+
+    /// Submit the grant-rights form, then refresh the auth overlay.
+    fn submit_grant(&mut self) {
+        let request = {
+            let Overlay::GrantRights(form) = &self.overlay else {
+                return;
+            };
+            if form.client_id.trim().is_empty() || form.client_secret.is_empty() {
+                None
+            } else {
+                Some(Request::GrantRights {
+                    dec_party_id: form.dec_party_id.clone(),
+                    client_id: form.client_id.trim().to_owned(),
+                    client_secret: form.client_secret.clone(),
+                })
+            }
+        };
+        match request {
+            Some(request) => {
+                let _ = self.requests.send(request);
+                self.overlay = Overlay::Busy("Granting rights…".to_owned());
+            }
+            None => {
+                self.overlay =
+                    Overlay::Message("Admin client id and secret are required.".to_owned());
+            }
+        }
     }
 
     /// Open the governance approvals list for the party in the detail view.

--- a/crates/decman-cli/src/app.rs
+++ b/crates/decman-cli/src/app.rs
@@ -769,6 +769,11 @@ fn build_gov_view(
         rules_contract_id,
         member_party_id,
     } = client.fetch_governance(party_id)?;
+    // Confirm/execute/propose all need a real rules contract id; bail early with
+    // a clear message rather than sending empty ids that fail obscurely later.
+    let rules_contract_id = rules_contract_id
+        .filter(|id| !id.is_empty())
+        .ok_or_else(|| anyhow::anyhow!("no governance rules contract found for this party"))?;
     let items = actions
         .into_iter()
         .map(GovItem::OffChain)
@@ -778,7 +783,9 @@ fn build_gov_view(
         party_name: party_name.to_owned(),
         party_id: party_id.to_owned(),
         governance_type: governance_type.to_owned(),
-        rules_contract_id: rules_contract_id.unwrap_or_default(),
+        rules_contract_id,
+        // Empty is tolerated: it only weakens "revoke", which already handles
+        // not finding this node's own confirmation gracefully.
         member_party_id: member_party_id.unwrap_or_default(),
         threshold,
         items,
@@ -931,6 +938,14 @@ fn build_deploy_context(
 /// Build the `POST /contracts` body for a governance-core deployment, or a
 /// human error describing why it cannot be submitted.
 fn build_contracts_request(form: &DeployForm) -> Result<Value, String> {
+    if form.package_id.is_empty() {
+        return Err(
+            "Unknown governance-core package — vet the governance-core DAR first.".to_owned(),
+        );
+    }
+    if form.member_parties.is_empty() {
+        return Err("No governance members resolved — peers may be unreachable.".to_owned());
+    }
     let threshold: i64 = form
         .threshold
         .trim()
@@ -941,13 +956,13 @@ fn build_contracts_request(form: &DeployForm) -> Result<Value, String> {
         .trim()
         .parse()
         .map_err(|_| "Timeout must be a whole number".to_owned())?;
-    if form.package_id.is_empty() {
-        return Err(
-            "Unknown governance-core package — vet the governance-core DAR first.".to_owned(),
-        );
+    // Validate ranges client-side so the error is immediate, not a chain failure.
+    let member_count = i64::try_from(form.member_parties.len()).unwrap_or(i64::MAX);
+    if !(1..=member_count).contains(&threshold) {
+        return Err(format!("Threshold must be between 1 and {member_count}."));
     }
-    if form.member_parties.is_empty() {
-        return Err("No governance members resolved — peers may be unreachable.".to_owned());
+    if timeout <= 0 {
+        return Err("Timeout must be a positive number of microseconds.".to_owned());
     }
     Ok(json!({
         "decentralized_party_id": form.party_id,
@@ -2743,6 +2758,24 @@ mod tests {
         match build_contracts_request(&form) {
             Err(error) => assert!(error.contains("governance-core")),
             Ok(_) => panic!("expected a missing-package error"),
+        }
+    }
+
+    #[test]
+    fn build_contracts_request_rejects_out_of_range_threshold() {
+        // Two members, so a threshold of 3 is out of the 1..=2 range.
+        let mut form = deploy_form();
+        form.threshold = "3".to_owned();
+        match build_contracts_request(&form) {
+            Err(error) => assert!(error.contains("between 1 and 2")),
+            Ok(_) => panic!("expected an out-of-range threshold error"),
+        }
+
+        let mut form = deploy_form();
+        form.timeout_micros = "0".to_owned();
+        match build_contracts_request(&form) {
+            Err(error) => assert!(error.contains("positive")),
+            Ok(_) => panic!("expected a non-positive timeout error"),
         }
     }
 

--- a/crates/decman-cli/src/app.rs
+++ b/crates/decman-cli/src/app.rs
@@ -853,18 +853,33 @@ fn confirmation_cids(confirmations: &[GovConfirmation]) -> Vec<String> {
         .collect()
 }
 
-/// Build a [`PeerEntry`] from the add-peer form (trimming fields; an empty
-/// party becomes `None`; a non-numeric port falls back to 0).
-fn peer_from_form(form: &PeerForm) -> PeerEntry {
+/// Validate the add-peer form into a [`PeerEntry`], or return the index of the
+/// first invalid field so the cursor can land on it. Required: participant id
+/// (0), address (2), a non-zero `u16` port (3) and public key (4); name (1) and
+/// party (5) are optional.
+fn validate_peer_form(form: &PeerForm) -> Result<PeerEntry, usize> {
+    if form.participant_id.trim().is_empty() {
+        return Err(0);
+    }
+    if form.address.trim().is_empty() {
+        return Err(2);
+    }
+    let port: u16 = match form.port.trim().parse() {
+        Ok(port) if port > 0 => port,
+        _ => return Err(3),
+    };
+    if form.public_key.trim().is_empty() {
+        return Err(4);
+    }
     let party = form.party.trim();
-    PeerEntry {
+    Ok(PeerEntry {
         participant_id: form.participant_id.trim().to_owned(),
         name: form.name.trim().to_owned(),
         address: form.address.trim().to_owned(),
-        port: form.port.trim().parse().unwrap_or(0),
+        port,
         public_key: form.public_key.trim().to_owned(),
         party: (!party.is_empty()).then(|| party.to_owned()),
-    }
+    })
 }
 
 /// Serialize the editor's peer list as the bare JSON array `POST /network-config`
@@ -1677,10 +1692,15 @@ impl App {
                     KeyCode::Esc => state.adding = None,
                     KeyCode::Up => form.cursor = form.cursor.saturating_sub(1),
                     KeyCode::Down | KeyCode::Tab if form.cursor < 6 => form.cursor += 1,
-                    KeyCode::Enter if form.cursor >= 6 => {
-                        state.peers.push(peer_from_form(form));
-                        state.adding = None;
-                    }
+                    KeyCode::Enter if form.cursor >= 6 => match validate_peer_form(form) {
+                        // Only add a valid peer; otherwise land the cursor on
+                        // the first invalid field rather than writing port 0.
+                        Ok(peer) => {
+                            state.peers.push(peer);
+                            state.adding = None;
+                        }
+                        Err(invalid_field) => form.cursor = invalid_field,
+                    },
                     KeyCode::Enter if form.cursor < 6 => form.cursor += 1,
                     KeyCode::Char(c) => match form.cursor {
                         0 => form.participant_id.push(c),
@@ -2777,6 +2797,35 @@ mod tests {
             Err(error) => assert!(error.contains("positive")),
             Ok(_) => panic!("expected a non-positive timeout error"),
         }
+    }
+
+    #[test]
+    fn validate_peer_form_rejects_blank_and_zero_port() {
+        let full = PeerForm {
+            participant_id: "alpha::1220".to_owned(),
+            name: "alpha".to_owned(),
+            address: "10.0.0.1".to_owned(),
+            port: "9001".to_owned(),
+            public_key: "abcd".to_owned(),
+            party: String::new(),
+            cursor: 0,
+        };
+        match validate_peer_form(&full) {
+            Ok(peer) => assert_eq!(peer.port, 9001),
+            Err(field) => panic!("expected a valid peer, got invalid field {field}"),
+        }
+
+        // Blank port → cursor should land on the port field (index 3).
+        let mut blank_port = full;
+        blank_port.port = String::new();
+        assert!(matches!(validate_peer_form(&blank_port), Err(3)));
+
+        // Missing participant id → field 0.
+        let mut no_id = PeerForm::blank();
+        no_id.address = "10.0.0.1".to_owned();
+        no_id.port = "9001".to_owned();
+        no_id.public_key = "abcd".to_owned();
+        assert!(matches!(validate_peer_form(&no_id), Err(0)));
     }
 
     #[test]

--- a/crates/decman-cli/src/app.rs
+++ b/crates/decman-cli/src/app.rs
@@ -2434,18 +2434,26 @@ impl App {
         let Some(party) = self.detail.as_ref() else {
             return;
         };
-        let self_id = self
+        // Require this node's identity to be resolved before listing candidates,
+        // otherwise self could not be excluded and might be kicked by mistake.
+        let Some(self_id) = self
             .peers
             .iter()
             .find(|peer| peer.is_self)
-            .map(|peer| peer.participant_id.clone());
+            .map(|peer| peer.participant_id.clone())
+        else {
+            self.overlay = Overlay::Message(
+                "Still resolving this node's identity — try again in a moment.".to_owned(),
+            );
+            return;
+        };
         let candidates: Vec<KickCandidate> = party
             .participants
             .iter()
             .filter(|participant| participant.owner_key.is_some())
             .filter_map(|participant| {
                 let id = participant.participant_uid.to_string();
-                if self_id.as_deref() == Some(id.as_str()) {
+                if id == self_id {
                     return None;
                 }
                 Some(KickCandidate {

--- a/crates/decman-cli/src/app.rs
+++ b/crates/decman-cli/src/app.rs
@@ -7,11 +7,21 @@ use base64::prelude::*;
 use ratatui::DefaultTerminal;
 use ratatui::crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use ratatui::widgets::TableState;
-use serde_json::Value;
+use serde_json::{Value, json};
 
-use common::types::{AuditLogEntry, DecentralizedParty, PeerPackageComparison, VettedPackageInfo};
+use common::types::{
+    AuditLogEntry, DecentralizedParty, PeerPackageComparison, VettedPackageInfo, WorkflowKind,
+    WorkflowProgress, WorkflowRole,
+};
 
-use crate::api::{AuthSettings, DecmanClient, FeedItem, Holding, PeerView, party_name};
+use crate::api::{
+    AuthSettings, ChainAuditEntry, DecmanClient, DomainGovAction, ExecuteParams, FeedItem,
+    GovAction, GovConfirmation, GovState, GovernanceConfirmations, Holding, KnownMember,
+    PartyAuthStatus, PeerView, party_name,
+};
+use crate::composer::{
+    self, Composer, ComposerContext, ComposerSubmit, FieldKind, SelectOption, TypeOption,
+};
 use crate::config::Profile;
 use crate::ui;
 
@@ -20,6 +30,7 @@ use crate::ui;
 pub struct DetailData {
     pub holdings: Result<Vec<Holding>, String>,
     pub audit: Result<Vec<AuditLogEntry>, String>,
+    pub gov_state: Result<Option<GovState>, String>,
 }
 
 /// How the main app exited: quit the program, or log out back to the menu.
@@ -93,6 +104,33 @@ pub enum Request {
         peer_ids: Vec<String>,
     },
     Detail(String),
+    Onboard {
+        prefix: String,
+        peer_ids: Vec<String>,
+    },
+    Kick {
+        party_id: String,
+        participant_id: String,
+        new_threshold: i32,
+        previous_threshold: i32,
+    },
+    CancelWorkflow(WorkflowKind),
+    RetryWorkflow(String),
+    ChainAudit(String),
+    AuthStatus,
+    TestAuth,
+    Governance {
+        party_id: String,
+        party_name: String,
+        governance_type: String,
+    },
+    GovAction(Box<GovActionRequest>),
+    OperatorInfo,
+    DeployContext {
+        party_id: String,
+        party_name: String,
+    },
+    DeploySubmit(Box<Value>),
 }
 
 /// A result delivered by a background worker.
@@ -104,6 +142,11 @@ pub enum Update {
     Compare(Result<PeerPackageComparison, String>),
     Action(Result<String, String>),
     Detail(DetailData),
+    ChainAudit(Result<Vec<ChainAuditEntry>, String>),
+    AuthStatus(Result<Vec<PartyAuthStatus>, String>),
+    Governance(Result<Box<GovView>, String>),
+    OperatorInfo(String),
+    DeployContext(Result<Box<DeployForm>, String>),
 }
 
 /// A DAR file picked from disk for upload / distribution.
@@ -117,6 +160,143 @@ pub struct PeerChoice {
     pub id: String,
     pub name: String,
     pub checked: bool,
+}
+
+/// The onboarding (create-party) form: a party-id prefix plus a tickable list
+/// of peers to invite. `cursor` 0 selects the prefix field; `1..=peers.len()`
+/// select a peer row.
+pub struct OnboardForm {
+    pub prefix: String,
+    pub peers: Vec<PeerChoice>,
+    pub cursor: usize,
+}
+
+impl OnboardForm {
+    /// Whether the prefix field (cursor 0) is focused.
+    fn on_prefix(&self) -> bool {
+        self.cursor == 0
+    }
+
+    /// The peer row index under the cursor, if a peer row is focused.
+    fn peer_index(&self) -> Option<usize> {
+        self.cursor.checked_sub(1)
+    }
+}
+
+/// A participant that may be kicked from a party (an owner of the party).
+pub struct KickCandidate {
+    pub participant_id: String,
+    pub label: String,
+}
+
+/// The kick-participant form: pick an owner to remove and set the new
+/// signing threshold for the remaining owners.
+pub struct KickForm {
+    pub party_id: String,
+    pub party_name: String,
+    pub previous_threshold: i32,
+    pub candidates: Vec<KickCandidate>,
+    pub selected: usize,
+    pub new_threshold: i32,
+    /// Highest threshold allowed after the kick (remaining owner count).
+    pub max_threshold: i32,
+}
+
+/// One pending governance item shown in the approvals overlay: an off-chain
+/// action or an on-chain (core-domain) proposal.
+pub enum GovItem {
+    OffChain(GovAction),
+    Domain(DomainGovAction),
+}
+
+/// State of the governance-approvals overlay for one party.
+pub struct GovView {
+    pub party_name: String,
+    pub party_id: String,
+    /// The party's governance type (`core_self` or `vault`), used for off-chain
+    /// actions and to refresh the overlay after a mutation.
+    pub governance_type: String,
+    pub rules_contract_id: String,
+    pub member_party_id: String,
+    pub threshold: i32,
+    pub items: Vec<GovItem>,
+    pub selected: usize,
+}
+
+/// A governance mutation to perform against a pending action.
+enum GovOp {
+    Confirm {
+        action: Value,
+        governance_type: String,
+        proposal_cid: Option<String>,
+    },
+    Execute {
+        action: Value,
+        confirmation_cids: Vec<String>,
+        governance_type: String,
+        proposal_cid: Option<String>,
+    },
+    Cancel {
+        confirmation_cid: String,
+        governance_type: String,
+    },
+    Expire {
+        confirmation_cid: String,
+        governance_type: String,
+    },
+    /// Propose a new on-chain action (`POST /governance/propose`).
+    Propose { proposal: Value },
+}
+
+/// Which composer the type picker is choosing for.
+#[derive(Clone, Copy)]
+pub enum ComposerKind {
+    /// A brand-new off-chain governance action (submitted via confirm).
+    Action,
+    /// A new on-chain governance proposal.
+    Proposal,
+}
+
+/// The action / proposal type picker, before a specific form is opened.
+pub struct ComposerPick {
+    pub kind: ComposerKind,
+    pub party_id: String,
+    pub party_name: String,
+    pub governance_type: String,
+    pub rules_contract_id: String,
+    pub default_threshold: i64,
+    pub options: Vec<TypeOption>,
+    pub selected: usize,
+}
+
+/// The governance-core contract deployment form. The member set, participant
+/// ids and package id are resolved from the server; the operator only edits the
+/// initial governance threshold and the proposal timeout (the contract's field
+/// structure is fixed, mirroring the web frontend's locked gov-core preset).
+pub struct DeployForm {
+    pub party_id: String,
+    pub party_name: String,
+    /// The `governance_core` package id (empty if the DAR is not vetted).
+    pub package_id: String,
+    pub operator_party: String,
+    /// Participant uids, aligned with `member_parties`.
+    pub participant_ids: Vec<String>,
+    /// Member party ids (the governance member set).
+    pub member_parties: Vec<String>,
+    pub threshold: String,
+    pub timeout_micros: String,
+    /// 0 = threshold, 1 = timeout, 2 = submit row.
+    pub cursor: usize,
+}
+
+/// A governance mutation plus the context needed to refresh the overlay after.
+pub struct GovActionRequest {
+    op: GovOp,
+    party_id: String,
+    party_name: String,
+    /// Party-level governance type, used to refresh the overlay after the op.
+    governance_type: String,
+    rules_contract_id: String,
 }
 
 /// A modal overlay drawn above the main UI.
@@ -142,6 +322,35 @@ pub enum Overlay {
         value: Value,
         scroll: u16,
     },
+    /// The onboarding (create-party) form.
+    Onboard(OnboardForm),
+    /// The kick-participant form.
+    Kick(KickForm),
+    /// A scrollable detail view of a feed item (workflow run or invitation).
+    /// Boxed: a feed item (with its workflow run) is large relative to the
+    /// other overlay variants.
+    FeedDetail {
+        item: Box<FeedItem>,
+        scroll: u16,
+    },
+    /// The on-chain governance audit trail for the open party.
+    ChainAudit {
+        entries: Vec<ChainAuditEntry>,
+        scroll: u16,
+    },
+    /// Per-party authentication status and rights.
+    Auth {
+        parties: Vec<PartyAuthStatus>,
+        scroll: u16,
+    },
+    /// The governance approvals list for a party (confirm / execute / revoke).
+    Governance(Box<GovView>),
+    /// The action / proposal type picker.
+    ComposerPick(Box<ComposerPick>),
+    /// A composer form for a chosen action / proposal variant.
+    Composer(Box<Composer>),
+    /// The governance-core contract deployment form.
+    Deploy(Box<DeployForm>),
 }
 
 /// The selectable top-level views.
@@ -247,6 +456,28 @@ fn filter_dars<'a>(dars: &'a [VettedPackageInfo], query: &str) -> Vec<&'a Vetted
         .collect()
 }
 
+/// Validate a decentralized-party id prefix, mirroring the web frontend's
+/// onboarding rules: starts with a letter, only `[A-Za-z0-9_-]`, ≤180 chars.
+fn validate_prefix(prefix: &str) -> Result<(), String> {
+    match prefix.chars().next() {
+        None => return Err("Party id prefix is required.".to_owned()),
+        Some(c) if !c.is_ascii_alphabetic() => {
+            return Err("Party id prefix must start with a letter.".to_owned());
+        }
+        Some(_) => {}
+    }
+    if prefix.chars().count() > 180 {
+        return Err("Party id prefix must be 180 characters or fewer.".to_owned());
+    }
+    if !prefix
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err("Party id prefix may only contain letters, digits, '-' and '_'.".to_owned());
+    }
+    Ok(())
+}
+
 /// Keep a table's selection in range after its data changes.
 fn clamp_selection(table: &mut TableState, len: usize) {
     let selected = match table.selected() {
@@ -279,8 +510,15 @@ pub fn spawn_workers(
             }
         };
         loop {
-            let result = client.fetch_peers().map_err(|error| format!("{error:#}"));
-            if peer_tx.send(Update::Peers(result)).is_err() {
+            // Re-probe peers and refresh the workflows feed on the same cadence
+            // the web frontend uses, so live progress and incoming invitations
+            // appear without the operator pressing refresh.
+            let peers = client.fetch_peers().map_err(|error| format!("{error:#}"));
+            if peer_tx.send(Update::Peers(peers)).is_err() {
+                break;
+            }
+            let feed = client.fetch_feed().map_err(|error| format!("{error:#}"));
+            if peer_tx.send(Update::Feed(feed)).is_err() {
                 break;
             }
             thread::sleep(peer_interval);
@@ -351,8 +589,392 @@ fn handle_request(client: &mut DecmanClient, request: Request) -> Update {
         Request::Detail(party_id) => Update::Detail(DetailData {
             holdings: client.fetch_holdings(&party_id).map_err(err),
             audit: client.fetch_audit(&party_id).map_err(err),
+            gov_state: client.fetch_governance_state(&party_id).map_err(err),
         }),
+        Request::ChainAudit(party_id) => {
+            Update::ChainAudit(client.fetch_chain_audit(&party_id).map_err(err))
+        }
+        Request::AuthStatus => Update::AuthStatus(client.fetch_auth_status().map_err(err)),
+        Request::TestAuth => Update::AuthStatus(
+            client
+                .test_auth()
+                .and_then(|()| client.fetch_auth_status())
+                .map_err(err),
+        ),
+        Request::Governance {
+            party_id,
+            party_name,
+            governance_type,
+        } => Update::Governance(
+            build_gov_view(client, &party_id, &party_name, &governance_type)
+                .map(Box::new)
+                .map_err(err),
+        ),
+        Request::GovAction(request) => {
+            let GovActionRequest {
+                op,
+                party_id,
+                party_name,
+                governance_type,
+                rules_contract_id,
+            } = *request;
+            let result = perform_gov_op(client, &party_id, &rules_contract_id, &op)
+                .and_then(|()| build_gov_view(client, &party_id, &party_name, &governance_type))
+                .map(Box::new)
+                .map_err(err);
+            Update::Governance(result)
+        }
+        Request::OperatorInfo => match client.fetch_operator_info() {
+            Ok(party_id) => Update::OperatorInfo(party_id),
+            // Operator info is best-effort prefill; swallow errors silently.
+            Err(_) => Update::OperatorInfo(String::new()),
+        },
+        Request::DeployContext {
+            party_id,
+            party_name,
+        } => Update::DeployContext(
+            build_deploy_context(client, &party_id, &party_name)
+                .map(Box::new)
+                .map_err(err),
+        ),
+        Request::DeploySubmit(body) => Update::Action(
+            client
+                .deploy_contracts(*body)
+                .map(|()| "Contracts workflow started".to_owned())
+                .map_err(err),
+        ),
+        Request::Onboard { prefix, peer_ids } => Update::Action(
+            client
+                .start_onboarding(&prefix, &peer_ids)
+                .map(|()| format!("Onboarding started for {prefix}"))
+                .map_err(err),
+        ),
+        Request::Kick {
+            party_id,
+            participant_id,
+            new_threshold,
+            previous_threshold,
+        } => Update::Action(
+            client
+                .kick_participant(
+                    &party_id,
+                    &participant_id,
+                    new_threshold,
+                    previous_threshold,
+                )
+                .map(|()| "Kick started".to_owned())
+                .map_err(err),
+        ),
+        Request::CancelWorkflow(kind) => Update::Action(
+            client
+                .cancel_workflow(kind)
+                .map(|()| "Workflow cancelled".to_owned())
+                .map_err(err),
+        ),
+        Request::RetryWorkflow(name) => Update::Action(
+            client
+                .retry_workflow(&name)
+                .map(|()| "Workflow retry started".to_owned())
+                .map_err(err),
+        ),
     }
+}
+
+/// Fetch the pending governance confirmations for a party and assemble the
+/// approvals view (off-chain actions first, then on-chain proposals).
+fn build_gov_view(
+    client: &mut DecmanClient,
+    party_id: &str,
+    party_name: &str,
+    governance_type: &str,
+) -> Result<GovView> {
+    let GovernanceConfirmations {
+        actions,
+        domain_actions,
+        threshold,
+        rules_contract_id,
+        member_party_id,
+    } = client.fetch_governance(party_id)?;
+    let items = actions
+        .into_iter()
+        .map(GovItem::OffChain)
+        .chain(domain_actions.into_iter().map(GovItem::Domain))
+        .collect();
+    Ok(GovView {
+        party_name: party_name.to_owned(),
+        party_id: party_id.to_owned(),
+        governance_type: governance_type.to_owned(),
+        rules_contract_id: rules_contract_id.unwrap_or_default(),
+        member_party_id: member_party_id.unwrap_or_default(),
+        threshold,
+        items,
+        selected: 0,
+    })
+}
+
+/// Perform one governance mutation against the API.
+fn perform_gov_op(
+    client: &mut DecmanClient,
+    party_id: &str,
+    rules_contract_id: &str,
+    op: &GovOp,
+) -> Result<()> {
+    match op {
+        GovOp::Confirm {
+            action,
+            governance_type,
+            proposal_cid,
+        } => client.confirm_action(
+            party_id,
+            rules_contract_id,
+            action,
+            governance_type,
+            proposal_cid.as_deref(),
+        ),
+        GovOp::Execute {
+            action,
+            confirmation_cids,
+            governance_type,
+            proposal_cid,
+        } => client.execute_action(
+            party_id,
+            rules_contract_id,
+            &ExecuteParams {
+                action: action.clone(),
+                confirmation_cids: confirmation_cids.clone(),
+                governance_type: governance_type.clone(),
+                proposal_cid: proposal_cid.clone(),
+                disclosed: Vec::new(),
+            },
+        ),
+        GovOp::Cancel {
+            confirmation_cid,
+            governance_type,
+        } => client.cancel_confirmation(party_id, confirmation_cid, governance_type),
+        GovOp::Expire {
+            confirmation_cid,
+            governance_type,
+        } => client.expire_confirmation(
+            party_id,
+            rules_contract_id,
+            confirmation_cid,
+            governance_type,
+        ),
+        GovOp::Propose { proposal } => client.propose_action(party_id, rules_contract_id, proposal),
+    }
+}
+
+/// The contract ids of a set of confirmations, for the execute call.
+fn confirmation_cids(confirmations: &[GovConfirmation]) -> Vec<String> {
+    confirmations
+        .iter()
+        .map(|confirmation| confirmation.contract_id.clone())
+        .collect()
+}
+
+/// The placeholder action sent with on-chain (`core_domain`) confirm/execute —
+/// the server builds the real choice from `proposal_cid` and ignores this.
+fn placeholder_action() -> Value {
+    json!({ "type": "governance_set_threshold", "new_threshold": 0 })
+}
+
+/// Resolve the package id, members and operator needed to deploy governance
+/// core for a party, and build the deployment form with sensible defaults.
+fn build_deploy_context(
+    client: &mut DecmanClient,
+    party_id: &str,
+    party_name: &str,
+) -> Result<DeployForm> {
+    let packages = client.fetch_packages(party_id)?;
+    let known = client.fetch_known_members(party_id)?;
+    // Operator party is best-effort prefill — a deploy can still be sent without.
+    let operator_party = client.fetch_operator_info().unwrap_or_default();
+
+    let mut participant_ids = Vec::new();
+    let mut member_parties = Vec::new();
+    for KnownMember {
+        participant_uid,
+        member_party_id,
+    } in known
+    {
+        if let Some(party) = member_party_id.filter(|party| !party.is_empty()) {
+            participant_ids.push(participant_uid);
+            member_parties.push(party);
+        }
+    }
+
+    // Default threshold ≈ a 2/3 majority, at least 2 (matches the web frontend).
+    let count = i64::try_from(member_parties.len()).unwrap_or(0);
+    let threshold = ((count * 2 + 2) / 3).max(2);
+
+    Ok(DeployForm {
+        party_id: party_id.to_owned(),
+        party_name: party_name.to_owned(),
+        package_id: packages.governance_core.unwrap_or_default(),
+        operator_party,
+        participant_ids,
+        member_parties,
+        threshold: threshold.to_string(),
+        timeout_micros: "86400000000".to_owned(),
+        cursor: 0,
+    })
+}
+
+/// Build the `POST /contracts` body for a governance-core deployment, or a
+/// human error describing why it cannot be submitted.
+fn build_contracts_request(form: &DeployForm) -> Result<Value, String> {
+    let threshold: i64 = form
+        .threshold
+        .trim()
+        .parse()
+        .map_err(|_| "Threshold must be a whole number".to_owned())?;
+    let timeout: i64 = form
+        .timeout_micros
+        .trim()
+        .parse()
+        .map_err(|_| "Timeout must be a whole number".to_owned())?;
+    if form.package_id.is_empty() {
+        return Err(
+            "Unknown governance-core package — vet the governance-core DAR first.".to_owned(),
+        );
+    }
+    if form.member_parties.is_empty() {
+        return Err("No governance members resolved — peers may be unreachable.".to_owned());
+    }
+    Ok(json!({
+        "decentralized_party_id": form.party_id,
+        "participant_ids": form.participant_ids,
+        "participant_parties": form.member_parties,
+        "operator_party": form.operator_party,
+        "contracts": [{
+            "id": "create-governance-rules",
+            "name": "GovernanceRules",
+            "package_id": form.package_id,
+            "module_name": "Governance.Rules",
+            "entity_name": "GovernanceRules",
+            "fields": [
+                { "type": "decentralized_party" },
+                { "type": "party_set", "parties": form.member_parties },
+                { "type": "governance_threshold", "value": threshold },
+                { "type": "rel_time", "microseconds": timeout },
+                { "type": "optional", "inner": { "type": "party_set", "parties": [] } }
+            ]
+        }]
+    }))
+}
+
+/// The governance type for a party's rules contract, or `None` when the party
+/// has no governance rules contract. Mirrors the web frontend's classification.
+fn party_governance_type(party: &DecentralizedParty) -> Option<&'static str> {
+    party.contracts.iter().find_map(|contract| {
+        let template = contract.template_id.as_str();
+        if template == "Governance.Rules:GovernanceRules" {
+            Some("core_self")
+        } else if template.contains("VaultGovernanceRules") || template.contains("VaultGovernance")
+        {
+            Some("vault")
+        } else {
+            None
+        }
+    })
+}
+
+/// Current unix time in seconds (0 if the clock is before the epoch).
+fn now_secs() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .and_then(|d| i64::try_from(d.as_secs()).ok())
+        .unwrap_or(0)
+}
+
+/// The select option value one step forward / back from `current`.
+fn next_select_value(options: &[SelectOption], current: &str, forward: bool) -> String {
+    if options.is_empty() {
+        return current.to_owned();
+    }
+    let index = options
+        .iter()
+        .position(|option| option.value == current)
+        .unwrap_or(0);
+    let len = options.len();
+    let next = if forward {
+        (index + 1) % len
+    } else {
+        (index + len - 1) % len
+    };
+    options[next].value.to_owned()
+}
+
+/// Handle a key in the composer form. Returns `true` when the form was
+/// submitted (Enter on the virtual submit row).
+fn composer_key(composer: &mut Composer, key: KeyEvent) -> bool {
+    let field_count = composer.fields.len();
+    let multiline = composer
+        .fields
+        .get(composer.cursor)
+        .is_some_and(|field| matches!(field.kind, FieldKind::List | FieldKind::Rows(_)));
+
+    match key.code {
+        KeyCode::Up => {
+            composer.cursor = composer.cursor.saturating_sub(1);
+            return false;
+        }
+        KeyCode::Down | KeyCode::Tab => {
+            if composer.cursor < field_count {
+                composer.cursor += 1;
+            }
+            return false;
+        }
+        KeyCode::Enter if composer.cursor >= field_count => return true,
+        // Enter advances to the next field, except in a multi-line field where
+        // it inserts a newline (handled below).
+        KeyCode::Enter if !multiline => {
+            if composer.cursor < field_count {
+                composer.cursor += 1;
+            }
+            return false;
+        }
+        _ => {}
+    }
+
+    if let Some(field) = composer.fields.get_mut(composer.cursor) {
+        match &field.kind {
+            FieldKind::Bool => {
+                if matches!(
+                    key.code,
+                    KeyCode::Left | KeyCode::Right | KeyCode::Char(' ')
+                ) {
+                    field.value = if field.value == "true" {
+                        "false".to_owned()
+                    } else {
+                        "true".to_owned()
+                    };
+                }
+            }
+            FieldKind::Select(options) => match key.code {
+                KeyCode::Left => field.value = next_select_value(options, &field.value, false),
+                KeyCode::Right | KeyCode::Char(' ') => {
+                    field.value = next_select_value(options, &field.value, true);
+                }
+                _ => {}
+            },
+            FieldKind::Text | FieldKind::Int | FieldKind::List | FieldKind::Rows(_) => {
+                match key.code {
+                    KeyCode::Char(c) => field.value.push(c),
+                    KeyCode::Backspace => {
+                        field.value.pop();
+                    }
+                    // Only reached for multi-line fields (single-line Enter is
+                    // handled above as field navigation).
+                    KeyCode::Enter => field.value.push('\n'),
+                    _ => {}
+                }
+            }
+        }
+    }
+    false
 }
 
 /// Application state for the decman-cli terminal UI.
@@ -384,6 +1006,8 @@ pub struct App {
     audit_table: TableState,
     tick: usize,
     can_logout: bool,
+    /// The operator party id, prefetched for composer prefill (empty if unknown).
+    operator_party: String,
     should_quit: bool,
     should_logout: bool,
 }
@@ -418,6 +1042,7 @@ impl App {
             audit_table: TableState::default(),
             tick: 0,
             can_logout,
+            operator_party: String::new(),
             should_quit: false,
             should_logout: false,
         }
@@ -511,6 +1136,8 @@ impl App {
         let _ = self.requests.send(Request::Parties);
         let _ = self.requests.send(Request::Dars);
         let _ = self.requests.send(Request::Feed);
+        // Prefetch the operator party for composer prefill.
+        let _ = self.requests.send(Request::OperatorInfo);
 
         while !self.should_quit && !self.should_logout {
             self.tick = self.tick.wrapping_add(1);
@@ -554,7 +1181,12 @@ impl App {
                     clamp_selection(&mut self.feed_table, self.feed.len());
                     self.feed_status = Status::Loaded;
                 }
-                Update::Feed(Err(error)) => self.feed_status = Status::Error(error),
+                // Keep the last feed on a transient poll error; only surface it
+                // when there is nothing to show (mirrors the peer-poll behavior).
+                Update::Feed(Err(error)) if self.feed.is_empty() => {
+                    self.feed_status = Status::Error(error);
+                }
+                Update::Feed(Err(_)) => {}
                 Update::Peers(Ok(peers)) => {
                     self.peers = peers;
                     clamp_selection(&mut self.peers_table, self.peers.len());
@@ -586,6 +1218,39 @@ impl App {
                 Update::Action(Err(error)) => {
                     if matches!(self.overlay, Overlay::Busy(_)) {
                         self.overlay = Overlay::Message(format!("Failed: {error}"));
+                    }
+                }
+                Update::ChainAudit(result) => {
+                    if matches!(self.overlay, Overlay::Busy(_)) {
+                        self.overlay = match result {
+                            Ok(entries) => Overlay::ChainAudit { entries, scroll: 0 },
+                            Err(error) => Overlay::Message(error),
+                        };
+                    }
+                }
+                Update::AuthStatus(result) => {
+                    if matches!(self.overlay, Overlay::Busy(_) | Overlay::Auth { .. }) {
+                        self.overlay = match result {
+                            Ok(parties) => Overlay::Auth { parties, scroll: 0 },
+                            Err(error) => Overlay::Message(error),
+                        };
+                    }
+                }
+                Update::Governance(result) => {
+                    if matches!(self.overlay, Overlay::Busy(_) | Overlay::Governance(_)) {
+                        self.overlay = match result {
+                            Ok(view) => Overlay::Governance(view),
+                            Err(error) => Overlay::Message(error),
+                        };
+                    }
+                }
+                Update::OperatorInfo(party_id) => self.operator_party = party_id,
+                Update::DeployContext(result) => {
+                    if matches!(self.overlay, Overlay::Busy(_)) {
+                        self.overlay = match result {
+                            Ok(form) => Overlay::Deploy(form),
+                            Err(error) => Overlay::Message(error),
+                        };
                     }
                 }
                 // Ignore late detail results after the view was closed.
@@ -635,6 +1300,8 @@ impl App {
             (KeyCode::Esc, _) => self.should_quit = true,
             (KeyCode::Char('/'), _) if self.active_tab.searchable() => self.searching = true,
             (KeyCode::Char('r'), _) => self.refresh_active(),
+            // View authentication status for all parties (any tab).
+            (KeyCode::Char('A'), _) => self.open_auth(),
             (KeyCode::Tab | KeyCode::Right, _) => self.switch_to(self.active_tab.next()),
             (KeyCode::BackTab | KeyCode::Left, _) => self.switch_to(self.active_tab.previous()),
             (KeyCode::Char('1'), _) => self.switch_to(Tab::Parties),
@@ -645,6 +1312,8 @@ impl App {
             (KeyCode::Up | KeyCode::Char('k'), _) => self.select_previous(),
             // Open the party detail view.
             (KeyCode::Enter, _) if self.active_tab == Tab::Parties => self.open_party_detail(),
+            // Start onboarding a new decentralized party.
+            (KeyCode::Char('n'), _) if self.active_tab == Tab::Parties => self.open_onboard(),
             // Workflows actions.
             (KeyCode::Char('a'), _) if self.active_tab == Tab::Workflows => {
                 self.invitation_action(true);
@@ -653,6 +1322,9 @@ impl App {
                 self.invitation_action(false);
             }
             (KeyCode::Char('d'), _) if self.active_tab == Tab::Workflows => self.dismiss_run(),
+            (KeyCode::Char('c'), _) if self.active_tab == Tab::Workflows => self.cancel_run(),
+            (KeyCode::Char('t'), _) if self.active_tab == Tab::Workflows => self.retry_run(),
+            (KeyCode::Enter, _) if self.active_tab == Tab::Workflows => self.open_feed_detail(),
             // Dars actions.
             (KeyCode::Char('c'), _) if self.active_tab == Tab::Dars => self.start_compare(),
             (KeyCode::Char('u'), _) if self.active_tab == Tab::Dars => self.start_upload(),
@@ -668,6 +1340,18 @@ impl App {
             None,
             Close,
             Distribute,
+            Onboard,
+            Kick,
+            TestAuth,
+            GovConfirm,
+            GovExecute,
+            GovRevoke,
+            GovExpire,
+            ComposeAction,
+            ComposeProposal,
+            OpenComposer,
+            SubmitComposer,
+            SubmitDeploy,
         }
 
         let mut act = Act::None;
@@ -688,10 +1372,125 @@ impl App {
                 KeyCode::Enter => act = Act::Distribute,
                 _ => {}
             },
-            Overlay::Compare { scroll, .. } | Overlay::Json { scroll, .. } => match key.code {
+            Overlay::Compare { scroll, .. }
+            | Overlay::Json { scroll, .. }
+            | Overlay::FeedDetail { scroll, .. }
+            | Overlay::ChainAudit { scroll, .. } => match key.code {
                 KeyCode::Esc | KeyCode::Enter | KeyCode::Char('q') => act = Act::Close,
                 KeyCode::Up | KeyCode::Char('k') => *scroll = scroll.saturating_sub(1),
                 KeyCode::Down | KeyCode::Char('j') => *scroll = scroll.saturating_add(1),
+                _ => {}
+            },
+            Overlay::Onboard(form) => match key.code {
+                KeyCode::Esc => act = Act::Close,
+                KeyCode::Enter => act = Act::Onboard,
+                KeyCode::Up => form.cursor = form.cursor.saturating_sub(1),
+                KeyCode::Down | KeyCode::Tab => {
+                    if form.cursor < form.peers.len() {
+                        form.cursor += 1;
+                    }
+                }
+                KeyCode::Char(' ') if !form.on_prefix() => {
+                    if let Some(peer) = form.peer_index().and_then(|i| form.peers.get_mut(i)) {
+                        peer.checked = !peer.checked;
+                    }
+                }
+                KeyCode::Backspace if form.on_prefix() => {
+                    form.prefix.pop();
+                }
+                KeyCode::Char(c) if form.on_prefix() => form.prefix.push(c),
+                _ => {}
+            },
+            Overlay::Kick(form) => match key.code {
+                KeyCode::Esc => act = Act::Close,
+                KeyCode::Enter => act = Act::Kick,
+                KeyCode::Up | KeyCode::Char('k') => {
+                    form.selected = form.selected.saturating_sub(1);
+                }
+                KeyCode::Down | KeyCode::Char('j') => {
+                    if form.selected + 1 < form.candidates.len() {
+                        form.selected += 1;
+                    }
+                }
+                KeyCode::Left | KeyCode::Char('-') => {
+                    form.new_threshold = (form.new_threshold - 1).max(1);
+                }
+                KeyCode::Right | KeyCode::Char('+') => {
+                    form.new_threshold = (form.new_threshold + 1).min(form.max_threshold);
+                }
+                _ => {}
+            },
+            Overlay::Auth { scroll, .. } => match key.code {
+                KeyCode::Esc | KeyCode::Char('q') => act = Act::Close,
+                KeyCode::Char('t') => act = Act::TestAuth,
+                KeyCode::Up | KeyCode::Char('k') => *scroll = scroll.saturating_sub(1),
+                KeyCode::Down | KeyCode::Char('j') => *scroll = scroll.saturating_add(1),
+                _ => {}
+            },
+            Overlay::Governance(view) => match key.code {
+                KeyCode::Esc | KeyCode::Char('q') => act = Act::Close,
+                KeyCode::Up | KeyCode::Char('k') => {
+                    view.selected = view.selected.saturating_sub(1);
+                }
+                KeyCode::Down | KeyCode::Char('j') => {
+                    if view.selected + 1 < view.items.len() {
+                        view.selected += 1;
+                    }
+                }
+                KeyCode::Char('c') => act = Act::GovConfirm,
+                KeyCode::Char('e') => act = Act::GovExecute,
+                KeyCode::Char('r') => act = Act::GovRevoke,
+                KeyCode::Char('x') => act = Act::GovExpire,
+                KeyCode::Char('n') => act = Act::ComposeAction,
+                KeyCode::Char('p') => act = Act::ComposeProposal,
+                _ => {}
+            },
+            Overlay::ComposerPick(pick) => match key.code {
+                KeyCode::Esc | KeyCode::Char('q') => act = Act::Close,
+                KeyCode::Up => pick.selected = pick.selected.saturating_sub(1),
+                KeyCode::Down => {
+                    if pick.selected + 1 < pick.options.len() {
+                        pick.selected += 1;
+                    }
+                }
+                KeyCode::Enter => act = Act::OpenComposer,
+                _ => {}
+            },
+            Overlay::Composer(composer) => {
+                if key.code == KeyCode::Esc {
+                    act = Act::Close;
+                } else if composer_key(composer, key) {
+                    act = Act::SubmitComposer;
+                }
+            }
+            Overlay::Deploy(form) => match key.code {
+                KeyCode::Esc => act = Act::Close,
+                KeyCode::Up => form.cursor = form.cursor.saturating_sub(1),
+                KeyCode::Down | KeyCode::Tab => {
+                    if form.cursor < 2 {
+                        form.cursor += 1;
+                    }
+                }
+                KeyCode::Enter if form.cursor >= 2 => act = Act::SubmitDeploy,
+                KeyCode::Enter => {
+                    if form.cursor < 2 {
+                        form.cursor += 1;
+                    }
+                }
+                KeyCode::Char(c) if c.is_ascii_digit() => match form.cursor {
+                    0 => form.threshold.push(c),
+                    1 => form.timeout_micros.push(c),
+                    _ => {}
+                },
+                KeyCode::Backspace => match form.cursor {
+                    0 => {
+                        form.threshold.pop();
+                    }
+                    1 => {
+                        form.timeout_micros.pop();
+                    }
+                    _ => {}
+                },
                 _ => {}
             },
             Overlay::Message(_) | Overlay::Busy(_) => {
@@ -706,6 +1505,18 @@ impl App {
             Act::None => {}
             Act::Close => self.overlay = Overlay::None,
             Act::Distribute => self.confirm_distribute(),
+            Act::Onboard => self.confirm_onboard(),
+            Act::Kick => self.confirm_kick(),
+            Act::TestAuth => self.run_auth_test(),
+            Act::GovConfirm => self.gov_confirm(),
+            Act::GovExecute => self.gov_execute(),
+            Act::GovRevoke => self.gov_revoke(),
+            Act::GovExpire => self.gov_expire(),
+            Act::ComposeAction => self.open_composer_pick(ComposerKind::Action),
+            Act::ComposeProposal => self.open_composer_pick(ComposerKind::Proposal),
+            Act::OpenComposer => self.open_composer(),
+            Act::SubmitComposer => self.submit_composer(),
+            Act::SubmitDeploy => self.submit_deploy(),
         }
     }
 
@@ -769,6 +1580,14 @@ impl App {
             }
             // Open the selected audit entry's JSON in a modal.
             KeyCode::Enter | KeyCode::Char(' ') => self.open_audit_json(),
+            // Kick a participant from this party.
+            KeyCode::Char('K') => self.open_kick(),
+            // View the on-chain governance audit trail.
+            KeyCode::Char('c') => self.open_chain_audit(),
+            // Open the governance approvals list (confirm / execute / revoke).
+            KeyCode::Char('g') => self.open_governance(),
+            // Deploy governance-core contracts for this party.
+            KeyCode::Char('D') => self.open_deploy(),
             _ => {}
         }
     }
@@ -829,6 +1648,515 @@ impl App {
         };
         let _ = self.requests.send(Request::Dismiss(name));
         self.overlay = Overlay::Busy("Dismissing workflow…".to_owned());
+    }
+
+    /// Cancel the selected workflow run (only valid for an in-progress run this
+    /// node coordinates).
+    fn cancel_run(&mut self) {
+        let kind = match self.selected_feed_item() {
+            Some(FeedItem::Run(run))
+                if run.status == WorkflowProgress::InProgress
+                    && run.role == WorkflowRole::Coordinator =>
+            {
+                run.kind
+            }
+            Some(FeedItem::Run(_)) => {
+                self.overlay = Overlay::Message(
+                    "Only in-progress workflows you coordinate can be cancelled.".to_owned(),
+                );
+                return;
+            }
+            _ => return,
+        };
+        let _ = self.requests.send(Request::CancelWorkflow(kind));
+        self.overlay = Overlay::Busy("Cancelling workflow…".to_owned());
+    }
+
+    /// Retry the selected workflow run (only valid for a failed run this node
+    /// coordinates).
+    fn retry_run(&mut self) {
+        let name = match self.selected_feed_item() {
+            Some(FeedItem::Run(run))
+                if run.status == WorkflowProgress::Failed
+                    && run.role == WorkflowRole::Coordinator =>
+            {
+                run.instance_name.clone()
+            }
+            Some(FeedItem::Run(_)) => {
+                self.overlay = Overlay::Message(
+                    "Only failed workflows you coordinate can be retried.".to_owned(),
+                );
+                return;
+            }
+            _ => return,
+        };
+        let _ = self.requests.send(Request::RetryWorkflow(name));
+        self.overlay = Overlay::Busy("Retrying workflow…".to_owned());
+    }
+
+    /// Open the action / proposal type picker from the governance overlay.
+    fn open_composer_pick(&mut self, kind: ComposerKind) {
+        let pick = {
+            let Overlay::Governance(view) = &self.overlay else {
+                return;
+            };
+            if matches!(kind, ComposerKind::Proposal) && view.governance_type != "core_self" {
+                None
+            } else {
+                let options = match kind {
+                    ComposerKind::Action => composer::action_types(&view.governance_type),
+                    ComposerKind::Proposal => composer::proposal_types(),
+                };
+                Some(ComposerPick {
+                    kind,
+                    party_id: view.party_id.clone(),
+                    party_name: view.party_name.clone(),
+                    governance_type: view.governance_type.clone(),
+                    rules_contract_id: view.rules_contract_id.clone(),
+                    default_threshold: i64::from(view.threshold),
+                    options,
+                    selected: 0,
+                })
+            }
+        };
+        self.overlay = match pick {
+            Some(pick) => Overlay::ComposerPick(Box::new(pick)),
+            None => Overlay::Message(
+                "Proposals are only available on core-self governance parties.".to_owned(),
+            ),
+        };
+    }
+
+    /// Open the composer form for the type selected in the picker.
+    fn open_composer(&mut self) {
+        let composer = {
+            let Overlay::ComposerPick(pick) = &self.overlay else {
+                return;
+            };
+            let Some(option) = pick.options.get(pick.selected) else {
+                return;
+            };
+            let ctx = ComposerContext {
+                party_id: pick.party_id.clone(),
+                operator_party: self.operator_party.clone(),
+                default_threshold: pick.default_threshold,
+            };
+            let (fields, submit) = match pick.kind {
+                ComposerKind::Action => (
+                    composer::fields_for_action(option.key, &ctx),
+                    ComposerSubmit::Confirm,
+                ),
+                ComposerKind::Proposal => (
+                    composer::fields_for_proposal(option.key, &ctx),
+                    ComposerSubmit::Propose,
+                ),
+            };
+            Composer {
+                title: option.label.to_owned(),
+                action_type: option.key,
+                submit,
+                party_id: pick.party_id.clone(),
+                party_name: pick.party_name.clone(),
+                governance_type: pick.governance_type.clone(),
+                rules_contract_id: pick.rules_contract_id.clone(),
+                fields,
+                cursor: 0,
+            }
+        };
+        self.overlay = Overlay::Composer(Box::new(composer));
+    }
+
+    /// Validate the composer form and submit it (confirm or propose).
+    fn submit_composer(&mut self) {
+        let outcome = {
+            let Overlay::Composer(composer) = &self.overlay else {
+                return;
+            };
+            composer::build_payload(composer).map(|payload| {
+                let op = match composer.submit {
+                    ComposerSubmit::Confirm => GovOp::Confirm {
+                        action: payload,
+                        governance_type: composer.governance_type.clone(),
+                        proposal_cid: None,
+                    },
+                    ComposerSubmit::Propose => GovOp::Propose { proposal: payload },
+                };
+                GovActionRequest {
+                    op,
+                    party_id: composer.party_id.clone(),
+                    party_name: composer.party_name.clone(),
+                    governance_type: composer.governance_type.clone(),
+                    rules_contract_id: composer.rules_contract_id.clone(),
+                }
+            })
+        };
+        match outcome {
+            Ok(request) => {
+                let _ = self.requests.send(Request::GovAction(Box::new(request)));
+                self.overlay = Overlay::Busy("Submitting…".to_owned());
+            }
+            Err(error) => self.overlay = Overlay::Message(error),
+        }
+    }
+
+    /// Start a governance-core contract deployment for the party in detail view.
+    fn open_deploy(&mut self) {
+        let Some(party) = self.detail.as_ref() else {
+            return;
+        };
+        if party_governance_type(party).is_some() {
+            self.overlay = Overlay::Message(
+                "This party already has governance contracts deployed.".to_owned(),
+            );
+            return;
+        }
+        let _ = self.requests.send(Request::DeployContext {
+            party_id: party.party_id.to_string(),
+            party_name: party_name(party).to_owned(),
+        });
+        self.overlay = Overlay::Busy("Preparing contract deployment…".to_owned());
+    }
+
+    /// Validate the deploy form and start the contracts workflow.
+    fn submit_deploy(&mut self) {
+        let outcome = {
+            let Overlay::Deploy(form) = &self.overlay else {
+                return;
+            };
+            build_contracts_request(form)
+        };
+        match outcome {
+            Ok(body) => {
+                let _ = self.requests.send(Request::DeploySubmit(Box::new(body)));
+                self.overlay = Overlay::Busy("Deploying contracts…".to_owned());
+            }
+            Err(error) => self.overlay = Overlay::Message(error),
+        }
+    }
+
+    /// Fetch and show the per-party authentication status overlay.
+    fn open_auth(&mut self) {
+        let _ = self.requests.send(Request::AuthStatus);
+        self.overlay = Overlay::Busy("Loading authentication status…".to_owned());
+    }
+
+    /// Re-test authentication for all parties, then refresh the auth overlay.
+    fn run_auth_test(&mut self) {
+        let _ = self.requests.send(Request::TestAuth);
+        self.overlay = Overlay::Busy("Testing authentication…".to_owned());
+    }
+
+    /// Open the governance approvals list for the party in the detail view.
+    fn open_governance(&mut self) {
+        let Some(party) = self.detail.as_ref() else {
+            return;
+        };
+        let Some(governance_type) = party_governance_type(party) else {
+            self.overlay =
+                Overlay::Message("This party has no governance rules contract.".to_owned());
+            return;
+        };
+        let _ = self.requests.send(Request::Governance {
+            party_id: party.party_id.to_string(),
+            party_name: party_name(party).to_owned(),
+            governance_type: governance_type.to_owned(),
+        });
+        self.overlay = Overlay::Busy("Loading governance approvals…".to_owned());
+    }
+
+    /// Build a governance-action request for the selected item, applying `op`.
+    fn gov_request(view: &GovView, op: GovOp) -> GovActionRequest {
+        GovActionRequest {
+            op,
+            party_id: view.party_id.clone(),
+            party_name: view.party_name.clone(),
+            governance_type: view.governance_type.clone(),
+            rules_contract_id: view.rules_contract_id.clone(),
+        }
+    }
+
+    /// Add this node's confirmation to the selected governance action.
+    fn gov_confirm(&mut self) {
+        let request = {
+            let Overlay::Governance(view) = &self.overlay else {
+                return;
+            };
+            let Some(item) = view.items.get(view.selected) else {
+                return;
+            };
+            let op = match item {
+                GovItem::OffChain(action) => GovOp::Confirm {
+                    action: action.action.clone(),
+                    governance_type: view.governance_type.clone(),
+                    proposal_cid: None,
+                },
+                GovItem::Domain(domain) => GovOp::Confirm {
+                    action: placeholder_action(),
+                    governance_type: "core_domain".to_owned(),
+                    proposal_cid: Some(domain.proposal_cid.clone()),
+                },
+            };
+            Self::gov_request(view, op)
+        };
+        let _ = self.requests.send(Request::GovAction(Box::new(request)));
+        self.overlay = Overlay::Busy("Confirming action…".to_owned());
+    }
+
+    /// Execute the selected governance action once its threshold is met.
+    fn gov_execute(&mut self) {
+        let (can_execute, request) = {
+            let Overlay::Governance(view) = &self.overlay else {
+                return;
+            };
+            let Some(item) = view.items.get(view.selected) else {
+                return;
+            };
+            let (can_execute, op) = match item {
+                GovItem::OffChain(action) => (
+                    action.can_execute,
+                    GovOp::Execute {
+                        action: action.action.clone(),
+                        confirmation_cids: confirmation_cids(&action.confirmations),
+                        governance_type: view.governance_type.clone(),
+                        proposal_cid: None,
+                    },
+                ),
+                GovItem::Domain(domain) => (
+                    domain.can_execute,
+                    GovOp::Execute {
+                        action: placeholder_action(),
+                        confirmation_cids: confirmation_cids(&domain.confirmations),
+                        governance_type: "core_domain".to_owned(),
+                        proposal_cid: Some(domain.proposal_cid.clone()),
+                    },
+                ),
+            };
+            (can_execute, Self::gov_request(view, op))
+        };
+        if !can_execute {
+            self.overlay =
+                Overlay::Message("Not enough confirmations to execute this action yet.".to_owned());
+            return;
+        }
+        let _ = self.requests.send(Request::GovAction(Box::new(request)));
+        self.overlay = Overlay::Busy("Executing action…".to_owned());
+    }
+
+    /// Revoke this node's own confirmation on the selected governance action.
+    fn gov_revoke(&mut self) {
+        let request = {
+            let Overlay::Governance(view) = &self.overlay else {
+                return;
+            };
+            let Some(item) = view.items.get(view.selected) else {
+                return;
+            };
+            let (confirmations, governance_type) = match item {
+                GovItem::OffChain(action) => (&action.confirmations, view.governance_type.clone()),
+                GovItem::Domain(domain) => (&domain.confirmations, "core_domain".to_owned()),
+            };
+            confirmations
+                .iter()
+                .find(|confirmation| confirmation.confirming_party == view.member_party_id)
+                .map(|mine| {
+                    Self::gov_request(
+                        view,
+                        GovOp::Cancel {
+                            confirmation_cid: mine.contract_id.clone(),
+                            governance_type,
+                        },
+                    )
+                })
+        };
+        match request {
+            Some(request) => {
+                let _ = self.requests.send(Request::GovAction(Box::new(request)));
+                self.overlay = Overlay::Busy("Revoking confirmation…".to_owned());
+            }
+            None => {
+                self.overlay = Overlay::Message("You have no confirmation to revoke.".to_owned());
+            }
+        }
+    }
+
+    /// Expire the first stale confirmation on the selected governance action.
+    fn gov_expire(&mut self) {
+        let now = now_secs();
+        let request = {
+            let Overlay::Governance(view) = &self.overlay else {
+                return;
+            };
+            let Some(item) = view.items.get(view.selected) else {
+                return;
+            };
+            let (confirmations, governance_type) = match item {
+                GovItem::OffChain(action) => (&action.confirmations, view.governance_type.clone()),
+                GovItem::Domain(domain) => (&domain.confirmations, "core_domain".to_owned()),
+            };
+            confirmations
+                .iter()
+                .find(|confirmation| confirmation.expires_at > 0 && confirmation.expires_at <= now)
+                .map(|stale| {
+                    Self::gov_request(
+                        view,
+                        GovOp::Expire {
+                            confirmation_cid: stale.contract_id.clone(),
+                            governance_type,
+                        },
+                    )
+                })
+        };
+        match request {
+            Some(request) => {
+                let _ = self.requests.send(Request::GovAction(Box::new(request)));
+                self.overlay = Overlay::Busy("Expiring confirmation…".to_owned());
+            }
+            None => {
+                self.overlay =
+                    Overlay::Message("No expired confirmations on this action.".to_owned());
+            }
+        }
+    }
+
+    /// Fetch and show the on-chain governance audit trail for the open party.
+    fn open_chain_audit(&mut self) {
+        if let Some(party) = self.detail.as_ref() {
+            let _ = self
+                .requests
+                .send(Request::ChainAudit(party.party_id.to_string()));
+            self.overlay = Overlay::Busy("Loading on-chain audit…".to_owned());
+        }
+    }
+
+    /// Open a scrollable detail view for the selected feed item.
+    fn open_feed_detail(&mut self) {
+        if let Some(item) = self.selected_feed_item() {
+            self.overlay = Overlay::FeedDetail {
+                item: Box::new(item.clone()),
+                scroll: 0,
+            };
+        }
+    }
+
+    /// Open the onboarding form, seeded with all configured peers (self
+    /// excluded), each ticked by default — matching the web frontend.
+    fn open_onboard(&mut self) {
+        let peers: Vec<PeerChoice> = self
+            .peers
+            .iter()
+            .filter(|peer| !peer.is_self)
+            .map(|peer| PeerChoice {
+                id: peer.participant_id.clone(),
+                name: peer.name.clone(),
+                checked: true,
+            })
+            .collect();
+        if peers.is_empty() {
+            self.overlay = Overlay::Message(
+                "No peers available to onboard with. Configure peers first.".to_owned(),
+            );
+            return;
+        }
+        self.overlay = Overlay::Onboard(OnboardForm {
+            prefix: String::new(),
+            peers,
+            cursor: 0,
+        });
+    }
+
+    /// Validate the onboarding form and send the start request.
+    fn confirm_onboard(&mut self) {
+        let Overlay::Onboard(form) = &self.overlay else {
+            return;
+        };
+        let prefix = form.prefix.trim().to_owned();
+        if let Err(message) = validate_prefix(&prefix) {
+            self.overlay = Overlay::Message(message);
+            return;
+        }
+        let peer_ids: Vec<String> = form
+            .peers
+            .iter()
+            .filter(|peer| peer.checked)
+            .map(|peer| peer.id.clone())
+            .collect();
+        if peer_ids.is_empty() {
+            self.overlay = Overlay::Message("Select at least one peer to onboard.".to_owned());
+            return;
+        }
+        let _ = self.requests.send(Request::Onboard {
+            prefix: prefix.clone(),
+            peer_ids,
+        });
+        self.overlay = Overlay::Busy(format!("Starting onboarding for {prefix}…"));
+    }
+
+    /// Open the kick form for the party in the detail view, listing the owner
+    /// participants that can be removed (self excluded).
+    fn open_kick(&mut self) {
+        let Some(party) = self.detail.as_ref() else {
+            return;
+        };
+        let self_id = self
+            .peers
+            .iter()
+            .find(|peer| peer.is_self)
+            .map(|peer| peer.participant_id.clone());
+        let candidates: Vec<KickCandidate> = party
+            .participants
+            .iter()
+            .filter(|participant| participant.owner_key.is_some())
+            .filter_map(|participant| {
+                let id = participant.participant_uid.to_string();
+                if self_id.as_deref() == Some(id.as_str()) {
+                    return None;
+                }
+                Some(KickCandidate {
+                    participant_id: id,
+                    label: participant.participant_uid.prefix.clone(),
+                })
+            })
+            .collect();
+        if candidates.is_empty() {
+            self.overlay = Overlay::Message("No owner participants available to kick.".to_owned());
+            return;
+        }
+        let owners = i32::try_from(party.owners.len()).unwrap_or(i32::MAX);
+        let remaining = (owners - 1).max(0);
+        if remaining < 1 {
+            self.overlay =
+                Overlay::Message("Cannot kick: the party would be left with no owners.".to_owned());
+            return;
+        }
+        let suggested = (((remaining + 1) / 2).max(1)).min(remaining);
+        self.overlay = Overlay::Kick(KickForm {
+            party_id: party.party_id.to_string(),
+            party_name: party_name(party).to_owned(),
+            previous_threshold: party.threshold,
+            candidates,
+            selected: 0,
+            new_threshold: suggested,
+            max_threshold: remaining,
+        });
+    }
+
+    /// Send the kick request for the selected candidate in the kick form.
+    fn confirm_kick(&mut self) {
+        let Overlay::Kick(form) = &self.overlay else {
+            return;
+        };
+        let Some(candidate) = form.candidates.get(form.selected) else {
+            return;
+        };
+        let request = Request::Kick {
+            party_id: form.party_id.clone(),
+            participant_id: candidate.participant_id.clone(),
+            new_threshold: form.new_threshold,
+            previous_threshold: form.previous_threshold,
+        };
+        let label = candidate.label.clone();
+        let _ = self.requests.send(request);
+        self.overlay = Overlay::Busy(format!("Kicking {label}…"));
     }
 
     /// Kick off the package checker.
@@ -1061,6 +2389,59 @@ mod tests {
         // A substring of the namespace hex matches against the full party id.
         assert_eq!(filter_parties(&parties, "c4010d").len(), 1);
         assert_eq!(filter_parties(&parties, "nomatch").len(), 0);
+    }
+
+    #[test]
+    fn validate_prefix_accepts_valid_and_rejects_invalid() {
+        assert!(validate_prefix("vault-rc5").is_ok());
+        assert!(validate_prefix("a_b-9").is_ok());
+        assert!(validate_prefix("").is_err()); // empty
+        assert!(validate_prefix("9abc").is_err()); // must start with a letter
+        assert!(validate_prefix("ab cd").is_err()); // space
+        assert!(validate_prefix("ab.cd").is_err()); // illegal char
+        assert!(validate_prefix(&"a".repeat(181)).is_err()); // too long
+        assert!(validate_prefix(&"a".repeat(180)).is_ok()); // at the limit
+    }
+
+    fn deploy_form() -> DeployForm {
+        DeployForm {
+            party_id: "dec::1220".to_owned(),
+            party_name: "cbtc-network".to_owned(),
+            package_id: "#governance-core-v1".to_owned(),
+            operator_party: "op::1220".to_owned(),
+            participant_ids: vec!["p1::1220".to_owned(), "p2::1220".to_owned()],
+            member_parties: vec!["m1::1220".to_owned(), "m2::1220".to_owned()],
+            threshold: "2".to_owned(),
+            timeout_micros: "86400000000".to_owned(),
+            cursor: 0,
+        }
+    }
+
+    #[test]
+    fn build_contracts_request_assembles_gov_core() {
+        let body = match build_contracts_request(&deploy_form()) {
+            Ok(body) => body,
+            Err(error) => panic!("build failed: {error}"),
+        };
+        assert_eq!(body["decentralized_party_id"], "dec::1220");
+        assert_eq!(body["participant_ids"][0], "p1::1220");
+        assert_eq!(body["participant_parties"][1], "m2::1220");
+        let contract = &body["contracts"][0];
+        assert_eq!(contract["entity_name"], "GovernanceRules");
+        assert_eq!(contract["fields"][1]["type"], "party_set");
+        assert_eq!(contract["fields"][2]["type"], "governance_threshold");
+        assert_eq!(contract["fields"][2]["value"], 2);
+        assert_eq!(contract["fields"][3]["microseconds"], 86_400_000_000_i64);
+    }
+
+    #[test]
+    fn build_contracts_request_rejects_missing_package() {
+        let mut form = deploy_form();
+        form.package_id = String::new();
+        match build_contracts_request(&form) {
+            Err(error) => assert!(error.contains("governance-core")),
+            Ok(_) => panic!("expected a missing-package error"),
+        }
     }
 
     #[test]

--- a/crates/decman-cli/src/app.rs
+++ b/crates/decman-cli/src/app.rs
@@ -17,7 +17,7 @@ use common::types::{
 use crate::api::{
     AuthSettings, ChainAuditEntry, DecmanClient, DomainGovAction, ExecuteParams, FeedItem,
     GovAction, GovConfirmation, GovState, GovernanceConfirmations, Holding, KnownMember,
-    PartyAuthStatus, PeerView, party_name,
+    PartyAuthStatus, PeerEntry, PeerView, party_name,
 };
 use crate::composer::{
     self, Composer, ComposerContext, ComposerSubmit, FieldKind, SelectOption, TypeOption,
@@ -136,6 +136,8 @@ pub enum Request {
         party_name: String,
     },
     DeploySubmit(Box<Value>),
+    NetworkPeers,
+    SaveNetwork(Box<Value>),
 }
 
 /// A result delivered by a background worker.
@@ -152,6 +154,7 @@ pub enum Update {
     Governance(Result<Box<GovView>, String>),
     OperatorInfo(String),
     DeployContext(Result<Box<DeployForm>, String>),
+    NetworkPeers(Result<Vec<PeerEntry>, String>),
 }
 
 /// A DAR file picked from disk for upload / distribution.
@@ -304,6 +307,40 @@ pub struct GovActionRequest {
     rules_contract_id: String,
 }
 
+/// The add-peer sub-form of the network-config editor.
+pub struct PeerForm {
+    pub participant_id: String,
+    pub name: String,
+    pub address: String,
+    pub port: String,
+    pub public_key: String,
+    pub party: String,
+    /// 0..=5 select a field; 6 is the submit row.
+    pub cursor: usize,
+}
+
+impl PeerForm {
+    fn blank() -> Self {
+        Self {
+            participant_id: String::new(),
+            name: String::new(),
+            address: String::new(),
+            port: String::new(),
+            public_key: String::new(),
+            party: String::new(),
+            cursor: 0,
+        }
+    }
+}
+
+/// State of the network-config editor: the editable peer list, plus an
+/// optional in-progress add-peer form.
+pub struct NetworkEditState {
+    pub peers: Vec<PeerEntry>,
+    pub selected: usize,
+    pub adding: Option<PeerForm>,
+}
+
 /// The grant-rights form: an admin client id + secret used to grant act/read
 /// rights for one party. The secret is sent once and not stored.
 pub struct GrantForm {
@@ -369,6 +406,8 @@ pub enum Overlay {
     Composer(Box<Composer>),
     /// The governance-core contract deployment form.
     Deploy(Box<DeployForm>),
+    /// The network-config (peer list) editor.
+    NetworkEdit(Box<NetworkEditState>),
 }
 
 /// The selectable top-level views.
@@ -671,6 +710,13 @@ fn handle_request(client: &mut DecmanClient, request: Request) -> Update {
                 .map(|()| "Contracts workflow started".to_owned())
                 .map_err(err),
         ),
+        Request::NetworkPeers => Update::NetworkPeers(client.fetch_network_peers().map_err(err)),
+        Request::SaveNetwork(body) => Update::Action(
+            client
+                .save_network_peers(*body)
+                .map(|()| "Network configuration saved".to_owned())
+                .map_err(err),
+        ),
         Request::Onboard { prefix, peer_ids } => Update::Action(
             client
                 .start_onboarding(&prefix, &peer_ids)
@@ -798,6 +844,40 @@ fn confirmation_cids(confirmations: &[GovConfirmation]) -> Vec<String> {
         .iter()
         .map(|confirmation| confirmation.contract_id.clone())
         .collect()
+}
+
+/// Build a [`PeerEntry`] from the add-peer form (trimming fields; an empty
+/// party becomes `None`; a non-numeric port falls back to 0).
+fn peer_from_form(form: &PeerForm) -> PeerEntry {
+    let party = form.party.trim();
+    PeerEntry {
+        participant_id: form.participant_id.trim().to_owned(),
+        name: form.name.trim().to_owned(),
+        address: form.address.trim().to_owned(),
+        port: form.port.trim().parse().unwrap_or(0),
+        public_key: form.public_key.trim().to_owned(),
+        party: (!party.is_empty()).then(|| party.to_owned()),
+    }
+}
+
+/// Serialize the editor's peer list as the bare JSON array `POST /network-config`
+/// expects.
+fn peers_to_json(peers: &[PeerEntry]) -> Value {
+    Value::Array(
+        peers
+            .iter()
+            .map(|peer| {
+                json!({
+                    "participant_id": peer.participant_id,
+                    "name": peer.name,
+                    "address": peer.address,
+                    "port": peer.port,
+                    "public_key": peer.public_key,
+                    "party": peer.party,
+                })
+            })
+            .collect(),
+    )
 }
 
 /// The placeholder action sent with on-chain (`core_domain`) confirm/execute —
@@ -1287,6 +1367,18 @@ impl App {
                         };
                     }
                 }
+                Update::NetworkPeers(result) => {
+                    if matches!(self.overlay, Overlay::Busy(_)) {
+                        self.overlay = match result {
+                            Ok(peers) => Overlay::NetworkEdit(Box::new(NetworkEditState {
+                                peers,
+                                selected: 0,
+                                adding: None,
+                            })),
+                            Err(error) => Overlay::Message(error),
+                        };
+                    }
+                }
                 // Ignore late detail results after the view was closed.
                 Update::Detail(data) if self.detail.is_some() => {
                     self.detail_data = Some(data);
@@ -1348,6 +1440,8 @@ impl App {
             (KeyCode::Enter, _) if self.active_tab == Tab::Parties => self.open_party_detail(),
             // Start onboarding a new decentralized party.
             (KeyCode::Char('n'), _) if self.active_tab == Tab::Parties => self.open_onboard(),
+            // Edit the network peer configuration.
+            (KeyCode::Char('e'), _) if self.active_tab == Tab::Peers => self.open_network_edit(),
             // Workflows actions.
             (KeyCode::Char('a'), _) if self.active_tab == Tab::Workflows => {
                 self.invitation_action(true);
@@ -1388,6 +1482,7 @@ impl App {
             SubmitDeploy,
             OpenGrant,
             SubmitGrant,
+            SaveNetwork,
         }
 
         let mut act = Act::None;
@@ -1562,6 +1657,71 @@ impl App {
                 },
                 _ => {}
             },
+            Overlay::NetworkEdit(state) => match &mut state.adding {
+                Some(form) => match key.code {
+                    KeyCode::Esc => state.adding = None,
+                    KeyCode::Up => form.cursor = form.cursor.saturating_sub(1),
+                    KeyCode::Down | KeyCode::Tab if form.cursor < 6 => form.cursor += 1,
+                    KeyCode::Enter if form.cursor >= 6 => {
+                        state.peers.push(peer_from_form(form));
+                        state.adding = None;
+                    }
+                    KeyCode::Enter if form.cursor < 6 => form.cursor += 1,
+                    KeyCode::Char(c) => match form.cursor {
+                        0 => form.participant_id.push(c),
+                        1 => form.name.push(c),
+                        2 => form.address.push(c),
+                        3 => {
+                            if c.is_ascii_digit() {
+                                form.port.push(c);
+                            }
+                        }
+                        4 => form.public_key.push(c),
+                        5 => form.party.push(c),
+                        _ => {}
+                    },
+                    KeyCode::Backspace => match form.cursor {
+                        0 => {
+                            form.participant_id.pop();
+                        }
+                        1 => {
+                            form.name.pop();
+                        }
+                        2 => {
+                            form.address.pop();
+                        }
+                        3 => {
+                            form.port.pop();
+                        }
+                        4 => {
+                            form.public_key.pop();
+                        }
+                        5 => {
+                            form.party.pop();
+                        }
+                        _ => {}
+                    },
+                    _ => {}
+                },
+                None => match key.code {
+                    KeyCode::Esc | KeyCode::Char('q') => act = Act::Close,
+                    KeyCode::Up | KeyCode::Char('k') => {
+                        state.selected = state.selected.saturating_sub(1);
+                    }
+                    KeyCode::Down | KeyCode::Char('j')
+                        if state.selected + 1 < state.peers.len() =>
+                    {
+                        state.selected += 1;
+                    }
+                    KeyCode::Char('a') => state.adding = Some(PeerForm::blank()),
+                    KeyCode::Char('d') if state.selected < state.peers.len() => {
+                        state.peers.remove(state.selected);
+                        state.selected = state.selected.min(state.peers.len().saturating_sub(1));
+                    }
+                    KeyCode::Char('s') => act = Act::SaveNetwork,
+                    _ => {}
+                },
+            },
             Overlay::Message(_) | Overlay::Busy(_) => {
                 if matches!(key.code, KeyCode::Esc | KeyCode::Enter | KeyCode::Char('q')) {
                     act = Act::Close;
@@ -1588,6 +1748,7 @@ impl App {
             Act::SubmitDeploy => self.submit_deploy(),
             Act::OpenGrant => self.open_grant(),
             Act::SubmitGrant => self.submit_grant(),
+            Act::SaveNetwork => self.save_network(),
         }
     }
 
@@ -1903,6 +2064,24 @@ impl App {
             }
             Err(error) => self.overlay = Overlay::Message(error),
         }
+    }
+
+    /// Fetch the peer configuration and open the network-config editor.
+    fn open_network_edit(&mut self) {
+        let _ = self.requests.send(Request::NetworkPeers);
+        self.overlay = Overlay::Busy("Loading network configuration…".to_owned());
+    }
+
+    /// Save the edited peer list back to the node.
+    fn save_network(&mut self) {
+        let body = {
+            let Overlay::NetworkEdit(state) = &self.overlay else {
+                return;
+            };
+            peers_to_json(&state.peers)
+        };
+        let _ = self.requests.send(Request::SaveNetwork(Box::new(body)));
+        self.overlay = Overlay::Busy("Saving network configuration…".to_owned());
     }
 
     /// Fetch and show the per-party authentication status overlay.

--- a/crates/decman-cli/src/app.rs
+++ b/crates/decman-cli/src/app.rs
@@ -15,9 +15,9 @@ use common::types::{
 };
 
 use crate::api::{
-    AuthSettings, ChainAuditEntry, DecmanClient, DomainGovAction, ExecuteParams, FeedItem,
-    GovAction, GovConfirmation, GovState, GovernanceConfirmations, Holding, KnownMember,
-    PartyAuthStatus, PeerEntry, PeerView, party_name,
+    AuthSettings, ChainAuditEntry, DecmanClient, DiscoverResult, DomainGovAction, ExecuteParams,
+    FeedItem, GovAction, GovConfirmation, GovState, GovernanceConfirmations, Holding, KnownMember,
+    PartyAuthStatus, PartyConfigView, PeerEntry, PeerView, party_name,
 };
 use crate::composer::{
     self, Composer, ComposerContext, ComposerSubmit, FieldKind, SelectOption, TypeOption,
@@ -138,6 +138,9 @@ pub enum Request {
     DeploySubmit(Box<Value>),
     NetworkPeers,
     SaveNetwork(Box<Value>),
+    PartyConfig(String),
+    SavePartyConfig(Box<Value>),
+    Discover(Box<Value>),
 }
 
 /// A result delivered by a background worker.
@@ -155,6 +158,8 @@ pub enum Update {
     OperatorInfo(String),
     DeployContext(Result<Box<DeployForm>, String>),
     NetworkPeers(Result<Vec<PeerEntry>, String>),
+    PartyConfig(Result<Box<PartyConfigForm>, String>),
+    Discovered(Result<DiscoverResult, String>),
 }
 
 /// A DAR file picked from disk for upload / distribution.
@@ -341,6 +346,79 @@ pub struct NetworkEditState {
     pub adding: Option<PeerForm>,
 }
 
+/// Which IdP the party-config form is editing.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum IdpMode {
+    Keycloak,
+    Auth0,
+}
+
+/// One row in the party-config form (a field, the provider toggle, or an action).
+#[derive(Clone, Copy)]
+pub enum PcRow {
+    Mode,
+    MemberParty,
+    UserId,
+    KcUrl,
+    KcRealm,
+    KcClientId,
+    KcSecret,
+    Auth0Domain,
+    Auth0Audience,
+    Auth0ClientId,
+    Auth0Secret,
+    Discover,
+    Submit,
+}
+
+/// The per-party IdP configuration editor (Keycloak or Auth0).
+pub struct PartyConfigForm {
+    pub dec_party_id: String,
+    pub party_name: String,
+    pub mode: IdpMode,
+    pub member_party_id: String,
+    pub user_id: String,
+    pub kc_url: String,
+    pub kc_realm: String,
+    pub kc_client_id: String,
+    /// Empty leaves the stored secret unchanged when one is set.
+    pub kc_secret: String,
+    pub kc_has_secret: bool,
+    pub auth0_domain: String,
+    pub auth0_audience: String,
+    pub auth0_client_id: String,
+    pub auth0_secret: String,
+    pub auth0_has_secret: bool,
+    pub cursor: usize,
+    /// Transient status line (discover result / error), shown in the form.
+    pub status: String,
+}
+
+impl PartyConfigForm {
+    /// The rows shown for the current provider mode, in display order.
+    pub fn rows(&self) -> Vec<PcRow> {
+        let mut rows = vec![PcRow::Mode, PcRow::MemberParty, PcRow::UserId];
+        match self.mode {
+            IdpMode::Keycloak => {
+                rows.extend([
+                    PcRow::KcUrl,
+                    PcRow::KcRealm,
+                    PcRow::KcClientId,
+                    PcRow::KcSecret,
+                ]);
+            }
+            IdpMode::Auth0 => rows.extend([
+                PcRow::Auth0Domain,
+                PcRow::Auth0Audience,
+                PcRow::Auth0ClientId,
+                PcRow::Auth0Secret,
+            ]),
+        }
+        rows.extend([PcRow::Discover, PcRow::Submit]);
+        rows
+    }
+}
+
 /// The grant-rights form: an admin client id + secret used to grant act/read
 /// rights for one party. The secret is sent once and not stored.
 pub struct GrantForm {
@@ -408,6 +486,8 @@ pub enum Overlay {
     Deploy(Box<DeployForm>),
     /// The network-config (peer list) editor.
     NetworkEdit(Box<NetworkEditState>),
+    /// The per-party IdP configuration editor.
+    PartyConfig(Box<PartyConfigForm>),
 }
 
 /// The selectable top-level views.
@@ -717,6 +797,20 @@ fn handle_request(client: &mut DecmanClient, request: Request) -> Update {
                 .map(|()| "Network configuration saved".to_owned())
                 .map_err(err),
         ),
+        Request::PartyConfig(dec_party_id) => Update::PartyConfig(
+            build_party_config_form(client, &dec_party_id)
+                .map(Box::new)
+                .map_err(err),
+        ),
+        Request::SavePartyConfig(body) => Update::Action(
+            client
+                .save_party_config(*body)
+                .map(|()| "Party configuration saved".to_owned())
+                .map_err(err),
+        ),
+        Request::Discover(body) => {
+            Update::Discovered(client.discover_member_party(*body).map_err(err))
+        }
         Request::Onboard { prefix, peer_ids } => Update::Action(
             client
                 .start_onboarding(&prefix, &peer_ids)
@@ -900,6 +994,120 @@ fn peers_to_json(peers: &[PeerEntry]) -> Value {
             })
             .collect(),
     )
+}
+
+/// Fetch a party's IdP configuration and build the editor form, defaulting to
+/// the Auth0 tab when an Auth0 domain is already configured.
+fn build_party_config_form(
+    client: &mut DecmanClient,
+    dec_party_id: &str,
+) -> Result<PartyConfigForm> {
+    let config = client.fetch_party_config(dec_party_id)?;
+    let PartyConfigView {
+        member_party_id,
+        user_id,
+        keycloak_url,
+        keycloak_realm,
+        keycloak_client_id,
+        has_client_secret,
+        auth0_domain,
+        auth0_audience,
+        auth0_client_id,
+        has_auth0_client_secret,
+    } = config;
+    let mode = if auth0_domain.as_deref().is_some_and(|d| !d.is_empty()) {
+        IdpMode::Auth0
+    } else {
+        IdpMode::Keycloak
+    };
+    Ok(PartyConfigForm {
+        dec_party_id: dec_party_id.to_owned(),
+        party_name: dec_party_id
+            .split("::")
+            .next()
+            .unwrap_or(dec_party_id)
+            .to_owned(),
+        mode,
+        member_party_id: member_party_id.unwrap_or_default(),
+        user_id: user_id.unwrap_or_default(),
+        kc_url: keycloak_url,
+        kc_realm: keycloak_realm,
+        kc_client_id: keycloak_client_id,
+        kc_secret: String::new(),
+        kc_has_secret: has_client_secret,
+        auth0_domain: auth0_domain.unwrap_or_default(),
+        auth0_audience: auth0_audience.unwrap_or_default(),
+        auth0_client_id: auth0_client_id.unwrap_or_default(),
+        auth0_secret: String::new(),
+        auth0_has_secret: has_auth0_client_secret,
+        cursor: 0,
+        status: String::new(),
+    })
+}
+
+/// Build the `PUT /party-config` body from the form. A blank secret is omitted
+/// (keep existing); the inactive provider's secret is never sent.
+fn party_config_body(form: &PartyConfigForm) -> Value {
+    let mut body = json!({
+        "dec_party_id": form.dec_party_id,
+        "member_party_id": form.member_party_id.trim(),
+        "user_id": form.user_id.trim(),
+    });
+    match form.mode {
+        IdpMode::Keycloak => {
+            body["keycloak_url"] = json!(form.kc_url.trim());
+            body["keycloak_realm"] = json!(form.kc_realm.trim());
+            body["keycloak_client_id"] = json!(form.kc_client_id.trim());
+            if !form.kc_secret.is_empty() {
+                body["keycloak_client_secret"] = json!(form.kc_secret);
+            }
+        }
+        IdpMode::Auth0 => {
+            body["auth0_domain"] = json!(form.auth0_domain.trim());
+            body["auth0_audience"] = json!(form.auth0_audience.trim());
+            body["auth0_client_id"] = json!(form.auth0_client_id.trim());
+            if !form.auth0_secret.is_empty() {
+                body["auth0_client_secret"] = json!(form.auth0_secret);
+            }
+        }
+    }
+    body
+}
+
+/// Build the discover-member-party body from the form's active provider fields.
+fn discover_body(form: &PartyConfigForm) -> Value {
+    match form.mode {
+        IdpMode::Keycloak => json!({
+            "keycloak_url": form.kc_url.trim(),
+            "keycloak_realm": form.kc_realm.trim(),
+            "keycloak_client_id": form.kc_client_id.trim(),
+            "keycloak_client_secret": form.kc_secret,
+        }),
+        IdpMode::Auth0 => json!({
+            "auth0_domain": form.auth0_domain.trim(),
+            "auth0_audience": form.auth0_audience.trim(),
+            "auth0_client_id": form.auth0_client_id.trim(),
+            "auth0_client_secret": form.auth0_secret,
+        }),
+    }
+}
+
+/// The editable string for a party-config form row, or `None` for the
+/// provider toggle and the action rows.
+fn pc_field_mut(form: &mut PartyConfigForm, row: Option<PcRow>) -> Option<&mut String> {
+    match row? {
+        PcRow::MemberParty => Some(&mut form.member_party_id),
+        PcRow::UserId => Some(&mut form.user_id),
+        PcRow::KcUrl => Some(&mut form.kc_url),
+        PcRow::KcRealm => Some(&mut form.kc_realm),
+        PcRow::KcClientId => Some(&mut form.kc_client_id),
+        PcRow::KcSecret => Some(&mut form.kc_secret),
+        PcRow::Auth0Domain => Some(&mut form.auth0_domain),
+        PcRow::Auth0Audience => Some(&mut form.auth0_audience),
+        PcRow::Auth0ClientId => Some(&mut form.auth0_client_id),
+        PcRow::Auth0Secret => Some(&mut form.auth0_secret),
+        PcRow::Mode | PcRow::Discover | PcRow::Submit => None,
+    }
 }
 
 /// The placeholder action sent with on-chain (`core_domain`) confirm/execute —
@@ -1410,6 +1618,35 @@ impl App {
                         };
                     }
                 }
+                Update::PartyConfig(result) => {
+                    if matches!(self.overlay, Overlay::Busy(_)) {
+                        self.overlay = match result {
+                            Ok(form) => Overlay::PartyConfig(form),
+                            Err(error) => Overlay::Message(error),
+                        };
+                    }
+                }
+                Update::Discovered(result) => {
+                    if let Overlay::PartyConfig(form) = &mut self.overlay {
+                        match result {
+                            Ok(discovered) => {
+                                form.user_id = discovered.user_id;
+                                match discovered.primary_party {
+                                    Some(party) => {
+                                        form.member_party_id = party;
+                                        form.status = "Discovered member party.".to_owned();
+                                    }
+                                    None => {
+                                        form.status =
+                                            "Authenticated, but no primary party assigned."
+                                                .to_owned();
+                                    }
+                                }
+                            }
+                            Err(error) => form.status = format!("Discover failed: {error}"),
+                        }
+                    }
+                }
                 // Ignore late detail results after the view was closed.
                 Update::Detail(data) if self.detail.is_some() => {
                     self.detail_data = Some(data);
@@ -1514,6 +1751,9 @@ impl App {
             OpenGrant,
             SubmitGrant,
             SaveNetwork,
+            OpenPartyConfig,
+            SubmitPartyConfig,
+            Discover,
         }
 
         let mut act = Act::None;
@@ -1586,6 +1826,7 @@ impl App {
                 KeyCode::Esc | KeyCode::Char('q') => act = Act::Close,
                 KeyCode::Char('t') => act = Act::TestAuth,
                 KeyCode::Char('g') => act = Act::OpenGrant,
+                KeyCode::Char('e') => act = Act::OpenPartyConfig,
                 KeyCode::Up | KeyCode::Char('k') => *selected = selected.saturating_sub(1),
                 KeyCode::Down | KeyCode::Char('j') if *selected + 1 < parties.len() => {
                     *selected += 1;
@@ -1758,6 +1999,46 @@ impl App {
                     _ => {}
                 },
             },
+            Overlay::PartyConfig(form) => {
+                let rows = form.rows();
+                let row = rows.get(form.cursor).copied();
+                match key.code {
+                    KeyCode::Esc => act = Act::Close,
+                    KeyCode::Up => form.cursor = form.cursor.saturating_sub(1),
+                    KeyCode::Down | KeyCode::Tab if form.cursor + 1 < rows.len() => {
+                        form.cursor += 1;
+                    }
+                    KeyCode::Left | KeyCode::Right | KeyCode::Char(' ')
+                        if matches!(row, Some(PcRow::Mode)) =>
+                    {
+                        form.mode = match form.mode {
+                            IdpMode::Keycloak => IdpMode::Auth0,
+                            IdpMode::Auth0 => IdpMode::Keycloak,
+                        };
+                        form.cursor = 0;
+                    }
+                    KeyCode::Enter => match row {
+                        Some(PcRow::Discover) => act = Act::Discover,
+                        Some(PcRow::Submit) => act = Act::SubmitPartyConfig,
+                        _ => {
+                            if form.cursor + 1 < rows.len() {
+                                form.cursor += 1;
+                            }
+                        }
+                    },
+                    KeyCode::Char(c) => {
+                        if let Some(field) = pc_field_mut(form, row) {
+                            field.push(c);
+                        }
+                    }
+                    KeyCode::Backspace => {
+                        if let Some(field) = pc_field_mut(form, row) {
+                            field.pop();
+                        }
+                    }
+                    _ => {}
+                }
+            }
             Overlay::Message(_) | Overlay::Busy(_) => {
                 if matches!(key.code, KeyCode::Esc | KeyCode::Enter | KeyCode::Char('q')) {
                     act = Act::Close;
@@ -1785,6 +2066,9 @@ impl App {
             Act::OpenGrant => self.open_grant(),
             Act::SubmitGrant => self.submit_grant(),
             Act::SaveNetwork => self.save_network(),
+            Act::OpenPartyConfig => self.open_party_config(),
+            Act::SubmitPartyConfig => self.submit_party_config(),
+            Act::Discover => self.run_discover(),
         }
     }
 
@@ -2130,6 +2414,49 @@ impl App {
     fn run_auth_test(&mut self) {
         let _ = self.requests.send(Request::TestAuth);
         self.overlay = Overlay::Busy("Testing authentication…".to_owned());
+    }
+
+    /// Open the IdP-config editor for the party selected in the auth overlay.
+    fn open_party_config(&mut self) {
+        let dec_party_id = {
+            let Overlay::Auth { parties, selected } = &self.overlay else {
+                return;
+            };
+            match parties.get(*selected) {
+                Some(party) => party.dec_party_id.clone(),
+                None => return,
+            }
+        };
+        let _ = self.requests.send(Request::PartyConfig(dec_party_id));
+        self.overlay = Overlay::Busy("Loading party configuration…".to_owned());
+    }
+
+    /// Validate and save the party-config form.
+    fn submit_party_config(&mut self) {
+        let body = {
+            let Overlay::PartyConfig(form) = &self.overlay else {
+                return;
+            };
+            if form.member_party_id.trim().is_empty() || form.user_id.trim().is_empty() {
+                self.overlay =
+                    Overlay::Message("Member party id and user id are required.".to_owned());
+                return;
+            }
+            party_config_body(form)
+        };
+        let _ = self.requests.send(Request::SavePartyConfig(Box::new(body)));
+        self.overlay = Overlay::Busy("Saving party configuration…".to_owned());
+    }
+
+    /// Discover the member party from the form's current IdP credentials. The
+    /// form stays open (with a status line) so the result patches into it.
+    fn run_discover(&mut self) {
+        let Overlay::PartyConfig(form) = &mut self.overlay else {
+            return;
+        };
+        let body = discover_body(form);
+        form.status = "Discovering member party…".to_owned();
+        let _ = self.requests.send(Request::Discover(Box::new(body)));
     }
 
     /// Open the grant-rights form for the party selected in the auth overlay.
@@ -2835,6 +3162,56 @@ mod tests {
         no_id.port = "9001".to_owned();
         no_id.public_key = "abcd".to_owned();
         assert!(matches!(validate_peer_form(&no_id), Err(0)));
+    }
+
+    fn party_config_form() -> PartyConfigForm {
+        PartyConfigForm {
+            dec_party_id: "dec::1220".to_owned(),
+            party_name: "dec".to_owned(),
+            mode: IdpMode::Keycloak,
+            member_party_id: "member::1220".to_owned(),
+            user_id: "user-1".to_owned(),
+            kc_url: "https://kc".to_owned(),
+            kc_realm: "realm".to_owned(),
+            kc_client_id: "client".to_owned(),
+            kc_secret: String::new(),
+            kc_has_secret: true,
+            auth0_domain: String::new(),
+            auth0_audience: String::new(),
+            auth0_client_id: String::new(),
+            auth0_secret: String::new(),
+            auth0_has_secret: false,
+            cursor: 0,
+            status: String::new(),
+        }
+    }
+
+    #[test]
+    fn party_config_body_keycloak_omits_blank_secret() {
+        let body = party_config_body(&party_config_form());
+        assert_eq!(body["member_party_id"], "member::1220");
+        assert_eq!(body["keycloak_url"], "https://kc");
+        assert_eq!(body["keycloak_client_id"], "client");
+        // A blank secret is omitted (the server keeps the existing one).
+        assert!(body.get("keycloak_client_secret").is_none());
+        // Auth0 fields are not sent while in Keycloak mode.
+        assert!(body.get("auth0_domain").is_none());
+    }
+
+    #[test]
+    fn party_config_body_sends_typed_secret_and_auth0_fields() {
+        let mut form = party_config_form();
+        form.kc_secret = "s3cr3t".to_owned();
+        assert_eq!(party_config_body(&form)["keycloak_client_secret"], "s3cr3t");
+
+        let mut auth0 = party_config_form();
+        auth0.mode = IdpMode::Auth0;
+        auth0.auth0_domain = "tenant.auth0.com".to_owned();
+        auth0.auth0_client_id = "a0client".to_owned();
+        let body = party_config_body(&auth0);
+        assert_eq!(body["auth0_domain"], "tenant.auth0.com");
+        assert_eq!(body["auth0_client_id"], "a0client");
+        assert!(body.get("keycloak_client_secret").is_none());
     }
 
     #[test]

--- a/crates/decman-cli/src/app.rs
+++ b/crates/decman-cli/src/app.rs
@@ -933,9 +933,10 @@ fn build_deploy_context(
         }
     }
 
-    // Default threshold ≈ a 2/3 majority, at least 2 (matches the web frontend).
+    // Default threshold ≈ a 2/3 majority, at least 2, but never above the
+    // resolved member count so the initial form is always within the valid range.
     let count = i64::try_from(member_parties.len()).unwrap_or(0);
-    let threshold = ((count * 2 + 2) / 3).max(2);
+    let threshold = ((count * 2 + 2) / 3).max(2).min(count.max(1));
 
     Ok(DeployForm {
         party_id: party_id.to_owned(),

--- a/crates/decman-cli/src/composer.rs
+++ b/crates/decman-cli/src/composer.rs
@@ -216,14 +216,30 @@ fn select(
 }
 
 fn rows(key: &'static str, label: &'static str, columns: Vec<&'static str>) -> ComposerField {
-    let help = "one per line";
     field(
         key,
         label,
         FieldKind::Rows(columns),
         String::new(),
         true,
-        help,
+        "one per line",
+    )
+}
+
+/// A rows field whose JSON key the API requires: blank input serializes as `[]`
+/// (an absent key would fail server-side deserialization).
+fn rows_required(
+    key: &'static str,
+    label: &'static str,
+    columns: Vec<&'static str>,
+) -> ComposerField {
+    field(
+        key,
+        label,
+        FieldKind::Rows(columns),
+        String::new(),
+        false,
+        "one per line",
     )
 }
 
@@ -234,6 +250,18 @@ fn list_opt(key: &'static str, label: &'static str) -> ComposerField {
         FieldKind::List,
         String::new(),
         true,
+        "one per line",
+    )
+}
+
+/// A list field whose JSON key the API requires: blank input serializes as `[]`.
+fn list_required(key: &'static str, label: &'static str) -> ComposerField {
+    field(
+        key,
+        label,
+        FieldKind::List,
+        String::new(),
+        false,
         "one per line",
     )
 }
@@ -313,7 +341,7 @@ pub fn fields_for_action(action_type: &str, ctx: &ComposerContext) -> Vec<Compos
         ],
         "vault_update_far_beneficiaries" => vec![
             text("vault_id", "Vault contract id"),
-            rows(
+            rows_required(
                 "new_beneficiaries",
                 "Beneficiaries (party,weight)",
                 vec!["beneficiary", "weight"],
@@ -349,7 +377,7 @@ pub fn fields_for_action(action_type: &str, ctx: &ComposerContext) -> Vec<Compos
             text("vault_processor_rules_cid", "Processor rules cid"),
             text("vault_backend_signatory", "Backend signatory"),
             text("allocation_factory_cid", "Burn/mint factory cid"),
-            list_opt("initial_supported_vaults", "Initial supported vault cids"),
+            list_required("initial_supported_vaults", "Initial supported vault cids"),
         ],
         "utility_create_provider_request" | "utility_create_user_request" => {
             vec![text_value(
@@ -375,7 +403,7 @@ pub fn fields_for_action(action_type: &str, ctx: &ComposerContext) -> Vec<Compos
             text("holder", "Holder party"),
             text("id", "Credential id"),
             text("description", "Description"),
-            rows(
+            rows_required(
                 "claims",
                 "Claims (subject,property,value)",
                 vec!["subject", "property", "value"],
@@ -497,7 +525,7 @@ pub fn fields_for_proposal(proposal_type: &str, ctx: &ComposerContext) -> Vec<Co
             text("holder", "Holder party"),
             text("id", "Credential id"),
             text("description", "Description"),
-            rows(
+            rows_required(
                 "claims",
                 "Claims (subject,property,value)",
                 vec!["subject", "property", "value"],
@@ -519,6 +547,15 @@ pub fn build_payload(composer: &Composer) -> Result<Value, String> {
         "type".to_owned(),
         Value::String(composer.action_type.to_owned()),
     );
+    // A nested-object key (e.g. `limits`, `instrument_id`) is always emitted
+    // when the form declares any child for it, even if all children are blank —
+    // the matching server fields are required, so an absent key fails to parse.
+    for field in &composer.fields {
+        if let Some((parent, _)) = field.key.split_once('.') {
+            root.entry(parent.to_owned())
+                .or_insert_with(|| Value::Object(Map::new()));
+        }
+    }
     for field in &composer.fields {
         if let Some(value) = field_value(field)? {
             insert_path(&mut root, field.key, value);
@@ -677,8 +714,22 @@ mod tests {
         let payload = built("transfer", fields);
         assert_eq!(payload["instrument_id"]["admin"], "adm::1220");
         assert_eq!(payload["instrument_id"]["id"], "CBTC");
-        // The empty optional nested field is omitted entirely.
-        assert!(payload.get("limits").is_none());
+        // A declared nested-object parent is always present (required server
+        // field), but its blank optional child is omitted within it.
+        assert_eq!(payload["limits"], serde_json::json!({}));
+        assert!(payload["limits"].get("max_total_deposit").is_none());
+    }
+
+    #[test]
+    fn build_payload_required_array_is_empty_not_absent() {
+        // A required Vec field with blank input must serialize as `[]`, never absent.
+        let field = rows_required("new_beneficiaries", "Beneficiaries", vec!["beneficiary"]);
+        let payload = built("vault_update_far_beneficiaries", vec![field]);
+        assert_eq!(payload["new_beneficiaries"], serde_json::json!([]));
+
+        let field = list_required("initial_supported_vaults", "Vaults");
+        let payload = built("processor_deployment_request", vec![field]);
+        assert_eq!(payload["initial_supported_vaults"], serde_json::json!([]));
     }
 
     #[test]

--- a/crates/decman-cli/src/composer.rs
+++ b/crates/decman-cli/src/composer.rs
@@ -1,0 +1,781 @@
+//! A small data-driven form engine for composing governance actions and
+//! proposals. Each action / proposal variant is described by a list of
+//! [`ComposerField`]s; [`build_payload`] assembles the typed JSON body the
+//! decman API expects (the `{ "type": ..., ... }` internally-tagged shape).
+//!
+//! This keeps the 30-odd variants as data rather than bespoke forms, while
+//! still supporting nested objects (dot-path keys, e.g. `instrument_id.admin`)
+//! and arrays of records (comma-separated rows, e.g. beneficiaries).
+
+use serde_json::{Map, Value};
+
+/// What kind of input a [`ComposerField`] collects.
+pub enum FieldKind {
+    /// Free text (party id, contract id, description, decimal amount, …).
+    Text,
+    /// A whole number, serialized as a JSON integer.
+    Int,
+    /// A boolean toggle (← / → flips it).
+    Bool,
+    /// One choice from a fixed set (← / → cycles). Option values `"true"` /
+    /// `"false"` serialize as booleans, `"null"` / `"clear"` as JSON null.
+    Select(Vec<SelectOption>),
+    /// Newline-separated plain strings → a JSON array of strings.
+    List,
+    /// Newline-separated rows, each split on commas into `columns` → a JSON
+    /// array of `{ column: value }` objects.
+    Rows(Vec<&'static str>),
+}
+
+/// One option in a [`FieldKind::Select`].
+pub struct SelectOption {
+    pub value: &'static str,
+    pub label: &'static str,
+}
+
+impl SelectOption {
+    /// Build a select option.
+    pub fn new(value: &'static str, label: &'static str) -> Self {
+        Self { value, label }
+    }
+}
+
+/// One input in a composer form.
+pub struct ComposerField {
+    /// JSON key. May contain `.` to build nested objects (`a.b` → `{a:{b:..}}`).
+    pub key: &'static str,
+    pub label: &'static str,
+    pub kind: FieldKind,
+    /// Current edit buffer. For `Bool`/`Select` this holds the chosen value.
+    pub value: String,
+    /// When true, an empty value is omitted from the payload instead of erroring.
+    pub optional: bool,
+    pub help: &'static str,
+}
+
+/// Where a composed form is submitted.
+pub enum ComposerSubmit {
+    /// `POST /governance/confirm` (a brand-new off-chain action).
+    Confirm,
+    /// `POST /governance/propose`.
+    Propose,
+}
+
+/// A full composer form for one action / proposal variant.
+pub struct Composer {
+    pub title: String,
+    /// The internally-tagged `"type"` discriminant.
+    pub action_type: &'static str,
+    pub submit: ComposerSubmit,
+    pub party_id: String,
+    pub party_name: String,
+    /// The party-level governance type (`core_self` / `vault`), used for the
+    /// confirm call and to refresh the approvals overlay afterwards.
+    pub governance_type: String,
+    pub rules_contract_id: String,
+    pub fields: Vec<ComposerField>,
+    /// Index of the focused field; `fields.len()` is the virtual submit row.
+    pub cursor: usize,
+}
+
+/// Prefill context shared by every form.
+pub struct ComposerContext {
+    pub party_id: String,
+    /// The operator party (from `/operator-info`); empty if unknown.
+    pub operator_party: String,
+    /// The current governance threshold, used to prefill threshold fields.
+    pub default_threshold: i64,
+}
+
+/// One entry in the action / proposal type picker.
+pub struct TypeOption {
+    pub key: &'static str,
+    pub label: &'static str,
+}
+
+const fn opt(key: &'static str, label: &'static str) -> TypeOption {
+    TypeOption { key, label }
+}
+
+/// The governance action types offered for a party's governance type, in the
+/// same order and split the web frontend uses (`core_self` shows the four
+/// self-management actions; `vault` shows the rest).
+pub fn action_types(governance_type: &str) -> Vec<TypeOption> {
+    if governance_type == "core_self" {
+        vec![
+            opt("governance_add_member", "Add governance member"),
+            opt("governance_remove_member", "Remove governance member"),
+            opt("governance_set_threshold", "Set governance threshold"),
+            opt("governance_set_timeout", "Set governance timeout"),
+        ]
+    } else {
+        vec![
+            opt("vault_pause", "Pause vault"),
+            opt("vault_unpause", "Unpause vault"),
+            opt("vault_update_limits", "Update vault limits"),
+            opt("vault_update_backend", "Update vault backend"),
+            opt("vault_update_far_beneficiaries", "Update FAR beneficiaries"),
+            opt("vault_deployment", "Deploy vault"),
+            opt("yield_epoch_deployment", "Deploy yield epoch"),
+            opt(
+                "processor_deployment_request",
+                "Request processor deployment",
+            ),
+            opt("utility_create_provider_request", "Create provider service"),
+            opt("utility_create_user_request", "Create user service"),
+            opt("utility_setup", "Setup utility"),
+            opt(
+                "utility_accept_holder_service_request",
+                "Accept holder service",
+            ),
+            opt("credential_offer_free", "Offer free credential"),
+            opt("credential_accept_free", "Accept free credential"),
+            opt("dev_net_feature_app", "DevNet: feature app"),
+        ]
+    }
+}
+
+/// The proposal types offered on a `core_self` party, grouped as in the web
+/// frontend (`offer_paid_credential` is omitted — the API form is unimplemented).
+pub fn proposal_types() -> Vec<TypeOption> {
+    vec![
+        opt("generic_vote", "Generic vote"),
+        opt("setup_cc_preapproval", "Setup CC preapproval"),
+        opt("setup_token_preapproval", "Setup token preapproval"),
+        opt("transfer", "Transfer"),
+        opt("accept_transfer", "Accept transfer"),
+        opt("create_user_service_request", "Create user service request"),
+        opt(
+            "create_provider_service_request",
+            "Create provider service request",
+        ),
+        opt("setup_utility", "Setup utility"),
+        opt(
+            "set_provider_app_reward_beneficiaries",
+            "Set provider app reward beneficiaries",
+        ),
+        opt("set_enable_result_contracts", "Set enable result contracts"),
+        opt(
+            "create_delegated_batched_markers_proxy",
+            "Create delegated batched markers proxy",
+        ),
+        opt("mint", "Mint"),
+        opt("burn", "Burn"),
+        opt("accept_mint_request", "Accept mint request"),
+        opt("accept_burn_request", "Accept burn request"),
+        opt("offer_free_credential", "Offer free credential"),
+        opt("accept_free_credential", "Accept free credential"),
+    ]
+}
+
+/// Field constructors.
+fn text(key: &'static str, label: &'static str) -> ComposerField {
+    field(key, label, FieldKind::Text, String::new(), false, "")
+}
+
+fn text_value(key: &'static str, label: &'static str, value: String) -> ComposerField {
+    field(key, label, FieldKind::Text, value, false, "")
+}
+
+fn text_opt(key: &'static str, label: &'static str) -> ComposerField {
+    field(key, label, FieldKind::Text, String::new(), true, "")
+}
+
+fn int_value(
+    key: &'static str,
+    label: &'static str,
+    value: i64,
+    help: &'static str,
+) -> ComposerField {
+    field(key, label, FieldKind::Int, value.to_string(), false, help)
+}
+
+fn int_opt(key: &'static str, label: &'static str, help: &'static str) -> ComposerField {
+    field(key, label, FieldKind::Int, String::new(), true, help)
+}
+
+fn boolean(key: &'static str, label: &'static str, default: bool) -> ComposerField {
+    let value = if default { "true" } else { "false" }.to_owned();
+    field(key, label, FieldKind::Bool, value, false, "")
+}
+
+fn select(
+    key: &'static str,
+    label: &'static str,
+    options: Vec<SelectOption>,
+    default: &'static str,
+) -> ComposerField {
+    field(
+        key,
+        label,
+        FieldKind::Select(options),
+        default.to_owned(),
+        false,
+        "",
+    )
+}
+
+fn rows(key: &'static str, label: &'static str, columns: Vec<&'static str>) -> ComposerField {
+    let help = "one per line";
+    field(
+        key,
+        label,
+        FieldKind::Rows(columns),
+        String::new(),
+        true,
+        help,
+    )
+}
+
+fn list_opt(key: &'static str, label: &'static str) -> ComposerField {
+    field(
+        key,
+        label,
+        FieldKind::List,
+        String::new(),
+        true,
+        "one per line",
+    )
+}
+
+fn field(
+    key: &'static str,
+    label: &'static str,
+    kind: FieldKind,
+    value: String,
+    optional: bool,
+    help: &'static str,
+) -> ComposerField {
+    ComposerField {
+        key,
+        label,
+        kind,
+        value,
+        optional,
+        help,
+    }
+}
+
+/// Instrument-id pair fields (`instrument_id.admin` + `instrument_id.id`),
+/// prefilling the admin with `admin_default`.
+fn instrument_id(prefix: &'static str, admin_default: String) -> Vec<ComposerField> {
+    vec![
+        text_value(
+            match prefix {
+                "asset_instrument_id" => "asset_instrument_id.admin",
+                _ => "instrument_id.admin",
+            },
+            "Instrument admin",
+            admin_default,
+        ),
+        text(
+            match prefix {
+                "asset_instrument_id" => "asset_instrument_id.id",
+                _ => "instrument_id.id",
+            },
+            "Instrument id",
+        ),
+    ]
+}
+
+/// The fields for a governance action variant. Unknown types yield an empty
+/// form (the type tag alone is sent).
+pub fn fields_for_action(action_type: &str, ctx: &ComposerContext) -> Vec<ComposerField> {
+    let threshold = ctx.default_threshold.max(1);
+    match action_type {
+        "governance_add_member" => vec![
+            text("member", "Member party id"),
+            int_value("new_threshold", "New threshold", threshold, ""),
+        ],
+        "governance_remove_member" => vec![
+            text("member", "Member party id"),
+            int_value("new_threshold", "New threshold", threshold, ""),
+        ],
+        "governance_set_threshold" => {
+            vec![int_value("new_threshold", "New threshold", threshold, "")]
+        }
+        "governance_set_timeout" => vec![int_value(
+            "new_timeout_microseconds",
+            "Timeout (microseconds)",
+            3_600_000_000,
+            "1 hour = 3,600,000,000 µs",
+        )],
+        "vault_pause" | "vault_unpause" => vec![text("vault_id", "Vault contract id")],
+        "vault_update_limits" => vec![
+            text("vault_id", "Vault contract id"),
+            text_opt("new_limits.max_total_deposit", "Max total deposit"),
+            text_opt("new_limits.min_deposit_amount", "Min deposit amount"),
+            text_opt("new_limits.min_withdrawal_amount", "Min withdrawal amount"),
+        ],
+        "vault_update_backend" => vec![
+            text("vault_id", "Vault contract id"),
+            text("new_backend_signatory", "New backend signatory"),
+        ],
+        "vault_update_far_beneficiaries" => vec![
+            text("vault_id", "Vault contract id"),
+            rows(
+                "new_beneficiaries",
+                "Beneficiaries (party,weight)",
+                vec!["beneficiary", "weight"],
+            ),
+        ],
+        "vault_deployment" => {
+            let mut fields = vec![
+                text("vault_rules_cid", "Vault rules cid"),
+                text("vault_name", "Vault name"),
+                text("share_symbol", "Share symbol"),
+            ];
+            fields.extend(instrument_id("asset_instrument_id", String::new()));
+            fields.extend([
+                text_opt("limits.max_total_deposit", "Max total deposit"),
+                text_opt("limits.min_deposit_amount", "Min deposit amount"),
+                text_opt("limits.min_withdrawal_amount", "Min withdrawal amount"),
+                text("vault_backend_signatory", "Backend signatory"),
+                text("allocation_factory_cid", "Allocation factory cid"),
+                text("registrar_service_cid", "Registrar service cid"),
+            ]);
+            fields
+        }
+        "yield_epoch_deployment" => {
+            let mut fields = vec![
+                text("vault_rules_cid", "Vault rules cid"),
+                text("vault_cid", "Vault contract id"),
+            ];
+            fields.extend(instrument_id("asset_instrument_id", String::new()));
+            fields.push(text("vault_backend_signatory", "Backend signatory"));
+            fields
+        }
+        "processor_deployment_request" => vec![
+            text("vault_processor_rules_cid", "Processor rules cid"),
+            text("vault_backend_signatory", "Backend signatory"),
+            text("allocation_factory_cid", "Burn/mint factory cid"),
+            list_opt("initial_supported_vaults", "Initial supported vault cids"),
+        ],
+        "utility_create_provider_request" | "utility_create_user_request" => {
+            vec![text_value(
+                "operator",
+                "Operator party",
+                ctx.operator_party.clone(),
+            )]
+        }
+        "utility_setup" => vec![
+            text_value("operator", "Operator party", ctx.operator_party.clone()),
+            text("provider_service_cid", "Provider service cid"),
+            text("user_service_cid", "User service cid"),
+        ],
+        "utility_accept_holder_service_request" => vec![
+            text_value("operator", "Operator party", ctx.operator_party.clone()),
+            text("provider_service_cid", "Provider service cid"),
+            text("holder_service_request_cid", "Holder service request cid"),
+            text("holder", "Holder party"),
+        ],
+        "credential_offer_free" => vec![
+            text_value("operator", "Operator party", ctx.operator_party.clone()),
+            text("user_service_cid", "User service cid"),
+            text("holder", "Holder party"),
+            text("id", "Credential id"),
+            text("description", "Description"),
+            rows(
+                "claims",
+                "Claims (subject,property,value)",
+                vec!["subject", "property", "value"],
+            ),
+        ],
+        "credential_accept_free" => vec![
+            text_value("operator", "Operator party", ctx.operator_party.clone()),
+            text("user_service_cid", "User service cid"),
+            text("credential_offer_cid", "Credential offer cid"),
+        ],
+        "dev_net_feature_app" => vec![text("amulet_rules_cid", "Amulet rules cid")],
+        _ => Vec::new(),
+    }
+}
+
+/// The fields for a proposal variant.
+pub fn fields_for_proposal(proposal_type: &str, ctx: &ComposerContext) -> Vec<ComposerField> {
+    let party = ctx.party_id.clone();
+    let operator = || text_value("operator", "Operator party", ctx.operator_party.clone());
+    match proposal_type {
+        "generic_vote" => vec![text("description", "Vote description")],
+        "setup_cc_preapproval" => vec![
+            text("provider", "Provider party"),
+            text("expected_dso", "Expected DSO party"),
+        ],
+        "setup_token_preapproval" => vec![
+            operator(),
+            text("instrument_admin", "Instrument admin"),
+            rows("instrument_allowances", "Allowance ids", vec!["id"]),
+        ],
+        "transfer" => {
+            let mut fields = vec![
+                text("transfer_factory_cid", "Transfer factory cid"),
+                text("expected_admin", "Expected admin"),
+                text("receiver", "Receiver party"),
+                text("amount", "Amount"),
+            ];
+            fields.extend(instrument_id("instrument_id", String::new()));
+            fields.push(list_opt("input_holding_cids", "Input holding cids"));
+            fields.push(int_opt(
+                "validity_window_hours",
+                "Validity window (hours)",
+                "default 24",
+            ));
+            fields
+        }
+        "accept_transfer" => vec![text("transfer_instruction_cid", "Transfer instruction cid")],
+        "create_user_service_request" => vec![operator(), text_value("user", "User party", party)],
+        "create_provider_service_request" => {
+            vec![operator(), text_value("provider", "Provider party", party)]
+        }
+        "setup_utility" => vec![
+            text("provider_service_cid", "Provider service cid"),
+            operator(),
+            text("instrument_id_text", "Instrument id"),
+            boolean("create_transfer_rule", "Create transfer rule", true),
+            boolean(
+                "create_allocation_factory",
+                "Create allocation factory",
+                true,
+            ),
+        ],
+        "set_provider_app_reward_beneficiaries" => vec![
+            text("instrument_configuration_cid", "Instrument config cid"),
+            rows(
+                "provider_app_reward_beneficiaries",
+                "Beneficiaries (party,weight) — empty clears",
+                vec!["beneficiary", "weight"],
+            ),
+        ],
+        "set_enable_result_contracts" => vec![
+            text("registrar_service_cid", "Registrar service cid"),
+            select(
+                "enable_result_contracts",
+                "Enable result contracts",
+                vec![
+                    SelectOption::new("true", "Enable"),
+                    SelectOption::new("false", "Disable"),
+                    SelectOption::new("clear", "Clear (None)"),
+                ],
+                "true",
+            ),
+        ],
+        "create_delegated_batched_markers_proxy" => vec![operator()],
+        "mint" => {
+            let mut fields = vec![text("allocation_factory_cid", "Allocation factory cid")];
+            fields.extend(instrument_id("instrument_id", party));
+            fields.extend([
+                text("instrument_configuration_cid", "Instrument config cid"),
+                text("recipient", "Recipient party"),
+                text("amount", "Amount"),
+                text("description", "Description"),
+            ]);
+            fields
+        }
+        "burn" => {
+            let mut fields = vec![text("allocation_factory_cid", "Allocation factory cid")];
+            fields.extend(instrument_id("instrument_id", party));
+            fields.extend([
+                text("instrument_configuration_cid", "Instrument config cid"),
+                text("holder", "Holder party"),
+                text("amount", "Amount"),
+                text("description", "Description"),
+            ]);
+            fields
+        }
+        "accept_mint_request" => vec![
+            text("mint_request_cid", "Mint request cid"),
+            text("instrument_configuration_cid", "Instrument config cid"),
+            text("description", "Description"),
+        ],
+        "accept_burn_request" => vec![
+            text("burn_request_cid", "Burn request cid"),
+            text("instrument_configuration_cid", "Instrument config cid"),
+            text("description", "Description"),
+        ],
+        "offer_free_credential" => vec![
+            text("user_service_cid", "User service cid"),
+            text("holder", "Holder party"),
+            text("id", "Credential id"),
+            text("description", "Description"),
+            rows(
+                "claims",
+                "Claims (subject,property,value)",
+                vec!["subject", "property", "value"],
+            ),
+        ],
+        "accept_free_credential" => vec![
+            text("user_service_cid", "User service cid"),
+            text("credential_offer_cid", "Credential offer cid"),
+        ],
+        _ => Vec::new(),
+    }
+}
+
+/// Build the typed JSON payload for a composed form, or a human error message
+/// describing the first invalid / missing required field.
+pub fn build_payload(composer: &Composer) -> Result<Value, String> {
+    let mut root = Map::new();
+    root.insert(
+        "type".to_owned(),
+        Value::String(composer.action_type.to_owned()),
+    );
+    for field in &composer.fields {
+        if let Some(value) = field_value(field)? {
+            insert_path(&mut root, field.key, value);
+        }
+    }
+    Ok(Value::Object(root))
+}
+
+/// The typed JSON value for a field, or `None` when an optional field is empty.
+fn field_value(field: &ComposerField) -> Result<Option<Value>, String> {
+    let trimmed = field.value.trim();
+    let require = || -> Result<(), String> {
+        if field.optional || !trimmed.is_empty() {
+            Ok(())
+        } else {
+            Err(format!("{} is required", field.label))
+        }
+    };
+    match &field.kind {
+        FieldKind::Text => {
+            require()?;
+            Ok((!trimmed.is_empty()).then(|| Value::String(trimmed.to_owned())))
+        }
+        FieldKind::Int => {
+            require()?;
+            if trimmed.is_empty() {
+                return Ok(None);
+            }
+            trimmed
+                .parse::<i64>()
+                .map(|n| Some(Value::from(n)))
+                .map_err(|_| format!("{} must be a whole number", field.label))
+        }
+        FieldKind::Bool => Ok(Some(Value::Bool(trimmed == "true"))),
+        FieldKind::Select(_) => {
+            require()?;
+            Ok(match trimmed {
+                "" => None,
+                "null" | "clear" => Some(Value::Null),
+                "true" => Some(Value::Bool(true)),
+                "false" => Some(Value::Bool(false)),
+                other => Some(Value::String(other.to_owned())),
+            })
+        }
+        FieldKind::List => {
+            let items: Vec<Value> = trimmed
+                .lines()
+                .map(str::trim)
+                .filter(|line| !line.is_empty())
+                .map(|line| Value::String(line.to_owned()))
+                .collect();
+            if items.is_empty() && field.optional {
+                Ok(None)
+            } else {
+                Ok(Some(Value::Array(items)))
+            }
+        }
+        FieldKind::Rows(columns) => {
+            let mut out = Vec::new();
+            for line in trimmed.lines() {
+                let line = line.trim();
+                if line.is_empty() {
+                    continue;
+                }
+                let parts: Vec<&str> = line.split(',').map(str::trim).collect();
+                if parts.len() != columns.len() {
+                    return Err(format!(
+                        "{}: each row needs {} comma-separated values ({})",
+                        field.label,
+                        columns.len(),
+                        columns.join(",")
+                    ));
+                }
+                let mut obj = Map::new();
+                for (column, value) in columns.iter().zip(parts) {
+                    obj.insert((*column).to_owned(), Value::String(value.to_owned()));
+                }
+                out.push(Value::Object(obj));
+            }
+            if out.is_empty() && field.optional {
+                Ok(None)
+            } else {
+                Ok(Some(Value::Array(out)))
+            }
+        }
+    }
+}
+
+/// Insert `value` at a dot-separated `path`, creating intermediate objects.
+fn insert_path(root: &mut Map<String, Value>, path: &str, value: Value) {
+    let mut parts = path.split('.').peekable();
+    let mut current = root;
+    while let Some(part) = parts.next() {
+        if parts.peek().is_none() {
+            current.insert(part.to_owned(), value);
+            return;
+        }
+        let entry = current
+            .entry(part.to_owned())
+            .or_insert_with(|| Value::Object(Map::new()));
+        if !entry.is_object() {
+            *entry = Value::Object(Map::new());
+        }
+        match entry.as_object_mut() {
+            Some(next) => current = next,
+            None => return,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn composer(action_type: &'static str, fields: Vec<ComposerField>) -> Composer {
+        Composer {
+            title: "t".to_owned(),
+            action_type,
+            submit: ComposerSubmit::Propose,
+            party_id: "dec::1220".to_owned(),
+            party_name: "dec".to_owned(),
+            governance_type: "core_self".to_owned(),
+            rules_contract_id: "00rules".to_owned(),
+            fields,
+            cursor: 0,
+        }
+    }
+
+    /// Build a payload or fail the test with the error message.
+    fn built(action_type: &'static str, fields: Vec<ComposerField>) -> Value {
+        match build_payload(&composer(action_type, fields)) {
+            Ok(payload) => payload,
+            Err(error) => panic!("build_payload failed: {error}"),
+        }
+    }
+
+    #[test]
+    fn build_payload_flat_fields_typed() {
+        let fields = vec![
+            text_value("member", "Member", "m::1220".to_owned()),
+            int_value("new_threshold", "Threshold", 3, ""),
+        ];
+        let payload = built("governance_add_member", fields);
+        assert_eq!(payload["type"], "governance_add_member");
+        assert_eq!(payload["member"], "m::1220");
+        assert_eq!(payload["new_threshold"], 3);
+    }
+
+    #[test]
+    fn build_payload_nests_dot_paths_and_omits_optional() {
+        let fields = vec![
+            text_value("instrument_id.admin", "Admin", "adm::1220".to_owned()),
+            text_value("instrument_id.id", "Id", "CBTC".to_owned()),
+            text_opt("limits.max_total_deposit", "Max"),
+        ];
+        let payload = built("transfer", fields);
+        assert_eq!(payload["instrument_id"]["admin"], "adm::1220");
+        assert_eq!(payload["instrument_id"]["id"], "CBTC");
+        // The empty optional nested field is omitted entirely.
+        assert!(payload.get("limits").is_none());
+    }
+
+    #[test]
+    fn build_payload_rows_become_array_of_objects() {
+        let mut field = rows(
+            "new_beneficiaries",
+            "Beneficiaries",
+            vec!["beneficiary", "weight"],
+        );
+        field.value = "alice::1220,0.6\nbob::1220,0.4".to_owned();
+        let payload = built("vault_update_far_beneficiaries", vec![field]);
+        let Some(beneficiaries) = payload["new_beneficiaries"].as_array() else {
+            panic!("new_beneficiaries is not an array");
+        };
+        assert_eq!(beneficiaries.len(), 2);
+        assert_eq!(beneficiaries[0]["beneficiary"], "alice::1220");
+        assert_eq!(beneficiaries[0]["weight"], "0.6");
+    }
+
+    #[test]
+    fn build_payload_rejects_missing_required() {
+        let fields = vec![text("member", "Member party id")];
+        match build_payload(&composer("governance_add_member", fields)) {
+            Err(error) => assert!(error.contains("Member party id is required")),
+            Ok(_) => panic!("expected a missing-required error"),
+        }
+    }
+
+    #[test]
+    fn build_payload_rows_wrong_column_count_errors() {
+        let mut field = rows("claims", "Claims", vec!["subject", "property", "value"]);
+        field.value = "only,two".to_owned();
+        match build_payload(&composer("offer_free_credential", vec![field])) {
+            Err(error) => assert!(error.contains("each row needs 3")),
+            Ok(_) => panic!("expected a column-count error"),
+        }
+    }
+
+    #[test]
+    fn action_types_split_by_governance_type() {
+        let core = action_types("core_self");
+        assert_eq!(core.len(), 4);
+        assert!(
+            core.iter()
+                .all(|option| option.key.starts_with("governance_"))
+        );
+
+        let vault = action_types("vault");
+        assert!(vault.iter().any(|option| option.key == "vault_pause"));
+        assert!(
+            !vault
+                .iter()
+                .any(|option| option.key.starts_with("governance_"))
+        );
+
+        // The unimplemented paid-credential proposal is not offered.
+        assert!(
+            !proposal_types()
+                .iter()
+                .any(|option| option.key == "offer_paid_credential")
+        );
+    }
+
+    #[test]
+    fn fields_for_action_prefills_threshold_and_operator() {
+        let ctx = ComposerContext {
+            party_id: "dec::1".to_owned(),
+            operator_party: "op::1".to_owned(),
+            default_threshold: 5,
+        };
+        let fields = fields_for_action("governance_set_threshold", &ctx);
+        match fields.iter().find(|field| field.key == "new_threshold") {
+            Some(field) => assert_eq!(field.value, "5"),
+            None => panic!("new_threshold field missing"),
+        }
+
+        let setup = fields_for_action("utility_setup", &ctx);
+        match setup.iter().find(|field| field.key == "operator") {
+            Some(field) => assert_eq!(field.value, "op::1"),
+            None => panic!("operator field missing"),
+        }
+    }
+
+    #[test]
+    fn select_value_maps_to_bool_and_null() {
+        let mut field = select(
+            "enable_result_contracts",
+            "Enable",
+            vec![
+                SelectOption::new("true", "Enable"),
+                SelectOption::new("clear", "Clear"),
+            ],
+            "true",
+        );
+        field.value = "clear".to_owned();
+        assert_eq!(field_value(&field), Ok(Some(Value::Null)));
+        field.value = "true".to_owned();
+        assert_eq!(field_value(&field), Ok(Some(Value::Bool(true))));
+    }
+}

--- a/crates/decman-cli/src/main.rs
+++ b/crates/decman-cli/src/main.rs
@@ -1,6 +1,7 @@
 mod api;
 mod app;
 mod cli;
+mod composer;
 mod config;
 mod logo;
 mod ui;

--- a/crates/decman-cli/src/ui.rs
+++ b/crates/decman-cli/src/ui.rs
@@ -61,9 +61,12 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
                 " ↑/↓ field · type · ←/→ toggle · enter next/submit · esc cancel"
             }
             Overlay::Deploy(_) => " ↑/↓ field · type number · enter next/deploy · esc cancel",
+            Overlay::PartyConfig(_) => {
+                " ↑/↓ field · ←/→ provider · type · enter next/run · esc cancel"
+            }
             Overlay::Message(_) | Overlay::Busy(_) => " enter / esc to close",
             _ => {
-                " ↑/↓ audit · enter json · g gov · D deploy · c chain · K kick · esc back · q quit"
+                " ↑/↓ audit · enter json · a login · g gov · D deploy · c chain · K kick · esc back"
             }
         };
         frame.render_widget(
@@ -1148,6 +1151,25 @@ fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {
     Rect::new(x, y, width, height)
 }
 
+/// Draw a one-cell drop shadow behind a popup `rect` (offset down-right and
+/// clamped to `area`). Rendered before the popup's own `Clear`, so only the
+/// protruding bottom row and right column remain visible as the shadow.
+fn draw_shadow(frame: &mut Frame, rect: Rect, area: Rect) {
+    let x = rect.x.saturating_add(1);
+    let y = rect.y.saturating_add(1);
+    let max_x = area.x.saturating_add(area.width);
+    let max_y = area.y.saturating_add(area.height);
+    if x >= max_x || y >= max_y {
+        return;
+    }
+    let shadow = Rect::new(x, y, rect.width.min(max_x - x), rect.height.min(max_y - y));
+    frame.render_widget(Clear, shadow);
+    frame.render_widget(
+        Block::default().style(Style::default().bg(Color::Rgb(18, 18, 18))),
+        shadow,
+    );
+}
+
 /// The bordered block used by modal popups.
 fn popup_block(title: &str) -> Block<'static> {
     Block::bordered()
@@ -1310,6 +1332,7 @@ fn party_config_popup(frame: &mut Frame, area: Rect, form: &PartyConfigForm) {
     let rect = centered_rect(width, height, area);
     let title = format!("Party config · {}", form.party_name);
     let paragraph = Paragraph::new(lines).block(popup_block(&title));
+    draw_shadow(frame, rect, area);
     frame.render_widget(Clear, rect);
     frame.render_widget(paragraph, rect);
 }
@@ -1359,6 +1382,7 @@ fn peer_list_popup(frame: &mut Frame, area: Rect, state: &NetworkEditState) {
     let paragraph = Paragraph::new(lines)
         .scroll((scroll, 0))
         .block(popup_block("Network peers"));
+    draw_shadow(frame, rect, area);
     frame.render_widget(Clear, rect);
     frame.render_widget(paragraph, rect);
 }
@@ -1411,6 +1435,7 @@ fn peer_form_popup(frame: &mut Frame, area: Rect, form: &PeerForm) {
     let height = ((lines.len() as u16).saturating_add(2)).clamp(6, area.height.saturating_sub(4));
     let rect = centered_rect(width, height, area);
     let paragraph = Paragraph::new(lines).block(popup_block("Add peer"));
+    draw_shadow(frame, rect, area);
     frame.render_widget(Clear, rect);
     frame.render_widget(paragraph, rect);
 }
@@ -1476,6 +1501,7 @@ fn deploy_popup(frame: &mut Frame, area: Rect, form: &DeployForm) {
     let paragraph = Paragraph::new(lines)
         .scroll((0, 0))
         .block(popup_block(&title));
+    draw_shadow(frame, rect, area);
     frame.render_widget(Clear, rect);
     frame.render_widget(paragraph, rect);
 }
@@ -1513,6 +1539,7 @@ fn composer_pick_popup(frame: &mut Frame, area: Rect, pick: &ComposerPick) {
     let paragraph = Paragraph::new(lines)
         .scroll((scroll, 0))
         .block(popup_block(title));
+    draw_shadow(frame, rect, area);
     frame.render_widget(Clear, rect);
     frame.render_widget(paragraph, rect);
 }
@@ -1598,6 +1625,7 @@ fn composer_popup(frame: &mut Frame, area: Rect, composer: &Composer) {
     let paragraph = Paragraph::new(lines)
         .scroll((scroll, 0))
         .block(popup_block(&composer.title));
+    draw_shadow(frame, rect, area);
     frame.render_widget(Clear, rect);
     frame.render_widget(paragraph, rect);
 }
@@ -1709,6 +1737,7 @@ fn governance_popup(frame: &mut Frame, area: Rect, view: &GovView) {
     let paragraph = Paragraph::new(lines)
         .scroll((scroll, 0))
         .block(popup_block(&title));
+    draw_shadow(frame, rect, area);
     frame.render_widget(Clear, rect);
     frame.render_widget(paragraph, rect);
 }
@@ -1806,6 +1835,7 @@ fn auth_popup(frame: &mut Frame, area: Rect, parties: &[PartyAuthStatus], select
     let paragraph = Paragraph::new(lines)
         .scroll((scroll, 0))
         .block(popup_block("Authentication"));
+    draw_shadow(frame, rect, area);
     frame.render_widget(Clear, rect);
     frame.render_widget(paragraph, rect);
 }
@@ -1856,6 +1886,7 @@ fn grant_popup(frame: &mut Frame, area: Rect, form: &GrantForm) {
     let height = ((lines.len() as u16).saturating_add(2)).clamp(6, area.height.saturating_sub(4));
     let rect = centered_rect(width, height, area);
     let paragraph = Paragraph::new(lines).block(popup_block("Grant rights"));
+    draw_shadow(frame, rect, area);
     frame.render_widget(Clear, rect);
     frame.render_widget(paragraph, rect);
 }
@@ -1900,6 +1931,7 @@ fn chain_audit_popup(frame: &mut Frame, area: Rect, entries: &[ChainAuditEntry],
     let paragraph = Paragraph::new(lines)
         .scroll((scroll, 0))
         .block(popup_block("On-chain audit"));
+    draw_shadow(frame, rect, area);
     frame.render_widget(Clear, rect);
     frame.render_widget(paragraph, rect);
 }
@@ -1926,6 +1958,7 @@ fn json_popup(frame: &mut Frame, area: Rect, value: &serde_json::Value, scroll: 
     let paragraph = Paragraph::new(lines)
         .scroll((scroll, 0))
         .block(popup_block("Audit details"));
+    draw_shadow(frame, rect, area);
     frame.render_widget(Clear, rect);
     frame.render_widget(paragraph, rect);
 }
@@ -1939,6 +1972,7 @@ fn message_popup(frame: &mut Frame, area: Rect, title: &str, message: &str, colo
         .alignment(Alignment::Center)
         .wrap(Wrap { trim: true })
         .block(popup_block(title));
+    draw_shadow(frame, rect, area);
     frame.render_widget(Clear, rect);
     frame.render_widget(paragraph, rect);
 }
@@ -2005,6 +2039,7 @@ fn compare_popup(frame: &mut Frame, area: Rect, comparison: &PeerPackageComparis
     let paragraph = Paragraph::new(lines)
         .scroll((scroll, 0))
         .block(popup_block("Package check"));
+    draw_shadow(frame, rect, area);
     frame.render_widget(Clear, rect);
     frame.render_widget(paragraph, rect);
 }
@@ -2039,6 +2074,7 @@ fn peer_select_popup(
     let rect = centered_rect(width, height, area);
     let title = format!("Distribute {filename}");
     let paragraph = Paragraph::new(lines).block(popup_block(&title));
+    draw_shadow(frame, rect, area);
     frame.render_widget(Clear, rect);
     frame.render_widget(paragraph, rect);
 }
@@ -2087,6 +2123,7 @@ fn onboard_popup(frame: &mut Frame, area: Rect, form: &OnboardForm) {
     let height = ((lines.len() as u16) + 2).clamp(8, area.height.saturating_sub(4));
     let rect = centered_rect(width, height, area);
     let paragraph = Paragraph::new(lines).block(popup_block("Onboard new party"));
+    draw_shadow(frame, rect, area);
     frame.render_widget(Clear, rect);
     frame.render_widget(paragraph, rect);
 }
@@ -2140,6 +2177,7 @@ fn kick_popup(frame: &mut Frame, area: Rect, form: &KickForm) {
     let height = ((lines.len() as u16) + 2).clamp(8, area.height.saturating_sub(4));
     let rect = centered_rect(width, height, area);
     let paragraph = Paragraph::new(lines).block(popup_block("Kick participant"));
+    draw_shadow(frame, rect, area);
     frame.render_widget(Clear, rect);
     frame.render_widget(paragraph, rect);
 }
@@ -2160,6 +2198,7 @@ fn feed_detail_popup(frame: &mut Frame, area: Rect, item: &FeedItem, scroll: u16
         .scroll((scroll, 0))
         .wrap(Wrap { trim: false })
         .block(popup_block(&title));
+    draw_shadow(frame, rect, area);
     frame.render_widget(Clear, rect);
     frame.render_widget(paragraph, rect);
 }
@@ -3034,6 +3073,21 @@ mod tests {
         // A stored secret with a blank field shows the keep hint, never a value.
         assert!(rendered.contains("blank keeps it"));
         assert!(rendered.contains("Save"));
+    }
+
+    #[test]
+    fn draw_shadow_clamps_at_screen_edge_without_panicking() {
+        let Ok(mut terminal) = Terminal::new(TestBackend::new(20, 10)) else {
+            panic!("failed to build test terminal");
+        };
+        // A popup flush against the bottom-right corner: the offset shadow must
+        // clamp to the screen rather than panic on out-of-bounds.
+        let drawn = terminal.draw(|frame| {
+            let area = frame.area();
+            draw_shadow(frame, Rect::new(18, 8, 2, 2), area);
+            draw_shadow(frame, Rect::new(5, 3, 8, 4), area);
+        });
+        assert!(drawn.is_ok());
     }
 
     #[test]

--- a/crates/decman-cli/src/ui.rs
+++ b/crates/decman-cli/src/ui.rs
@@ -14,12 +14,13 @@ use common::types::{
 };
 
 use crate::api::{
-    AuthStatusKind, ChainAuditEntry, FeedItem, Holding, PartyAuthStatus, PeerView,
-    audit_action, invitation_name, party_name, run_name,
+    AuthStatusKind, ChainAuditEntry, FeedItem, Holding, PartyAuthStatus, PeerView, audit_action,
+    invitation_name, party_name, run_name,
 };
 use crate::app::{
-    App, ComposerKind, ComposerPick, DeployForm, DetailData, GovItem, GovView, GrantForm, KickForm,
-    NetworkEditState, OnboardForm, Overlay, PeerChoice, PeerForm, Status, Tab, TabView,
+    App, ComposerKind, ComposerPick, DeployForm, DetailData, GovItem, GovView, GrantForm, IdpMode,
+    KickForm, NetworkEditState, OnboardForm, Overlay, PartyConfigForm, PcRow, PeerChoice, PeerForm,
+    Status, Tab, TabView,
 };
 use crate::composer::{Composer, FieldKind};
 use crate::config::Profile;
@@ -1081,8 +1082,11 @@ fn footer_hint(active: Tab, overlay: &Overlay, can_logout: bool) -> String {
             " ↑/↓ field · space toggle peer · enter start · esc cancel".to_owned()
         }
         Overlay::Kick(_) => " ↑/↓ pick · ←/→ threshold · enter kick · esc cancel".to_owned(),
-        Overlay::Auth { .. } => " ↑/↓ select · t test · g grant rights · esc close".to_owned(),
+        Overlay::Auth { .. } => " ↑/↓ select · t test · g grant · e config · esc close".to_owned(),
         Overlay::GrantRights(_) => " ↑/↓ field · type · enter next/grant · esc cancel".to_owned(),
+        Overlay::PartyConfig(_) => {
+            " ↑/↓ field · ←/→ provider · type · enter next/run · esc cancel".to_owned()
+        }
         Overlay::Governance(_) => {
             " ↑/↓ · c confirm · e exec · r revoke · x expire · n new · p propose · esc".to_owned()
         }
@@ -1190,7 +1194,124 @@ fn draw_overlay(frame: &mut Frame, area: Rect, overlay: &Overlay, spinner: &str)
         Overlay::Composer(composer) => composer_popup(frame, area, composer),
         Overlay::Deploy(form) => deploy_popup(frame, area, form),
         Overlay::NetworkEdit(state) => network_edit_popup(frame, area, state),
+        Overlay::PartyConfig(form) => party_config_popup(frame, area, form),
     }
+}
+
+/// A `label  value` form row; the focused row is highlighted with a cursor.
+fn pc_line(label: &str, value: String, focused: bool) -> Line<'static> {
+    let style = if focused {
+        Style::default()
+            .fg(logo::ORANGE)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default()
+    };
+    let shown = if focused {
+        format!("{value}▏")
+    } else if value.is_empty() {
+        "(empty)".to_owned()
+    } else {
+        value
+    };
+    Line::from(vec![detail_label(label), Span::styled(shown, style)])
+}
+
+/// A masked secret row. Blank with a stored secret shows a keep hint.
+fn pc_secret_line(label: &str, value: &str, has_secret: bool, focused: bool) -> Line<'static> {
+    let style = if focused {
+        Style::default()
+            .fg(logo::ORANGE)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default()
+    };
+    let masked = "•".repeat(value.chars().count());
+    let shown = if focused {
+        format!("{masked}▏")
+    } else if value.is_empty() {
+        if has_secret {
+            "(set — blank keeps it)".to_owned()
+        } else {
+            "(none)".to_owned()
+        }
+    } else {
+        masked
+    };
+    Line::from(vec![detail_label(label), Span::styled(shown, style)])
+}
+
+/// An action button row (Discover / Save).
+fn pc_button(label: &str, focused: bool) -> Line<'static> {
+    let style = if focused {
+        Style::default()
+            .fg(Color::Black)
+            .bg(logo::ORANGE)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(Color::DarkGray)
+    };
+    Line::from(Span::styled(format!(" {label} "), style))
+}
+
+/// The per-party IdP configuration editor popup (Keycloak / Auth0).
+fn party_config_popup(frame: &mut Frame, area: Rect, form: &PartyConfigForm) {
+    let rows = form.rows();
+    let mut lines: Vec<Line> = rows
+        .iter()
+        .enumerate()
+        .map(|(index, row)| {
+            let focused = index == form.cursor;
+            match row {
+                PcRow::Mode => {
+                    let provider = match form.mode {
+                        IdpMode::Keycloak => "Keycloak",
+                        IdpMode::Auth0 => "Auth0",
+                    };
+                    pc_line("Provider", format!("‹ {provider} ›"), focused)
+                }
+                PcRow::MemberParty => {
+                    pc_line("Member party", form.member_party_id.clone(), focused)
+                }
+                PcRow::UserId => pc_line("User id", form.user_id.clone(), focused),
+                PcRow::KcUrl => pc_line("Keycloak URL", form.kc_url.clone(), focused),
+                PcRow::KcRealm => pc_line("Realm", form.kc_realm.clone(), focused),
+                PcRow::KcClientId => pc_line("Client id", form.kc_client_id.clone(), focused),
+                PcRow::KcSecret => pc_secret_line(
+                    "Client secret",
+                    &form.kc_secret,
+                    form.kc_has_secret,
+                    focused,
+                ),
+                PcRow::Auth0Domain => pc_line("Auth0 domain", form.auth0_domain.clone(), focused),
+                PcRow::Auth0Audience => pc_line("Audience", form.auth0_audience.clone(), focused),
+                PcRow::Auth0ClientId => pc_line("Client id", form.auth0_client_id.clone(), focused),
+                PcRow::Auth0Secret => pc_secret_line(
+                    "Client secret",
+                    &form.auth0_secret,
+                    form.auth0_has_secret,
+                    focused,
+                ),
+                PcRow::Discover => pc_button("Discover member party", focused),
+                PcRow::Submit => pc_button("Save", focused),
+            }
+        })
+        .collect();
+    if !form.status.is_empty() {
+        lines.push(Line::default());
+        lines.push(Line::styled(
+            form.status.clone(),
+            Style::default().fg(Color::DarkGray),
+        ));
+    }
+
+    let width = 76.min(area.width.saturating_sub(4));
+    let height = ((lines.len() as u16).saturating_add(2)).clamp(6, area.height.saturating_sub(4));
+    let rect = centered_rect(width, height, area);
+    let title = format!("Party config · {}", form.party_name);
+    let paragraph = Paragraph::new(lines).block(popup_block(&title));
+    frame.render_widget(Clear, rect);
+    frame.render_widget(paragraph, rect);
 }
 
 /// The network-config editor popup: the peer list, or the add-peer sub-form.
@@ -2880,6 +3001,39 @@ mod tests {
         assert!(rendered.contains("Add peer"));
         assert!(rendered.contains("Participant id"));
         assert!(rendered.contains("Public key"));
+    }
+
+    #[test]
+    fn party_config_popup_renders_keycloak_fields_and_secret_hint() {
+        let form = PartyConfigForm {
+            dec_party_id: "cbtc-network::1220".to_owned(),
+            party_name: "cbtc-network".to_owned(),
+            mode: IdpMode::Keycloak,
+            member_party_id: "member::1220".to_owned(),
+            user_id: "user-1".to_owned(),
+            kc_url: "https://kc".to_owned(),
+            kc_realm: "realm".to_owned(),
+            kc_client_id: "client".to_owned(),
+            kc_secret: String::new(),
+            kc_has_secret: true,
+            auth0_domain: String::new(),
+            auth0_audience: String::new(),
+            auth0_client_id: String::new(),
+            auth0_secret: String::new(),
+            auth0_has_secret: false,
+            // Focus the member-party row so the secret line renders unfocused.
+            cursor: 1,
+            status: String::new(),
+        };
+        let overlay = Overlay::PartyConfig(Box::new(form));
+        let rendered = render(|frame, area| draw_overlay(frame, area, &overlay, "⠋"));
+        assert!(rendered.contains("Party config"));
+        assert!(rendered.contains("Keycloak"));
+        assert!(rendered.contains("Member party"));
+        assert!(rendered.contains("Client id"));
+        // A stored secret with a blank field shows the keep hint, never a value.
+        assert!(rendered.contains("blank keeps it"));
+        assert!(rendered.contains("Save"));
     }
 
     #[test]

--- a/crates/decman-cli/src/ui.rs
+++ b/crates/decman-cli/src/ui.rs
@@ -376,9 +376,11 @@ fn summary_height(party: &DecentralizedParty, data: Option<&DetailData>) -> u16 
 }
 
 /// Format a microsecond duration as a compact human string (e.g. `24h`, `30m`).
+/// Days are only used for 2+ whole days, so a one-day timeout reads as `24h`
+/// (matching the web app's rel-time labels).
 fn format_micros_human(micros: i64) -> String {
     let secs = micros / 1_000_000;
-    if secs >= 86_400 && secs % 86_400 == 0 {
+    if secs >= 172_800 && secs % 86_400 == 0 {
         format!("{}d", secs / 86_400)
     } else if secs >= 3_600 && secs % 3_600 == 0 {
         format!("{}h", secs / 3_600)
@@ -2494,10 +2496,18 @@ mod tests {
         // The JSON is not shown inline — it opens as a modal (see below).
         assert!(!rendered.contains("new_threshold"));
         // The on-ledger governance state renders in the summary box (a
-        // 86_400_000_000µs timeout renders as "1d").
+        // 86_400_000_000µs timeout renders as "24h", not "1d").
         assert!(rendered.contains("Governance"));
         assert!(rendered.contains("threshold 2 of 3 members"));
-        assert!(rendered.contains("1d"));
+        assert!(rendered.contains("24h"));
+    }
+
+    #[test]
+    fn format_micros_human_uses_hours_for_one_day_and_days_for_two() {
+        assert_eq!(format_micros_human(86_400_000_000), "24h");
+        assert_eq!(format_micros_human(172_800_000_000), "2d");
+        assert_eq!(format_micros_human(3_600_000_000), "1h");
+        assert_eq!(format_micros_human(1_800_000_000), "30m");
     }
 
     #[test]

--- a/crates/decman-cli/src/ui.rs
+++ b/crates/decman-cli/src/ui.rs
@@ -14,7 +14,7 @@ use common::types::{
 };
 
 use crate::api::{
-    AuthStatusKind, ChainAuditEntry, FeedItem, GovState, Holding, PartyAuthStatus, PeerView,
+    AuthStatusKind, ChainAuditEntry, FeedItem, Holding, PartyAuthStatus, PeerView,
     audit_action, invitation_name, party_name, run_name,
 };
 use crate::app::{
@@ -353,12 +353,6 @@ fn holdings_count(data: Option<&DetailData>) -> usize {
         .map_or(1, |holdings| holdings.len().max(1))
 }
 
-/// The on-ledger governance state for the open party, if loaded.
-fn gov_state_of(data: Option<&DetailData>) -> Option<&GovState> {
-    data.and_then(|d| d.gov_state.as_ref().ok())
-        .and_then(Option::as_ref)
-}
-
 /// Height of the summary box, accounting for the optional owner-key and
 /// governance-state lines.
 fn summary_height(party: &DecentralizedParty, data: Option<&DetailData>) -> u16 {
@@ -366,11 +360,16 @@ fn summary_height(party: &DecentralizedParty, data: Option<&DetailData>) -> u16 
     if party.my_owner_key.is_some() {
         lines += 1;
     }
-    if let Some(state) = gov_state_of(data) {
-        lines += 1;
-        if state.out_of_date {
+    match data.map(|d| &d.gov_state) {
+        Some(Ok(Some(state))) => {
             lines += 1;
+            if state.out_of_date {
+                lines += 1;
+            }
         }
+        // Reserve a line to surface a governance-state load error.
+        Some(Err(_)) => lines += 1,
+        _ => {}
     }
     lines + 2
 }
@@ -422,24 +421,35 @@ fn draw_summary_box(
             Span::styled(key.clone(), Style::default().fg(logo::ORANGE)),
         ]));
     }
-    if let Some(state) = gov_state_of(data) {
-        let timeout = state
-            .action_confirmation_timeout_microseconds
-            .map_or_else(|| "—".to_owned(), format_micros_human);
-        lines.push(Line::from(vec![
-            label("Governance"),
-            Span::raw(format!(
-                "  threshold {threshold} of {members} members · timeout {timeout}",
-                threshold = state.threshold,
-                members = state.members.len(),
-            )),
-        ]));
-        if state.out_of_date {
-            lines.push(Line::styled(
-                "⚠ governance-core out of date — migrate this party",
-                Style::default().fg(Color::Yellow),
-            ));
+    match data.map(|d| &d.gov_state) {
+        Some(Ok(Some(state))) => {
+            let timeout = state
+                .action_confirmation_timeout_microseconds
+                .map_or_else(|| "—".to_owned(), format_micros_human);
+            lines.push(Line::from(vec![
+                label("Governance"),
+                Span::raw(format!(
+                    "  threshold {threshold} of {members} members · timeout {timeout}",
+                    threshold = state.threshold,
+                    members = state.members.len(),
+                )),
+            ]));
+            if state.out_of_date {
+                lines.push(Line::styled(
+                    "⚠ governance-core out of date — migrate this party",
+                    Style::default().fg(Color::Yellow),
+                ));
+            }
         }
+        // Surface a load error on its own line, like holdings / audit do.
+        Some(Err(error)) => lines.push(Line::from(vec![
+            label("Governance"),
+            Span::styled(
+                format!("  {}", truncate(error, 60)),
+                Style::default().fg(Color::Red),
+            ),
+        ])),
+        _ => {}
     }
     let block = popup_block(&format!("Party · {}", party_name(party)));
     frame.render_widget(Paragraph::new(lines).block(block), area);
@@ -1621,11 +1631,17 @@ fn auth_popup(frame: &mut Frame, area: Rect, parties: &[PartyAuthStatus], select
             selected_offset = u16::try_from(lines.len()).unwrap_or(0);
         }
         let marker = if index == selected { "▶ " } else { "  " };
-        lines.push(Line::from(Span::styled(
-            format!("{marker}{}", id_prefix(&party.dec_party_id)),
+        // Only the selected party's header is highlighted, like the other lists.
+        let header_style = if index == selected {
             Style::default()
                 .fg(logo::ORANGE)
-                .add_modifier(Modifier::BOLD),
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(Color::Gray)
+        };
+        lines.push(Line::from(Span::styled(
+            format!("{marker}{}", id_prefix(&party.dec_party_id)),
+            header_style,
         )));
         if let Some(member) = &party.member_party_id {
             lines.push(Line::from(vec![
@@ -2401,6 +2417,8 @@ mod tests {
 
     #[test]
     fn party_detail_renders_fields() {
+        use crate::api::GovState;
+
         let party_id = canton_id("cbtc-network");
         let participant_id = CantonId::parse(&format!("participant-1::{NS2}")).unwrap();
         let party = DecentralizedParty {

--- a/crates/decman-cli/src/ui.rs
+++ b/crates/decman-cli/src/ui.rs
@@ -1104,7 +1104,7 @@ fn footer_hint(active: Tab, overlay: &Overlay, can_logout: bool) -> String {
         }
         .to_owned(),
         Overlay::Message(_) => " enter / esc to close".to_owned(),
-        Overlay::Busy(_) => " working… · esc to dismiss".to_owned(),
+        Overlay::Busy(_) => " working… · enter/esc to dismiss".to_owned(),
         Overlay::None => {
             let base = match active {
                 Tab::Parties => " ↑↓ nav · enter view · n onboard · r refresh",

--- a/crates/decman-cli/src/ui.rs
+++ b/crates/decman-cli/src/ui.rs
@@ -2493,10 +2493,11 @@ mod tests {
         assert!(rendered.contains("success"));
         // The JSON is not shown inline — it opens as a modal (see below).
         assert!(!rendered.contains("new_threshold"));
-        // The on-ledger governance state renders in the summary box.
+        // The on-ledger governance state renders in the summary box (a
+        // 86_400_000_000µs timeout renders as "1d").
         assert!(rendered.contains("Governance"));
         assert!(rendered.contains("threshold 2 of 3 members"));
-        assert!(rendered.contains("24h"));
+        assert!(rendered.contains("1d"));
     }
 
     #[test]

--- a/crates/decman-cli/src/ui.rs
+++ b/crates/decman-cli/src/ui.rs
@@ -9,14 +9,19 @@ use ratatui::widgets::{
 };
 
 use common::types::{
-    ConnectionStatus, DecentralizedParty, PeerErrorKind, PeerPackageComparison, Permission,
-    VettedPackageInfo, WorkflowProgress,
+    ConnectionStatus, DecentralizedParty, PeerErrorKind, PeerPackageComparison, PendingInvitation,
+    Permission, VettedPackageInfo, WorkflowProgress, WorkflowRun,
 };
 
 use crate::api::{
-    FeedItem, Holding, PeerView, audit_action, invitation_name, party_name, run_name,
+    AuthStatusKind, ChainAuditEntry, FeedItem, GovState, Holding, PartyAuthStatus, PeerView,
+    audit_action, invitation_name, party_name, run_name,
 };
-use crate::app::{App, DetailData, Overlay, PeerChoice, Status, Tab, TabView};
+use crate::app::{
+    App, ComposerKind, ComposerPick, DeployForm, DetailData, GovItem, GovView, KickForm,
+    OnboardForm, Overlay, PeerChoice, Status, Tab, TabView,
+};
+use crate::composer::{Composer, FieldKind};
 use crate::config::Profile;
 use crate::logo;
 
@@ -44,10 +49,21 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         if let Some((party, data, audit_state)) = app.detail_view() {
             draw_party_detail(frame, body, party, data, audit_state);
         }
-        let hint = if matches!(app.overlay(), Overlay::Json { .. }) {
-            " ↑/↓ scroll · esc close"
-        } else {
-            " ↑/↓ audit · enter json · esc back · q quit"
+        let hint = match app.overlay() {
+            Overlay::Json { .. } | Overlay::ChainAudit { .. } => " ↑/↓ scroll · esc close",
+            Overlay::Kick(_) => " ↑/↓ pick · ←/→ threshold · enter kick · esc cancel",
+            Overlay::Governance(_) => {
+                " ↑/↓ · c confirm · e exec · r revoke · x expire · n new · p propose · esc"
+            }
+            Overlay::ComposerPick(_) => " ↑/↓ pick · enter open · esc cancel",
+            Overlay::Composer(_) => {
+                " ↑/↓ field · type · ←/→ toggle · enter next/submit · esc cancel"
+            }
+            Overlay::Deploy(_) => " ↑/↓ field · type number · enter next/deploy · esc cancel",
+            Overlay::Message(_) | Overlay::Busy(_) => " enter / esc to close",
+            _ => {
+                " ↑/↓ audit · enter json · g gov · D deploy · c chain · K kick · esc back · q quit"
+            }
         };
         frame.render_widget(
             Paragraph::new(hint).style(Style::default().fg(Color::DarkGray)),
@@ -309,7 +325,7 @@ fn draw_party_detail(
     audit_state: &mut TableState,
 ) {
     let [summary, participants, contracts, holdings, audit] = Layout::vertical([
-        Constraint::Length(if party.my_owner_key.is_some() { 5 } else { 4 }),
+        Constraint::Length(summary_height(party, data)),
         Constraint::Length(box_height(party.participants.len(), 5)),
         Constraint::Length(box_height(party.contracts.len(), 5)),
         // +1 content row for the holdings header line.
@@ -318,7 +334,7 @@ fn draw_party_detail(
     ])
     .areas(area);
 
-    draw_summary_box(frame, summary, party);
+    draw_summary_box(frame, summary, party, data);
     draw_participants_box(frame, participants, party);
     draw_contracts_box(frame, contracts, party);
     draw_holdings_box(frame, holdings, data);
@@ -337,8 +353,50 @@ fn holdings_count(data: Option<&DetailData>) -> usize {
         .map_or(1, |holdings| holdings.len().max(1))
 }
 
-/// The party summary box: id, threshold/owners/participants/contracts, key.
-fn draw_summary_box(frame: &mut Frame, area: Rect, party: &DecentralizedParty) {
+/// The on-ledger governance state for the open party, if loaded.
+fn gov_state_of(data: Option<&DetailData>) -> Option<&GovState> {
+    data.and_then(|d| d.gov_state.as_ref().ok())
+        .and_then(Option::as_ref)
+}
+
+/// Height of the summary box, accounting for the optional owner-key and
+/// governance-state lines.
+fn summary_height(party: &DecentralizedParty, data: Option<&DetailData>) -> u16 {
+    let mut lines = 2u16;
+    if party.my_owner_key.is_some() {
+        lines += 1;
+    }
+    if let Some(state) = gov_state_of(data) {
+        lines += 1;
+        if state.out_of_date {
+            lines += 1;
+        }
+    }
+    lines + 2
+}
+
+/// Format a microsecond duration as a compact human string (e.g. `24h`, `30m`).
+fn format_micros_human(micros: i64) -> String {
+    let secs = micros / 1_000_000;
+    if secs >= 86_400 && secs % 86_400 == 0 {
+        format!("{}d", secs / 86_400)
+    } else if secs >= 3_600 && secs % 3_600 == 0 {
+        format!("{}h", secs / 3_600)
+    } else if secs >= 60 && secs % 60 == 0 {
+        format!("{}m", secs / 60)
+    } else {
+        format!("{secs}s")
+    }
+}
+
+/// The party summary box: id, threshold/owners/participants/contracts, key, and
+/// on-ledger governance state (threshold, members, action timeout) when loaded.
+fn draw_summary_box(
+    frame: &mut Frame,
+    area: Rect,
+    party: &DecentralizedParty,
+    data: Option<&DetailData>,
+) {
     let label = |text: &'static str| Span::styled(text, Style::default().fg(Color::DarkGray));
     let mut lines = vec![
         Line::from(vec![
@@ -361,6 +419,25 @@ fn draw_summary_box(frame: &mut Frame, area: Rect, party: &DecentralizedParty) {
             label("Your key  "),
             Span::styled(key.clone(), Style::default().fg(logo::ORANGE)),
         ]));
+    }
+    if let Some(state) = gov_state_of(data) {
+        let timeout = state
+            .action_confirmation_timeout_microseconds
+            .map_or_else(|| "—".to_owned(), format_micros_human);
+        lines.push(Line::from(vec![
+            label("Governance"),
+            Span::raw(format!(
+                "  threshold {threshold} of {members} members · timeout {timeout}",
+                threshold = state.threshold,
+                members = state.members.len(),
+            )),
+        ]));
+        if state.out_of_date {
+            lines.push(Line::styled(
+                "⚠ governance-core out of date — migrate this party",
+                Style::default().fg(Color::Yellow),
+            ));
+        }
     }
     let block = popup_block(&format!("Party · {}", party_name(party)));
     frame.render_widget(Paragraph::new(lines).block(block), area);
@@ -985,20 +1062,39 @@ fn footer_hint(active: Tab, overlay: &Overlay, can_logout: bool) -> String {
             " ↑/↓ move · space toggle · enter distribute · esc cancel".to_owned()
         }
         Overlay::Compare { .. } => " ↑/↓ scroll · esc close".to_owned(),
-        Overlay::Json { .. } => " ↑/↓ scroll · esc close".to_owned(),
+        Overlay::Json { .. } | Overlay::FeedDetail { .. } | Overlay::ChainAudit { .. } => {
+            " ↑/↓ scroll · esc close".to_owned()
+        }
+        Overlay::Onboard(_) => {
+            " ↑/↓ field · space toggle peer · enter start · esc cancel".to_owned()
+        }
+        Overlay::Kick(_) => " ↑/↓ pick · ←/→ threshold · enter kick · esc cancel".to_owned(),
+        Overlay::Auth { .. } => " ↑/↓ scroll · t test auth · esc close".to_owned(),
+        Overlay::Governance(_) => {
+            " ↑/↓ · c confirm · e exec · r revoke · x expire · n new · p propose · esc".to_owned()
+        }
+        Overlay::ComposerPick(_) => " ↑/↓ pick · enter open · esc cancel".to_owned(),
+        Overlay::Composer(_) => {
+            " ↑/↓ field · type to edit · ←/→ toggle · enter next/submit · esc cancel".to_owned()
+        }
+        Overlay::Deploy(_) => {
+            " ↑/↓ field · type number · enter next/deploy · esc cancel".to_owned()
+        }
         Overlay::Message(_) => " enter / esc to close".to_owned(),
         Overlay::Busy(_) => " working… · esc to dismiss".to_owned(),
         Overlay::None => {
             let base = match active {
-                Tab::Parties => " ↑↓ nav · enter view · r refresh",
+                Tab::Parties => " ↑↓ nav · enter view · n onboard · r refresh",
                 Tab::Peers => " ↑↓ nav · tab switch",
                 Tab::Dars => " c check · u upload · d distribute",
-                Tab::Workflows => " a accept · x deny · d dismiss",
+                Tab::Workflows => {
+                    " a accept · x deny · c cancel · t retry · enter detail · d dismiss"
+                }
             };
             let tail = if can_logout {
-                " · esc logout · q quit"
+                " · A auth · esc logout · q quit"
             } else {
-                " · q quit"
+                " · A auth · q quit"
             };
             format!("{base}{tail}")
         }
@@ -1064,6 +1160,449 @@ fn draw_overlay(frame: &mut Frame, area: Rect, overlay: &Overlay, spinner: &str)
             peer_select_popup(frame, area, &dar.filename, peers, *cursor);
         }
         Overlay::Json { value, scroll } => json_popup(frame, area, value, *scroll),
+        Overlay::Onboard(form) => onboard_popup(frame, area, form),
+        Overlay::Kick(form) => kick_popup(frame, area, form),
+        Overlay::FeedDetail { item, scroll } => feed_detail_popup(frame, area, item, *scroll),
+        Overlay::ChainAudit { entries, scroll } => chain_audit_popup(frame, area, entries, *scroll),
+        Overlay::Auth { parties, scroll } => auth_popup(frame, area, parties, *scroll),
+        Overlay::Governance(view) => governance_popup(frame, area, view),
+        Overlay::ComposerPick(pick) => composer_pick_popup(frame, area, pick),
+        Overlay::Composer(composer) => composer_popup(frame, area, composer),
+        Overlay::Deploy(form) => deploy_popup(frame, area, form),
+    }
+}
+
+/// The governance-core contract deployment popup: resolved context plus the two
+/// editable fields (threshold, timeout) and a submit row.
+fn deploy_popup(frame: &mut Frame, area: Rect, form: &DeployForm) {
+    let edit_line = |label: &str, value: &str, focused: bool| {
+        let value_style = if focused {
+            Style::default()
+                .fg(logo::ORANGE)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default()
+        };
+        let shown = if focused {
+            format!("{value}▏")
+        } else {
+            value.to_owned()
+        };
+        Line::from(vec![detail_label(label), Span::styled(shown, value_style)])
+    };
+
+    let mut lines = vec![
+        detail_kv("Contract", "GovernanceRules".to_owned()),
+        detail_kv(
+            "Package",
+            if form.package_id.is_empty() {
+                "(governance-core DAR not vetted)".to_owned()
+            } else {
+                truncate(&form.package_id, 44)
+            },
+        ),
+        detail_kv("Members", form.member_parties.len().to_string()),
+    ];
+    lines.extend(
+        form.member_parties
+            .iter()
+            .map(|member| detail_item(id_prefix(member).to_owned())),
+    );
+    lines.push(Line::default());
+    lines.push(edit_line("Threshold", &form.threshold, form.cursor == 0));
+    lines.push(edit_line(
+        "Timeout (µs)",
+        &form.timeout_micros,
+        form.cursor == 1,
+    ));
+    lines.push(Line::default());
+    let submit_style = if form.cursor >= 2 {
+        Style::default()
+            .fg(Color::Black)
+            .bg(logo::ORANGE)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(Color::DarkGray)
+    };
+    lines.push(Line::from(Span::styled(" Deploy ", submit_style)));
+
+    let width = 70.min(area.width.saturating_sub(4));
+    let height = ((lines.len() as u16).saturating_add(2)).clamp(6, area.height.saturating_sub(4));
+    let rect = centered_rect(width, height, area);
+    let title = format!("Deploy governance · {}", form.party_name);
+    let paragraph = Paragraph::new(lines)
+        .scroll((0, 0))
+        .block(popup_block(&title));
+    frame.render_widget(Clear, rect);
+    frame.render_widget(paragraph, rect);
+}
+
+/// The action / proposal type picker popup.
+fn composer_pick_popup(frame: &mut Frame, area: Rect, pick: &ComposerPick) {
+    let title = match pick.kind {
+        ComposerKind::Action => "New governance action",
+        ComposerKind::Proposal => "New proposal",
+    };
+    let lines: Vec<Line> = pick
+        .options
+        .iter()
+        .enumerate()
+        .map(|(index, option)| {
+            let selected = index == pick.selected;
+            let marker = if selected { "▶ " } else { "  " };
+            let style = if selected {
+                Style::default()
+                    .fg(logo::ORANGE)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default()
+            };
+            Line::from(Span::styled(format!("{marker}{}", option.label), style))
+        })
+        .collect();
+
+    let width = 56.min(area.width.saturating_sub(4));
+    let height = ((lines.len() as u16).saturating_add(2)).clamp(6, area.height.saturating_sub(4));
+    let visible = height.saturating_sub(2);
+    let selected = u16::try_from(pick.selected).unwrap_or(0);
+    let scroll = selected.saturating_sub(visible.saturating_sub(1));
+    let rect = centered_rect(width, height, area);
+    let paragraph = Paragraph::new(lines)
+        .scroll((scroll, 0))
+        .block(popup_block(title));
+    frame.render_widget(Clear, rect);
+    frame.render_widget(paragraph, rect);
+}
+
+/// The display string for a composer field's current value.
+fn composer_field_display(field: &crate::composer::ComposerField, focused: bool) -> String {
+    match &field.kind {
+        FieldKind::Bool => format!("‹ {} ›", field.value),
+        FieldKind::Select(options) => {
+            let label = options
+                .iter()
+                .find(|option| option.value == field.value)
+                .map_or(field.value.as_str(), |option| option.label);
+            format!("‹ {label} ›")
+        }
+        FieldKind::List | FieldKind::Rows(_) => {
+            let preview = field.value.replace('\n', " | ");
+            if focused {
+                format!("{preview}▏")
+            } else if preview.is_empty() {
+                "(empty)".to_owned()
+            } else {
+                preview
+            }
+        }
+        FieldKind::Text | FieldKind::Int => {
+            if focused {
+                format!("{}▏", field.value)
+            } else if field.value.is_empty() {
+                "(empty)".to_owned()
+            } else {
+                field.value.clone()
+            }
+        }
+    }
+}
+
+/// The composer form popup: one row per field plus a virtual submit row.
+fn composer_popup(frame: &mut Frame, area: Rect, composer: &Composer) {
+    let mut lines: Vec<Line> = Vec::new();
+    for (index, field) in composer.fields.iter().enumerate() {
+        let focused = index == composer.cursor;
+        let value_style = if focused {
+            Style::default()
+                .fg(logo::ORANGE)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default()
+        };
+        let mut spans = vec![
+            Span::styled(
+                format!("{:<24}", truncate(field.label, 24)),
+                Style::default().fg(Color::DarkGray),
+            ),
+            Span::styled(composer_field_display(field, focused), value_style),
+        ];
+        if focused && !field.help.is_empty() {
+            spans.push(Span::styled(
+                format!("   {}", field.help),
+                Style::default().fg(Color::DarkGray),
+            ));
+        }
+        lines.push(Line::from(spans));
+    }
+    lines.push(Line::default());
+    let submit_focused = composer.cursor >= composer.fields.len();
+    let submit_style = if submit_focused {
+        Style::default()
+            .fg(Color::Black)
+            .bg(logo::ORANGE)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(Color::DarkGray)
+    };
+    lines.push(Line::from(Span::styled(" Submit ", submit_style)));
+
+    let width = 78.min(area.width.saturating_sub(4));
+    let height = ((lines.len() as u16).saturating_add(2)).clamp(6, area.height.saturating_sub(4));
+    let visible = height.saturating_sub(2);
+    let cursor = u16::try_from(composer.cursor).unwrap_or(0);
+    let scroll = cursor.saturating_sub(visible.saturating_sub(1));
+    let rect = centered_rect(width, height, area);
+    let paragraph = Paragraph::new(lines)
+        .scroll((scroll, 0))
+        .block(popup_block(&composer.title));
+    frame.render_widget(Clear, rect);
+    frame.render_widget(paragraph, rect);
+}
+
+/// Title-case a snake_case identifier (e.g. `set_threshold` → `Set Threshold`).
+fn humanize(value: &str) -> String {
+    let mut out = String::new();
+    for (i, word) in value.split('_').enumerate() {
+        if i > 0 {
+            out.push(' ');
+        }
+        let mut chars = word.chars();
+        if let Some(first) = chars.next() {
+            out.extend(first.to_uppercase());
+            out.push_str(chars.as_str());
+        }
+    }
+    out
+}
+
+/// A short human summary of an off-chain governance action (its `type` plus a
+/// salient field).
+fn gov_action_summary(action: &serde_json::Value) -> String {
+    let field_str = |key: &str| action.get(key).and_then(serde_json::Value::as_str);
+    let field_i64 = |key: &str| action.get(key).and_then(serde_json::Value::as_i64);
+    let kind = field_str("type").unwrap_or("action");
+    let base = humanize(kind);
+    let detail = match kind {
+        "governance_set_threshold" => field_i64("new_threshold").map(|n| format!("→ {n}")),
+        "governance_add_member" | "governance_remove_member" => {
+            field_str("member").map(|m| id_prefix(m).to_owned())
+        }
+        "governance_set_timeout" => field_i64("new_timeout_microseconds").map(format_micros_human),
+        "vault_pause" | "vault_unpause" | "vault_update_limits" | "vault_update_backend" => {
+            field_str("vault_id").map(|v| truncate(v, 12))
+        }
+        _ => None,
+    };
+    match detail {
+        Some(detail) => format!("{base}  {detail}"),
+        None => base,
+    }
+}
+
+/// The governance approvals popup: a selectable list of pending actions.
+fn governance_popup(frame: &mut Frame, area: Rect, view: &GovView) {
+    let ready = || Span::styled("  ✓ ready", Style::default().fg(Color::Green));
+    let dim = || Style::default().fg(Color::DarkGray);
+
+    let mut lines: Vec<Line> = Vec::new();
+    if view.items.is_empty() {
+        lines.push(dim_line("(no pending approvals)"));
+    }
+    for (index, item) in view.items.iter().enumerate() {
+        let selected = index == view.selected;
+        let marker = if selected { "▶ " } else { "  " };
+        let style = if selected {
+            Style::default()
+                .fg(logo::ORANGE)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default()
+        };
+        let mut spans = vec![Span::styled(marker, style)];
+        match item {
+            GovItem::OffChain(action) => {
+                spans.push(Span::styled(gov_action_summary(&action.action), style));
+                spans.push(Span::styled(
+                    format!("  {}/{}", action.confirmation_count, view.threshold),
+                    dim(),
+                ));
+                if action.can_execute {
+                    spans.push(ready());
+                }
+            }
+            GovItem::Domain(domain) => {
+                spans.push(Span::styled("[chain] ", Style::default().fg(Color::Cyan)));
+                let label = match domain.description.as_deref().filter(|d| !d.is_empty()) {
+                    Some(description) => format!("{} — {description}", domain.action_label),
+                    None => domain.action_label.clone(),
+                };
+                spans.push(Span::styled(label, style));
+                spans.push(Span::styled(
+                    format!("  {}", domain.confirmation_count),
+                    dim(),
+                ));
+                if domain.can_execute {
+                    spans.push(ready());
+                }
+                if domain.orphaned {
+                    spans.push(Span::styled("  orphaned", Style::default().fg(Color::Red)));
+                }
+            }
+        }
+        lines.push(Line::from(spans));
+    }
+
+    let width = 86.min(area.width.saturating_sub(4));
+    let height = ((lines.len() as u16).saturating_add(2)).clamp(6, area.height.saturating_sub(4));
+    let visible = height.saturating_sub(2);
+    let selected = u16::try_from(view.selected).unwrap_or(0);
+    let scroll = selected.saturating_sub(visible.saturating_sub(1));
+    let rect = centered_rect(width, height, area);
+    let title = format!(
+        "Approvals · {party} · threshold {threshold}",
+        party = view.party_name,
+        threshold = view.threshold
+    );
+    let paragraph = Paragraph::new(lines)
+        .scroll((scroll, 0))
+        .block(popup_block(&title));
+    frame.render_widget(Clear, rect);
+    frame.render_widget(paragraph, rect);
+}
+
+/// The human-readable prefix of a Canton id (segment before `::`).
+fn id_prefix(id: &str) -> &str {
+    id.split("::").next().unwrap_or(id)
+}
+
+/// Display color and label for a per-party authentication status.
+fn auth_status_display(status: &AuthStatusKind) -> (Color, String) {
+    match status {
+        AuthStatusKind::Authenticated => (Color::Green, "authenticated".to_owned()),
+        AuthStatusKind::Mock => (logo::ORANGE, "mock".to_owned()),
+        AuthStatusKind::Failed { error } => (Color::Red, format!("failed: {error}")),
+        AuthStatusKind::Notconfigured => (Color::DarkGray, "not configured".to_owned()),
+    }
+}
+
+/// A `✓ label` / `✗ label` chip, green when the right is held, else dim.
+fn right_chip(label: &str, held: bool) -> Span<'static> {
+    let (mark, color) = if held {
+        ("✓", Color::Green)
+    } else {
+        ("✗", Color::DarkGray)
+    };
+    Span::styled(format!("{mark} {label}"), Style::default().fg(color))
+}
+
+/// The authentication-status popup: each party's IdP status and ledger rights.
+fn auth_popup(frame: &mut Frame, area: Rect, parties: &[PartyAuthStatus], scroll: u16) {
+    let mut lines: Vec<Line> = Vec::new();
+    if parties.is_empty() {
+        lines.push(dim_line("(no parties configured)"));
+    }
+    let label = |text: &'static str| Span::styled(text, Style::default().fg(Color::DarkGray));
+    for party in parties {
+        lines.push(Line::from(Span::styled(
+            id_prefix(&party.dec_party_id).to_owned(),
+            Style::default()
+                .fg(logo::ORANGE)
+                .add_modifier(Modifier::BOLD),
+        )));
+        if let Some(member) = &party.member_party_id {
+            lines.push(Line::from(vec![
+                label("  member  "),
+                Span::raw(id_prefix(member).to_owned()),
+            ]));
+        }
+        if let Some(user) = &party.user_id {
+            lines.push(Line::from(vec![
+                label("  user    "),
+                Span::raw(user.clone()),
+            ]));
+        }
+        let (color, status_label) = auth_status_display(&party.status);
+        lines.push(Line::from(vec![
+            label("  status  "),
+            Span::styled(status_label, Style::default().fg(color)),
+        ]));
+        if let Some(rights) = &party.rights {
+            lines.push(Line::from(vec![
+                label("  rights  "),
+                label("member "),
+                right_chip("actAs", rights.member_party_act_as),
+                Span::raw(" "),
+                right_chip("readAs", rights.member_party_read_as),
+                label("  · dec "),
+                right_chip("actAs", rights.dec_party_act_as),
+                Span::raw(" "),
+                right_chip("readAs", rights.dec_party_read_as),
+            ]));
+        }
+        lines.push(Line::default());
+    }
+
+    let width = 76.min(area.width.saturating_sub(4));
+    let height = ((lines.len() as u16).saturating_add(2)).clamp(6, area.height.saturating_sub(4));
+    let rect = centered_rect(width, height, area);
+    let paragraph = Paragraph::new(lines)
+        .scroll((scroll, 0))
+        .block(popup_block("Authentication"));
+    frame.render_widget(Clear, rect);
+    frame.render_widget(paragraph, rect);
+}
+
+/// A scrollable popup of the on-chain governance audit trail.
+fn chain_audit_popup(frame: &mut Frame, area: Rect, entries: &[ChainAuditEntry], scroll: u16) {
+    let lines: Vec<Line> = if entries.is_empty() {
+        vec![dim_line("(no on-chain audit entries)")]
+    } else {
+        entries
+            .iter()
+            .map(|entry| {
+                let summary = if entry.action_summary.is_empty() {
+                    entry
+                        .choice
+                        .clone()
+                        .unwrap_or_else(|| entry.event_type.clone())
+                } else {
+                    entry.action_summary.clone()
+                };
+                Line::from(vec![
+                    Span::styled(
+                        format!("{:<17}", format_timestamp(entry.timestamp)),
+                        Style::default().fg(Color::DarkGray),
+                    ),
+                    Span::styled(
+                        format!("{:<9}", truncate(&entry.event_type, 9)),
+                        Style::default().fg(chain_event_color(&entry.event_type)),
+                    ),
+                    Span::styled(
+                        format!("{:<12}", truncate(&entry.governance_type, 12)),
+                        Style::default().fg(Color::DarkGray),
+                    ),
+                    Span::raw(summary),
+                ])
+            })
+            .collect()
+    };
+    let width = 84.min(area.width.saturating_sub(4));
+    let height = ((lines.len() as u16).saturating_add(2)).clamp(6, area.height.saturating_sub(4));
+    let rect = centered_rect(width, height, area);
+    let paragraph = Paragraph::new(lines)
+        .scroll((scroll, 0))
+        .block(popup_block("On-chain audit"));
+    frame.render_widget(Clear, rect);
+    frame.render_widget(paragraph, rect);
+}
+
+/// Color for an on-chain audit event type.
+fn chain_event_color(event_type: &str) -> Color {
+    match event_type {
+        "execute" => Color::Green,
+        "propose" | "confirm" => logo::ORANGE,
+        "cancel" | "expire" => Color::Red,
+        _ => Color::Gray,
     }
 }
 
@@ -1194,6 +1733,266 @@ fn peer_select_popup(
     let paragraph = Paragraph::new(lines).block(popup_block(&title));
     frame.render_widget(Clear, rect);
     frame.render_widget(paragraph, rect);
+}
+
+/// The onboarding (create-party) form popup: a prefix field above a tickable
+/// peer list, with the focused element highlighted.
+fn onboard_popup(frame: &mut Frame, area: Rect, form: &OnboardForm) {
+    let prefix_focus = form.cursor == 0;
+    let prefix_span = if form.prefix.is_empty() && !prefix_focus {
+        Span::styled("<party id prefix>", Style::default().fg(Color::DarkGray))
+    } else {
+        let cursor = if prefix_focus { "▏" } else { "" };
+        Span::styled(
+            format!("{}{cursor}", form.prefix),
+            Style::default()
+                .fg(logo::ORANGE)
+                .add_modifier(Modifier::BOLD),
+        )
+    };
+    let mut lines = vec![
+        Line::from(vec![
+            Span::styled("Prefix  ", Style::default().fg(Color::DarkGray)),
+            prefix_span,
+        ]),
+        Line::default(),
+        dim_line("Invite peers:"),
+    ];
+    for (i, peer) in form.peers.iter().enumerate() {
+        let focused = form.cursor == i + 1;
+        let marker = if focused { "▶ " } else { "  " };
+        let check = if peer.checked { "[x] " } else { "[ ] " };
+        let style = if focused {
+            Style::default()
+                .fg(logo::ORANGE)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default()
+        };
+        lines.push(Line::from(Span::styled(
+            format!("{marker}{check}{}", peer.name),
+            style,
+        )));
+    }
+
+    let width = 64.min(area.width.saturating_sub(4));
+    let height = ((lines.len() as u16) + 2).clamp(8, area.height.saturating_sub(4));
+    let rect = centered_rect(width, height, area);
+    let paragraph = Paragraph::new(lines).block(popup_block("Onboard new party"));
+    frame.render_widget(Clear, rect);
+    frame.render_widget(paragraph, rect);
+}
+
+/// The kick-participant form popup: pick an owner to remove and set the new
+/// signing threshold.
+fn kick_popup(frame: &mut Frame, area: Rect, form: &KickForm) {
+    let mut lines = vec![
+        Line::from(vec![
+            Span::styled("Party  ", Style::default().fg(Color::DarkGray)),
+            Span::raw(form.party_name.clone()),
+        ]),
+        Line::default(),
+        dim_line("Remove participant:"),
+    ];
+    for (i, candidate) in form.candidates.iter().enumerate() {
+        let focused = i == form.selected;
+        let marker = if focused { "▶ " } else { "  " };
+        let style = if focused {
+            Style::default()
+                .fg(logo::ORANGE)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default()
+        };
+        lines.push(Line::from(Span::styled(
+            format!("{marker}{}", candidate.label),
+            style,
+        )));
+    }
+    lines.push(Line::default());
+    lines.push(Line::from(vec![
+        Span::styled("New threshold  ", Style::default().fg(Color::DarkGray)),
+        Span::styled(
+            format!("{} ", form.new_threshold),
+            Style::default()
+                .fg(logo::ORANGE)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            format!(
+                "(was {prev}, max {max}) ←/→ adjust",
+                prev = form.previous_threshold,
+                max = form.max_threshold
+            ),
+            Style::default().fg(Color::DarkGray),
+        ),
+    ]));
+
+    let width = 64.min(area.width.saturating_sub(4));
+    let height = ((lines.len() as u16) + 2).clamp(8, area.height.saturating_sub(4));
+    let rect = centered_rect(width, height, area);
+    let paragraph = Paragraph::new(lines).block(popup_block("Kick participant"));
+    frame.render_widget(Clear, rect);
+    frame.render_widget(paragraph, rect);
+}
+
+/// A scrollable detail popup for a feed item (workflow run or invitation).
+fn feed_detail_popup(frame: &mut Frame, area: Rect, item: &FeedItem, scroll: u16) {
+    let (title, lines) = match item {
+        FeedItem::Run(run) => (format!("{} workflow", run.kind), run_detail_lines(run)),
+        FeedItem::Invitation(invitation) => (
+            format!("{} invitation", invitation.invitation_type),
+            invitation_detail_lines(invitation),
+        ),
+    };
+    let width = 84.min(area.width.saturating_sub(4));
+    let height = ((lines.len() as u16).saturating_add(2)).clamp(6, area.height.saturating_sub(4));
+    let rect = centered_rect(width, height, area);
+    let paragraph = Paragraph::new(lines)
+        .scroll((scroll, 0))
+        .wrap(Wrap { trim: false })
+        .block(popup_block(&title));
+    frame.render_widget(Clear, rect);
+    frame.render_widget(paragraph, rect);
+}
+
+/// A right-padded dim field label for the detail popups.
+fn detail_label(text: &str) -> Span<'static> {
+    Span::styled(format!("{text:<15}"), Style::default().fg(Color::DarkGray))
+}
+
+/// A `label  value` detail line.
+fn detail_kv(label: &str, value: String) -> Line<'static> {
+    Line::from(vec![detail_label(label), Span::raw(value)])
+}
+
+/// An indented detail value line (for list items).
+fn detail_item(value: String) -> Line<'static> {
+    Line::from(vec![
+        Span::raw("  "),
+        Span::styled(value, Style::default().fg(Color::Gray)),
+    ])
+}
+
+/// Detail lines for a workflow run.
+fn run_detail_lines(run: &WorkflowRun) -> Vec<Line<'static>> {
+    let (color, label) = workflow_status_display(run.status);
+    let mut lines = vec![
+        detail_kv("Instance", run.instance_name.clone()),
+        detail_kv("Kind", run.kind.to_string()),
+        detail_kv("Role", run.role.to_string()),
+        Line::from(vec![
+            detail_label("Status"),
+            Span::styled(label.to_owned(), Style::default().fg(color)),
+        ]),
+        detail_kv(
+            "Step",
+            format!(
+                "{step} ({index}/{total})",
+                step = if run.current_step.is_empty() {
+                    "—"
+                } else {
+                    &run.current_step
+                },
+                index = run.step_index,
+                total = run.step_total
+            ),
+        ),
+    ];
+    if let Some(prefix) = run.prefix.as_deref().filter(|p| !p.is_empty()) {
+        lines.push(detail_kv("Prefix", prefix.to_owned()));
+    }
+    if let Some(dec_party) = &run.dec_party_id {
+        lines.push(detail_kv("Dec party", dec_party.to_string()));
+    }
+    if run.previous_threshold.is_some() || run.new_threshold.is_some() {
+        lines.push(detail_kv(
+            "Threshold",
+            format!(
+                "{prev} → {next}",
+                prev = run.previous_threshold.unwrap_or(0),
+                next = run.new_threshold.unwrap_or(0)
+            ),
+        ));
+    }
+    if let Some(kicked) = &run.kicked_participant {
+        lines.push(detail_kv("Kicked", kicked.to_string()));
+    }
+    if !run.participants.is_empty() {
+        lines.push(detail_kv("Participants", String::new()));
+        lines.extend(run.participants.iter().map(|p| detail_item(p.to_string())));
+    }
+    if !run.completed_peers.is_empty() || !run.expected_peers.is_empty() {
+        lines.push(detail_kv(
+            "Peers",
+            format!(
+                "{done}/{total} done",
+                done = run.completed_peers.len(),
+                total = run.expected_peers.len()
+            ),
+        ));
+    }
+    if !run.package_names.is_empty() {
+        lines.push(detail_kv("Packages", run.package_names.join(", ")));
+    }
+    if !run.dar_filenames.is_empty() {
+        lines.push(detail_kv("DARs", run.dar_filenames.join(", ")));
+    }
+    if let Some(error) = &run.error {
+        lines.push(Line::default());
+        lines.push(Line::styled(
+            format!("Error: {error}"),
+            Style::default().fg(Color::Red),
+        ));
+    }
+    lines
+}
+
+/// Detail lines for a pending invitation.
+fn invitation_detail_lines(invitation: &PendingInvitation) -> Vec<Line<'static>> {
+    let mut lines = vec![detail_kv("Type", invitation.invitation_type.to_string())];
+    if let Some(name) = &invitation.coordinator_name {
+        lines.push(detail_kv("From", name.clone()));
+    }
+    lines.push(detail_kv(
+        "Coordinator",
+        invitation.coordinator_pubkey.clone(),
+    ));
+    if let Some(prefix) = invitation.prefix.as_deref().filter(|p| !p.is_empty()) {
+        lines.push(detail_kv("Prefix", prefix.to_owned()));
+    }
+    if let Some(dec_party) = &invitation.dec_party_id {
+        lines.push(detail_kv("Dec party", dec_party.to_string()));
+    }
+    if invitation.previous_threshold.is_some() || invitation.new_threshold.is_some() {
+        lines.push(detail_kv(
+            "Threshold",
+            format!(
+                "{prev} → {next}",
+                prev = invitation.previous_threshold.unwrap_or(0),
+                next = invitation.new_threshold.unwrap_or(0)
+            ),
+        ));
+    }
+    if let Some(kicked) = &invitation.kicked_participant {
+        lines.push(detail_kv("Kicked", kicked.to_string()));
+    }
+    if !invitation.participants.is_empty() {
+        lines.push(detail_kv("Participants", String::new()));
+        lines.extend(
+            invitation
+                .participants
+                .iter()
+                .map(|p| detail_item(p.to_string())),
+        );
+    }
+    if !invitation.package_names.is_empty() {
+        lines.push(detail_kv("Packages", invitation.package_names.join(", ")));
+    }
+    if !invitation.dar_filenames.is_empty() {
+        lines.push(detail_kv("DARs", invitation.dar_filenames.join(", ")));
+    }
+    lines
 }
 
 #[cfg(test)]
@@ -1474,6 +2273,12 @@ mod tests {
                 error_message: None,
                 created_at: 1_750_000_000,
             }]),
+            gov_state: Ok(Some(GovState {
+                members: vec!["m1".to_owned(), "m2".to_owned(), "m3".to_owned()],
+                threshold: 2,
+                action_confirmation_timeout_microseconds: Some(86_400_000_000),
+                out_of_date: false,
+            })),
         };
 
         let mut audit_state = TableState::default().with_selected(Some(0));
@@ -1519,6 +2324,29 @@ mod tests {
         assert!(rendered.contains("success"));
         // The JSON is not shown inline — it opens as a modal (see below).
         assert!(!rendered.contains("new_threshold"));
+        // The on-ledger governance state renders in the summary box.
+        assert!(rendered.contains("Governance"));
+        assert!(rendered.contains("threshold 2 of 3 members"));
+        assert!(rendered.contains("24h"));
+    }
+
+    #[test]
+    fn chain_audit_popup_renders_entries() {
+        let overlay = Overlay::ChainAudit {
+            entries: vec![ChainAuditEntry {
+                timestamp: 1_750_000_000,
+                event_type: "execute".to_owned(),
+                governance_type: "core_domain".to_owned(),
+                action_summary: "Executed SetThreshold".to_owned(),
+                choice: Some("GovernanceRules_Execute".to_owned()),
+            }],
+            scroll: 0,
+        };
+        let rendered = render(|frame, area| draw_overlay(frame, area, &overlay, "⠋"));
+        assert!(rendered.contains("On-chain audit"));
+        assert!(rendered.contains("execute"));
+        assert!(rendered.contains("core_domain"));
+        assert!(rendered.contains("Executed SetThreshold"));
     }
 
     #[test]
@@ -1551,6 +2379,246 @@ mod tests {
         assert_eq!(color_of("3"), Some(Color::Yellow)); // number
         assert_eq!(color_of("true"), Some(Color::Magenta)); // boolean
         assert_eq!(color_of("null"), Some(Color::Magenta)); // null
+    }
+
+    #[test]
+    fn onboard_popup_renders_prefix_and_peers() {
+        let overlay = Overlay::Onboard(OnboardForm {
+            prefix: "vault".to_owned(),
+            peers: vec![PeerChoice {
+                id: "p1::1220".to_owned(),
+                name: "alpha".to_owned(),
+                checked: true,
+            }],
+            cursor: 0,
+        });
+        let rendered = render(|frame, area| draw_overlay(frame, area, &overlay, "⠋"));
+        assert!(rendered.contains("Onboard new party"));
+        assert!(rendered.contains("vault"));
+        assert!(rendered.contains("alpha"));
+        assert!(rendered.contains("[x]"));
+    }
+
+    #[test]
+    fn kick_popup_renders_candidates_and_threshold() {
+        use crate::app::KickCandidate;
+
+        let overlay = Overlay::Kick(KickForm {
+            party_id: "dec::1220".to_owned(),
+            party_name: "cbtc-network".to_owned(),
+            previous_threshold: 3,
+            candidates: vec![KickCandidate {
+                participant_id: "p::1220".to_owned(),
+                label: "peerA".to_owned(),
+            }],
+            selected: 0,
+            new_threshold: 2,
+            max_threshold: 2,
+        });
+        let rendered = render(|frame, area| draw_overlay(frame, area, &overlay, "⠋"));
+        assert!(rendered.contains("Kick participant"));
+        assert!(rendered.contains("cbtc-network"));
+        assert!(rendered.contains("peerA"));
+        assert!(rendered.contains("New threshold"));
+    }
+
+    #[test]
+    fn feed_detail_popup_renders_run_fields_and_error() {
+        let run = WorkflowRun {
+            instance_name: "onboarding-vault-abc".to_owned(),
+            kind: WorkflowKind::Onboarding,
+            role: WorkflowRole::Coordinator,
+            status: WorkflowProgress::Failed,
+            current_step: "WaitingForPeers".to_owned(),
+            step_index: 1,
+            step_total: 7,
+            config_json: String::new(),
+            coordinator_pubkey: None,
+            coordinator_name: None,
+            expected_peers: Vec::new(),
+            completed_peers: Vec::new(),
+            dec_party_id: None,
+            prefix: Some("vault".to_owned()),
+            participants: Vec::new(),
+            previous_threshold: None,
+            new_threshold: None,
+            kicked_participant: None,
+            package_names: Vec::new(),
+            dar_filenames: Vec::new(),
+            error: Some("peer unreachable".to_owned()),
+            dismissed: false,
+            created_at: 0,
+            updated_at: 0,
+        };
+        let overlay = Overlay::FeedDetail {
+            item: Box::new(FeedItem::Run(run)),
+            scroll: 0,
+        };
+        let rendered = render(|frame, area| draw_overlay(frame, area, &overlay, "⠋"));
+        assert!(rendered.contains("Onboarding workflow"));
+        assert!(rendered.contains("Instance"));
+        assert!(rendered.contains("Failed"));
+        assert!(rendered.contains("Error:"));
+    }
+
+    #[test]
+    fn auth_popup_renders_status_and_rights() {
+        use crate::api::AuthRights;
+
+        let overlay = Overlay::Auth {
+            parties: vec![PartyAuthStatus {
+                dec_party_id: "cbtc-network::1220".to_owned(),
+                member_party_id: Some("member-a::1220".to_owned()),
+                user_id: Some("user-1".to_owned()),
+                status: AuthStatusKind::Authenticated,
+                rights: Some(AuthRights {
+                    member_party_act_as: true,
+                    member_party_read_as: true,
+                    dec_party_act_as: false,
+                    dec_party_read_as: true,
+                }),
+            }],
+            scroll: 0,
+        };
+        let rendered = render(|frame, area| draw_overlay(frame, area, &overlay, "⠋"));
+        assert!(rendered.contains("Authentication"));
+        assert!(rendered.contains("cbtc-network"));
+        assert!(rendered.contains("member-a"));
+        assert!(rendered.contains("user-1"));
+        assert!(rendered.contains("authenticated"));
+        assert!(rendered.contains("actAs"));
+    }
+
+    #[test]
+    fn gov_action_summary_humanizes_with_detail() {
+        assert_eq!(
+            gov_action_summary(
+                &serde_json::json!({ "type": "governance_set_threshold", "new_threshold": 3 })
+            ),
+            "Governance Set Threshold  → 3"
+        );
+        assert_eq!(
+            gov_action_summary(
+                &serde_json::json!({ "type": "vault_pause", "vault_id": "00abcdef0123456789" })
+            ),
+            "Vault Pause  00abcdef012…"
+        );
+        assert_eq!(
+            gov_action_summary(&serde_json::json!({ "type": "vault_deployment" })),
+            "Vault Deployment"
+        );
+    }
+
+    #[test]
+    fn governance_popup_renders_offchain_and_domain() {
+        use crate::api::{DomainGovAction, GovAction};
+
+        let view = GovView {
+            party_name: "cbtc-network".to_owned(),
+            party_id: "dec::1220".to_owned(),
+            governance_type: "vault".to_owned(),
+            rules_contract_id: "00rules".to_owned(),
+            member_party_id: "member::1220".to_owned(),
+            threshold: 2,
+            items: vec![
+                GovItem::OffChain(GovAction {
+                    action: serde_json::json!({
+                        "type": "governance_set_threshold",
+                        "new_threshold": 3,
+                    }),
+                    confirmations: Vec::new(),
+                    confirmation_count: 1,
+                    can_execute: false,
+                }),
+                GovItem::Domain(DomainGovAction {
+                    proposal_cid: "00prop".to_owned(),
+                    action_label: "SetupCcPreapproval".to_owned(),
+                    description: Some("set up preapproval".to_owned()),
+                    confirmations: Vec::new(),
+                    confirmation_count: 2,
+                    can_execute: true,
+                    orphaned: false,
+                }),
+            ],
+            selected: 0,
+        };
+        let overlay = Overlay::Governance(Box::new(view));
+        let rendered = render(|frame, area| draw_overlay(frame, area, &overlay, "⠋"));
+        assert!(rendered.contains("Approvals"));
+        assert!(rendered.contains("Governance Set Threshold"));
+        assert!(rendered.contains("1/2"));
+        assert!(rendered.contains("[chain]"));
+        assert!(rendered.contains("SetupCcPreapproval"));
+        assert!(rendered.contains("ready"));
+    }
+
+    #[test]
+    fn composer_pick_popup_lists_options() {
+        use crate::app::{ComposerKind, ComposerPick};
+
+        let pick = ComposerPick {
+            kind: ComposerKind::Action,
+            party_id: "dec::1".to_owned(),
+            party_name: "dec".to_owned(),
+            governance_type: "core_self".to_owned(),
+            rules_contract_id: "00r".to_owned(),
+            default_threshold: 2,
+            options: crate::composer::action_types("core_self"),
+            selected: 0,
+        };
+        let overlay = Overlay::ComposerPick(Box::new(pick));
+        let rendered = render(|frame, area| draw_overlay(frame, area, &overlay, "⠋"));
+        assert!(rendered.contains("New governance action"));
+        assert!(rendered.contains("Add governance member"));
+    }
+
+    #[test]
+    fn composer_popup_renders_fields_and_submit() {
+        use crate::composer::{ComposerContext, ComposerSubmit};
+
+        let ctx = ComposerContext {
+            party_id: "dec::1".to_owned(),
+            operator_party: String::new(),
+            default_threshold: 2,
+        };
+        let composer = Composer {
+            title: "Set governance threshold".to_owned(),
+            action_type: "governance_set_threshold",
+            submit: ComposerSubmit::Confirm,
+            party_id: "dec::1".to_owned(),
+            party_name: "dec".to_owned(),
+            governance_type: "core_self".to_owned(),
+            rules_contract_id: "00r".to_owned(),
+            fields: crate::composer::fields_for_action("governance_set_threshold", &ctx),
+            cursor: 0,
+        };
+        let overlay = Overlay::Composer(Box::new(composer));
+        let rendered = render(|frame, area| draw_overlay(frame, area, &overlay, "⠋"));
+        assert!(rendered.contains("Set governance threshold"));
+        assert!(rendered.contains("New threshold"));
+        assert!(rendered.contains("Submit"));
+    }
+
+    #[test]
+    fn deploy_popup_renders_context_and_fields() {
+        let form = DeployForm {
+            party_id: "dec::1220".to_owned(),
+            party_name: "cbtc-network".to_owned(),
+            package_id: "#governance-core-v1".to_owned(),
+            operator_party: "op::1220".to_owned(),
+            participant_ids: vec!["p1::1220".to_owned()],
+            member_parties: vec!["member-a::1220".to_owned()],
+            threshold: "2".to_owned(),
+            timeout_micros: "86400000000".to_owned(),
+            cursor: 0,
+        };
+        let overlay = Overlay::Deploy(Box::new(form));
+        let rendered = render(|frame, area| draw_overlay(frame, area, &overlay, "⠋"));
+        assert!(rendered.contains("Deploy governance"));
+        assert!(rendered.contains("GovernanceRules"));
+        assert!(rendered.contains("member-a"));
+        assert!(rendered.contains("Threshold"));
+        assert!(rendered.contains("Deploy"));
     }
 
     #[test]

--- a/crates/decman-cli/src/ui.rs
+++ b/crates/decman-cli/src/ui.rs
@@ -19,7 +19,7 @@ use crate::api::{
 };
 use crate::app::{
     App, ComposerKind, ComposerPick, DeployForm, DetailData, GovItem, GovView, GrantForm, KickForm,
-    OnboardForm, Overlay, PeerChoice, Status, Tab, TabView,
+    NetworkEditState, OnboardForm, Overlay, PeerChoice, PeerForm, Status, Tab, TabView,
 };
 use crate::composer::{Composer, FieldKind};
 use crate::config::Profile;
@@ -1081,12 +1081,18 @@ fn footer_hint(active: Tab, overlay: &Overlay, can_logout: bool) -> String {
         Overlay::Deploy(_) => {
             " ↑/↓ field · type number · enter next/deploy · esc cancel".to_owned()
         }
+        Overlay::NetworkEdit(state) => if state.adding.is_some() {
+            " ↑/↓ field · type · enter next/add · esc back"
+        } else {
+            " ↑/↓ select · a add · d remove · s save · esc cancel"
+        }
+        .to_owned(),
         Overlay::Message(_) => " enter / esc to close".to_owned(),
         Overlay::Busy(_) => " working… · esc to dismiss".to_owned(),
         Overlay::None => {
             let base = match active {
                 Tab::Parties => " ↑↓ nav · enter view · n onboard · r refresh",
-                Tab::Peers => " ↑↓ nav · tab switch",
+                Tab::Peers => " ↑↓ nav · e edit · tab switch",
                 Tab::Dars => " c check · u upload · d distribute",
                 Tab::Workflows => {
                     " a accept · x deny · c cancel · t retry · enter detail · d dismiss"
@@ -1171,7 +1177,109 @@ fn draw_overlay(frame: &mut Frame, area: Rect, overlay: &Overlay, spinner: &str)
         Overlay::ComposerPick(pick) => composer_pick_popup(frame, area, pick),
         Overlay::Composer(composer) => composer_popup(frame, area, composer),
         Overlay::Deploy(form) => deploy_popup(frame, area, form),
+        Overlay::NetworkEdit(state) => network_edit_popup(frame, area, state),
     }
+}
+
+/// The network-config editor popup: the peer list, or the add-peer sub-form.
+fn network_edit_popup(frame: &mut Frame, area: Rect, state: &NetworkEditState) {
+    match &state.adding {
+        Some(form) => peer_form_popup(frame, area, form),
+        None => peer_list_popup(frame, area, state),
+    }
+}
+
+/// The peer list view of the network editor.
+fn peer_list_popup(frame: &mut Frame, area: Rect, state: &NetworkEditState) {
+    let mut lines: Vec<Line> = Vec::new();
+    if state.peers.is_empty() {
+        lines.push(dim_line("(no peers — press a to add)"));
+    }
+    for (index, peer) in state.peers.iter().enumerate() {
+        let selected = index == state.selected;
+        let marker = if selected { "▶ " } else { "  " };
+        let style = if selected {
+            Style::default()
+                .fg(logo::ORANGE)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default()
+        };
+        lines.push(Line::from(vec![
+            Span::styled(
+                format!("{marker}{}", id_prefix(&peer.participant_id)),
+                style,
+            ),
+            Span::styled(
+                format!("  {}:{}", peer.address, peer.port),
+                Style::default().fg(Color::DarkGray),
+            ),
+        ]));
+    }
+
+    let width = 72.min(area.width.saturating_sub(4));
+    let height = ((lines.len() as u16).saturating_add(2)).clamp(6, area.height.saturating_sub(4));
+    let visible = height.saturating_sub(2);
+    let selected = u16::try_from(state.selected).unwrap_or(0);
+    let scroll = selected.saturating_sub(visible.saturating_sub(1));
+    let rect = centered_rect(width, height, area);
+    let paragraph = Paragraph::new(lines)
+        .scroll((scroll, 0))
+        .block(popup_block("Network peers"));
+    frame.render_widget(Clear, rect);
+    frame.render_widget(paragraph, rect);
+}
+
+/// The add-peer sub-form of the network editor.
+fn peer_form_popup(frame: &mut Frame, area: Rect, form: &PeerForm) {
+    let edit_line = |label: &str, value: &str, focused: bool| {
+        let value_style = if focused {
+            Style::default()
+                .fg(logo::ORANGE)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default()
+        };
+        let shown = if focused {
+            format!("{value}▏")
+        } else if value.is_empty() {
+            "(empty)".to_owned()
+        } else {
+            value.to_owned()
+        };
+        Line::from(vec![detail_label(label), Span::styled(shown, value_style)])
+    };
+
+    let fields = [
+        ("Participant id", form.participant_id.as_str()),
+        ("Name", form.name.as_str()),
+        ("Address", form.address.as_str()),
+        ("Port", form.port.as_str()),
+        ("Public key", form.public_key.as_str()),
+        ("Party (optional)", form.party.as_str()),
+    ];
+    let mut lines: Vec<Line> = fields
+        .iter()
+        .enumerate()
+        .map(|(index, (label, value))| edit_line(label, value, form.cursor == index))
+        .collect();
+    lines.push(Line::default());
+    let submit_style = if form.cursor >= fields.len() {
+        Style::default()
+            .fg(Color::Black)
+            .bg(logo::ORANGE)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(Color::DarkGray)
+    };
+    lines.push(Line::from(Span::styled(" Add peer ", submit_style)));
+
+    let width = 72.min(area.width.saturating_sub(4));
+    let height = ((lines.len() as u16).saturating_add(2)).clamp(6, area.height.saturating_sub(4));
+    let rect = centered_rect(width, height, area);
+    let paragraph = Paragraph::new(lines).block(popup_block("Add peer"));
+    frame.render_widget(Clear, rect);
+    frame.render_widget(paragraph, rect);
 }
 
 /// The governance-core contract deployment popup: resolved context plus the two
@@ -2698,6 +2806,51 @@ mod tests {
         assert!(rendered.contains("member-a"));
         assert!(rendered.contains("Threshold"));
         assert!(rendered.contains("Deploy"));
+    }
+
+    #[test]
+    fn network_edit_popup_lists_peers() {
+        use crate::api::PeerEntry;
+
+        let state = NetworkEditState {
+            peers: vec![PeerEntry {
+                participant_id: "alpha::1220".to_owned(),
+                name: "alpha".to_owned(),
+                address: "10.0.0.1".to_owned(),
+                port: 9001,
+                public_key: "abcd".to_owned(),
+                party: None,
+            }],
+            selected: 0,
+            adding: None,
+        };
+        let overlay = Overlay::NetworkEdit(Box::new(state));
+        let rendered = render(|frame, area| draw_overlay(frame, area, &overlay, "⠋"));
+        assert!(rendered.contains("Network peers"));
+        assert!(rendered.contains("alpha"));
+        assert!(rendered.contains("10.0.0.1:9001"));
+    }
+
+    #[test]
+    fn network_edit_add_form_renders_fields() {
+        let state = NetworkEditState {
+            peers: Vec::new(),
+            selected: 0,
+            adding: Some(PeerForm {
+                participant_id: String::new(),
+                name: String::new(),
+                address: String::new(),
+                port: String::new(),
+                public_key: String::new(),
+                party: String::new(),
+                cursor: 0,
+            }),
+        };
+        let overlay = Overlay::NetworkEdit(Box::new(state));
+        let rendered = render(|frame, area| draw_overlay(frame, area, &overlay, "⠋"));
+        assert!(rendered.contains("Add peer"));
+        assert!(rendered.contains("Participant id"));
+        assert!(rendered.contains("Public key"));
     }
 
     #[test]

--- a/crates/decman-cli/src/ui.rs
+++ b/crates/decman-cli/src/ui.rs
@@ -18,7 +18,7 @@ use crate::api::{
     audit_action, invitation_name, party_name, run_name,
 };
 use crate::app::{
-    App, ComposerKind, ComposerPick, DeployForm, DetailData, GovItem, GovView, KickForm,
+    App, ComposerKind, ComposerPick, DeployForm, DetailData, GovItem, GovView, GrantForm, KickForm,
     OnboardForm, Overlay, PeerChoice, Status, Tab, TabView,
 };
 use crate::composer::{Composer, FieldKind};
@@ -1069,7 +1069,8 @@ fn footer_hint(active: Tab, overlay: &Overlay, can_logout: bool) -> String {
             " ↑/↓ field · space toggle peer · enter start · esc cancel".to_owned()
         }
         Overlay::Kick(_) => " ↑/↓ pick · ←/→ threshold · enter kick · esc cancel".to_owned(),
-        Overlay::Auth { .. } => " ↑/↓ scroll · t test auth · esc close".to_owned(),
+        Overlay::Auth { .. } => " ↑/↓ select · t test · g grant rights · esc close".to_owned(),
+        Overlay::GrantRights(_) => " ↑/↓ field · type · enter next/grant · esc cancel".to_owned(),
         Overlay::Governance(_) => {
             " ↑/↓ · c confirm · e exec · r revoke · x expire · n new · p propose · esc".to_owned()
         }
@@ -1164,7 +1165,8 @@ fn draw_overlay(frame: &mut Frame, area: Rect, overlay: &Overlay, spinner: &str)
         Overlay::Kick(form) => kick_popup(frame, area, form),
         Overlay::FeedDetail { item, scroll } => feed_detail_popup(frame, area, item, *scroll),
         Overlay::ChainAudit { entries, scroll } => chain_audit_popup(frame, area, entries, *scroll),
-        Overlay::Auth { parties, scroll } => auth_popup(frame, area, parties, *scroll),
+        Overlay::Auth { parties, selected } => auth_popup(frame, area, parties, *selected),
+        Overlay::GrantRights(form) => grant_popup(frame, area, form),
         Overlay::Governance(view) => governance_popup(frame, area, view),
         Overlay::ComposerPick(pick) => composer_pick_popup(frame, area, pick),
         Overlay::Composer(composer) => composer_popup(frame, area, composer),
@@ -1496,15 +1498,21 @@ fn right_chip(label: &str, held: bool) -> Span<'static> {
 }
 
 /// The authentication-status popup: each party's IdP status and ledger rights.
-fn auth_popup(frame: &mut Frame, area: Rect, parties: &[PartyAuthStatus], scroll: u16) {
+fn auth_popup(frame: &mut Frame, area: Rect, parties: &[PartyAuthStatus], selected: usize) {
     let mut lines: Vec<Line> = Vec::new();
     if parties.is_empty() {
         lines.push(dim_line("(no parties configured)"));
     }
     let label = |text: &'static str| Span::styled(text, Style::default().fg(Color::DarkGray));
-    for party in parties {
+    // Line index where the selected party's block starts, for scroll-to-view.
+    let mut selected_offset = 0u16;
+    for (index, party) in parties.iter().enumerate() {
+        if index == selected {
+            selected_offset = u16::try_from(lines.len()).unwrap_or(0);
+        }
+        let marker = if index == selected { "▶ " } else { "  " };
         lines.push(Line::from(Span::styled(
-            id_prefix(&party.dec_party_id).to_owned(),
+            format!("{marker}{}", id_prefix(&party.dec_party_id)),
             Style::default()
                 .fg(logo::ORANGE)
                 .add_modifier(Modifier::BOLD),
@@ -1544,10 +1552,63 @@ fn auth_popup(frame: &mut Frame, area: Rect, parties: &[PartyAuthStatus], scroll
 
     let width = 76.min(area.width.saturating_sub(4));
     let height = ((lines.len() as u16).saturating_add(2)).clamp(6, area.height.saturating_sub(4));
+    let visible = height.saturating_sub(2);
+    // Scroll so the selected party's block stays in view.
+    let scroll = selected_offset.saturating_sub(visible.saturating_sub(1));
     let rect = centered_rect(width, height, area);
     let paragraph = Paragraph::new(lines)
         .scroll((scroll, 0))
         .block(popup_block("Authentication"));
+    frame.render_widget(Clear, rect);
+    frame.render_widget(paragraph, rect);
+}
+
+/// The grant-rights form popup: admin client id + secret for one party.
+fn grant_popup(frame: &mut Frame, area: Rect, form: &GrantForm) {
+    let edit_line = |label: &str, value: &str, focused: bool, mask: bool| {
+        let value_style = if focused {
+            Style::default()
+                .fg(logo::ORANGE)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default()
+        };
+        let base = if mask {
+            "•".repeat(value.chars().count())
+        } else {
+            value.to_owned()
+        };
+        let shown = if focused {
+            format!("{base}▏")
+        } else if value.is_empty() {
+            "(empty)".to_owned()
+        } else {
+            base
+        };
+        Line::from(vec![detail_label(label), Span::styled(shown, value_style)])
+    };
+
+    let mut lines = vec![
+        detail_kv("Party", form.party_name.clone()),
+        Line::default(),
+        edit_line("Admin client id", &form.client_id, form.cursor == 0, false),
+        edit_line("Admin secret", &form.client_secret, form.cursor == 1, true),
+        Line::default(),
+    ];
+    let submit_style = if form.cursor >= 2 {
+        Style::default()
+            .fg(Color::Black)
+            .bg(logo::ORANGE)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(Color::DarkGray)
+    };
+    lines.push(Line::from(Span::styled(" Grant rights ", submit_style)));
+
+    let width = 64.min(area.width.saturating_sub(4));
+    let height = ((lines.len() as u16).saturating_add(2)).clamp(6, area.height.saturating_sub(4));
+    let rect = centered_rect(width, height, area);
+    let paragraph = Paragraph::new(lines).block(popup_block("Grant rights"));
     frame.render_widget(Clear, rect);
     frame.render_widget(paragraph, rect);
 }
@@ -2478,7 +2539,7 @@ mod tests {
                     dec_party_read_as: true,
                 }),
             }],
-            scroll: 0,
+            selected: 0,
         };
         let rendered = render(|frame, area| draw_overlay(frame, area, &overlay, "⠋"));
         assert!(rendered.contains("Authentication"));
@@ -2487,6 +2548,24 @@ mod tests {
         assert!(rendered.contains("user-1"));
         assert!(rendered.contains("authenticated"));
         assert!(rendered.contains("actAs"));
+    }
+
+    #[test]
+    fn grant_popup_masks_secret() {
+        let form = GrantForm {
+            dec_party_id: "cbtc-network::1220".to_owned(),
+            party_name: "cbtc-network".to_owned(),
+            client_id: "validator-admin".to_owned(),
+            client_secret: "supersecret".to_owned(),
+            cursor: 0,
+        };
+        let overlay = Overlay::GrantRights(Box::new(form));
+        let rendered = render(|frame, area| draw_overlay(frame, area, &overlay, "⠋"));
+        assert!(rendered.contains("Grant rights"));
+        assert!(rendered.contains("validator-admin"));
+        // The secret is masked, never shown verbatim.
+        assert!(!rendered.contains("supersecret"));
+        assert!(rendered.contains('•'));
     }
 
     #[test]


### PR DESCRIPTION
Brings the decman-cli TUI close to web-console parity. It was monitoring plus light actions before; now it can drive the governance and workflow flows.

## What's new
- Onboarding: create a dec party (prefix + peer picker, mesh-error guidance). `n` on Parties.
- Kick a participant: `K` in party detail.
- Workflow controls: cancel / retry / detail on the Workflows tab (`c` / `t` / enter). The feed now auto-polls every 2s like the web app.
- Party detail: governance state (threshold, members, action timeout) and on-chain audit (`c`).
- Auth (`A`): per-party status + rights, test auth (`t`), grant rights (`g`), and a per-party IdP config editor (`e`) — Keycloak/Auth0 with discover-member-party (`PUT /party-config`).
- Governance approvals (`g` in detail): confirm / execute / revoke / expire pending off-chain actions and on-chain proposals.
- Governance composer (`n` action, `p` proposal): a data-driven form engine covering 30+ ActionType / ProposalType variants, building the exact internally-tagged JSON.
- Contracts deploy (`D`): governance-core preset with the member set prefilled from known-members.
- Network config editing (`e` on Peers): add / remove peers and save.

## Not in this PR (follow-ups)
- cbtc / vault contract presets and the full recursive FieldDefinition editor — gov-core deploy only for now (cbtc/vault are "coming soon" in the web UI too).
- FAR sub-objects in the vault/processor composer, and disclosed-contract blobs for executing deployment actions (devnet-specific).
- Composer dropdown prefill from the token-standard lookups (manual cid entry for now).
- Config-tab read display (full node/canton config, Noise key status).

## Verification
`cargo fmt` and `cargo clippy --all-targets --all-features -- -D warnings` are clean. ~56 unit and render tests added across api/app/ui/composer.
