### PR TITLE
feat(auth): runtime --insecure mode for no-IdP local dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1328,7 +1328,7 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "decman"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "actix-cors",
  "actix-web",

--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ docker compose up
 
 This starts three participant instances on ports 8081, 8082, and 8083.
 
+The compose stack uses bridge networking and reaches Canton through `host.docker.internal`, so it runs the same on Docker Desktop, OrbStack, and Linux. Each participant expects its Canton Ledger/Admin APIs reachable on the host (the standard layout forwards them to `localhost:5001/5002`, `5011/5012`, `5021/5022` — e.g. via `just port-forward`). See the header of [`development/docker-compose.yml`](development/docker-compose.yml) for the full prerequisites.
+
 ## Configuration
 
 All node configuration is done via environment variables (prefixed `DECPM_*`) or CLI arguments. The `--dir` (`-d`) flag points to a directory for persistent data. If a `.env` file exists in that directory, it is loaded automatically before parsing CLI arguments.
@@ -167,6 +169,10 @@ The database file path can be overridden with the `--db` CLI flag.
 | `DECPM_AUTH0_DOMAIN` | Auth0 tenant domain for frontend auth (mutually exclusive with `DECPM_KEYCLOAK_*`) | _(none)_ |
 | `DECPM_AUTH0_CLIENT_ID` | Auth0 SPA client ID for frontend auth | _(none)_ |
 | `DECPM_AUTH0_AUDIENCE` | Auth0 API audience the SPA's access tokens target | _(none)_ |
+| `DECPM_INSECURE` | Run without an IdP: accept any inbound token and present an unsafe HS256 token to Canton (CLI flag `--insecure`). **Never use in production.** See [Insecure mode](#insecure-mode-local-development-without-an-idp) | `false` |
+| `DECPM_CANTON_HMAC_SECRET` | HS256 secret decman signs the unsafe Canton token with, in insecure mode. Must match Canton's unsafe auth-service secret | `unsafe` |
+| `DECPM_CANTON_HMAC_AUDIENCE` | `aud` claim for the unsafe Canton token, in insecure mode. Must match Canton's `target-audience` | `https://canton.network.global` |
+| `DECPM_CANTON_HMAC_SUBJECT` | `sub` claim / ledger user for the unsafe Canton token, in insecure mode | `ledger-api-user` |
 | `DECPM_TIMEOUT_HANDSHAKE` | Noise handshake timeout in seconds | `30` |
 | `DECPM_TIMEOUT_MESSAGE` | Noise message timeout in seconds | `120` |
 | `DECPM_TIMEOUT_RETRY_ATTEMPTS` | Connection retry attempts | `3` |
@@ -176,6 +182,24 @@ The database file path can be overridden with the `--db` CLI flag.
 | `DECPM_NOISE_RETRY_BACKOFF_MS` | Backoff between attempts of the bounded peer-Noise retry wrapper, in milliseconds | `250` |
 
 All environment variables can also be passed as CLI arguments (e.g., `--canton-admin-host`).
+
+### Insecure mode (local development without an IdP)
+
+For local development against a Canton configured with **unsafe (shared-secret) auth**, you can run without setting up Keycloak or Auth0 at all. Start the node with `--insecure` (or `DECPM_INSECURE=true`) and it will:
+
+- accept **any** inbound token, so the admin UI needs no login, and
+- mint an unsafe **HS256** token for Canton instead of fetching one from an IdP.
+
+> [!WARNING]
+> Insecure mode disables authentication entirely. It is for local development only — **never enable `--insecure` / `DECPM_INSECURE` in a shared or production deployment.** The node logs a warning at startup whenever it is on.
+
+The token is signed and stamped from the `DECPM_CANTON_HMAC_*` variables above; point Canton's unsafe auth service at the same secret and audience so it accepts the token. With the defaults (`unsafe` / `https://canton.network.global`), `--insecure` alone is enough:
+
+```bash
+dec-party-manager -d ./development/participant-1 serve --insecure
+```
+
+This replaces the older `--features test-mode` build — no special build is required; the flag is honored by the standard release binary.
 
 ### Example `.env` File
 
@@ -320,7 +344,7 @@ curl http://localhost:8081/party-config/decparty::1220abc...
 
 ## API Endpoints
 
-The table below is a curated subset. A complete, interactive API reference is available via the **Swagger UI at `/swagger-ui/`** (OpenAPI document at `/api-docs/openapi.json`) — but note these endpoints are only mounted in development/test builds (`--features test-mode`); the shipped release image does not expose them.
+The table below is a curated subset. A complete, interactive API reference is available via the **Swagger UI at `/swagger-ui/`** (OpenAPI document at `/api-docs/openapi.json`) — but note this is only mounted when the node runs in [insecure mode](#insecure-mode-local-development-without-an-idp) (`--insecure`); a normal (secure) deployment does not expose it.
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
@@ -568,7 +592,7 @@ instances, same `wait_for_server` and `configure_peers` flow), except:
 - Canton gRPC admin (5002/5012/5022) and ledger (5001/5011/5021) ports are
   tunneled to localhost via `kubectl port-forward` (managed by
   `devnet.env.sh`'s `start_canton_tunnels`).
-- DecMan auth uses real Keycloak (the `JwtValidator`), not the test-mode
+- DecMan auth uses real Keycloak (the `JwtValidator`), not the insecure-mode
   `MockValidator` localnet uses. The test runner mints its own bearer token
   via password grant; per-party workflows use M2M `client_credentials`.
 - Member parties (`P{N}_MEMBER_PARTY_ID`) are pre-provisioned, not allocated

--- a/crates/decman/Cargo.toml
+++ b/crates/decman/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "decman"
-version = "1.4.0"
+version = "1.4.1"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/crates/decman/src/auth/mock.rs
+++ b/crates/decman/src/auth/mock.rs
@@ -1,20 +1,88 @@
-use std::sync::Arc;
+use std::{
+    sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
+use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
+use serde::Serialize;
 use tokio::sync::RwLock;
 
-use crate::{canton_id::CantonId, config::PartyCredentials};
+use crate::{
+    canton_id::CantonId,
+    config::{InsecureAuthConfig, PartyCredentials},
+};
 
-/// Static mock token for test mode (from legacy config)
+/// Static mock token. Kept as the fallback if runtime minting ever fails, and
+/// as the reference the inbound `MockValidator` recognises. Equivalent to the
+/// default-configured runtime token (HS256, secret `unsafe`, aud
+/// `https://canton.network.global`, sub `ledger-api-user`).
 pub const MOCK_TOKEN: &str = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOiJodHRwczovL2NhbnRvbi5uZXR3b3JrLmdsb2JhbCIsImlhdCI6MTc2Mzc0ODcwMiwic3ViIjoibGVkZ2VyLWFwaS11c2VyIn0.vpkfH4SoM9AZqbE38W4hrvl3xxy69jYs4u8gveskw9k";
 
-/// Static mock user ID for test mode (from legacy config)
+/// Default subject/user id, used by the inbound `MockValidator` and as the
+/// fallback if minting fails.
 pub const MOCK_USER_ID: &str = "ledger-api-user";
 
-/// Default placeholder member party ID for test mode
+/// Default placeholder member party ID for insecure mode
 const MOCK_MEMBER_PARTY_ID: &str =
     "mock-member::1220aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa01";
 
-/// Mock token manager for test mode
+/// Claims for the unsafe HS256 Canton token: audience, subject, and issued-at,
+/// with no expiry (Canton's unsafe auth does not require one).
+#[derive(Serialize)]
+struct UnsafeClaims<'a> {
+    aud: &'a str,
+    sub: &'a str,
+    iat: u64,
+}
+
+/// Mint an HS256 Canton token from the given secret/audience/subject.
+///
+/// # Errors
+///
+/// Returns a `jsonwebtoken` error if token encoding fails.
+fn mint_unsafe_token(
+    secret: &str,
+    audience: &str,
+    subject: &str,
+) -> Result<String, jsonwebtoken::errors::Error> {
+    let iat = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let claims = UnsafeClaims {
+        aud: audience,
+        sub: subject,
+        iat,
+    };
+    encode(
+        &Header::new(Algorithm::HS256),
+        &claims,
+        &EncodingKey::from_secret(secret.as_bytes()),
+    )
+}
+
+/// Mint the unsafe token and resolve its subject, from the configured
+/// secret/audience/subject. Falls back to the static [`MOCK_TOKEN`] if encoding
+/// fails. Never logs the secret.
+fn mint_credentials(cfg: &InsecureAuthConfig) -> (String, String) {
+    match mint_unsafe_token(&cfg.secret, &cfg.audience, &cfg.subject) {
+        Ok(token) => {
+            tracing::info!(
+                "Minted unsafe Canton HMAC token (aud={}, sub={})",
+                cfg.audience,
+                cfg.subject
+            );
+            (token, cfg.subject.clone())
+        }
+        Err(e) => {
+            tracing::error!("Failed to mint unsafe Canton HMAC token: {e}; using static fallback");
+            (MOCK_TOKEN.to_string(), MOCK_USER_ID.to_string())
+        }
+    }
+}
+
+/// Mock token manager for insecure mode. Holds a token minted once by the
+/// [`MockAuthRegistry`].
 pub struct MockTokenManager {
     user_id: String,
     token: String,
@@ -22,20 +90,12 @@ pub struct MockTokenManager {
 }
 
 impl MockTokenManager {
-    /// Create a new MockTokenManager with a specific member party ID
-    pub fn with_member_party_id(member_party_id: CantonId) -> Self {
+    fn new(token: String, user_id: String, member_party_id: CantonId) -> Self {
         Self {
-            user_id: MOCK_USER_ID.to_string(),
-            token: MOCK_TOKEN.to_string(),
+            user_id,
+            token,
             member_party_id,
         }
-    }
-
-    /// Create a new MockTokenManager with the default placeholder member party ID
-    pub fn new() -> Self {
-        let member_party_id =
-            CantonId::parse(MOCK_MEMBER_PARTY_ID).expect("hardcoded mock member party ID");
-        Self::with_member_party_id(member_party_id)
     }
 
     /// Get the user ID
@@ -54,45 +114,63 @@ impl MockTokenManager {
     }
 }
 
-impl Default for MockTokenManager {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-/// Mock registry for test mode — looks up member_party_id from party credentials,
-/// falling back to a default placeholder when no credentials are configured.
+/// Mock registry for insecure mode — mints the unsafe token once, then hands
+/// out managers that carry each party's configured member_party_id (falling
+/// back to a placeholder when no credentials are configured).
 pub struct MockAuthRegistry {
     party_credentials: Arc<RwLock<Vec<PartyCredentials>>>,
-    fallback: Arc<MockTokenManager>,
+    token: String,
+    user_id: String,
+    fallback_member: CantonId,
 }
 
 impl MockAuthRegistry {
-    /// Create a new MockAuthRegistry backed by the live party credentials
+    /// Create a registry using the default unsafe token settings.
     pub fn new(party_credentials: Arc<RwLock<Vec<PartyCredentials>>>) -> Self {
-        tracing::info!("Initializing mock authentication (test mode)");
+        Self::with_config(party_credentials, &InsecureAuthConfig::default())
+    }
+
+    /// Create a registry minting the unsafe token from `cfg`.
+    pub fn with_config(
+        party_credentials: Arc<RwLock<Vec<PartyCredentials>>>,
+        cfg: &InsecureAuthConfig,
+    ) -> Self {
+        tracing::info!("Initializing mock authentication (insecure mode)");
+        let (token, user_id) = mint_credentials(cfg);
+        let fallback_member =
+            CantonId::parse(MOCK_MEMBER_PARTY_ID).expect("hardcoded mock member party ID");
         Self {
             party_credentials,
-            fallback: Arc::new(MockTokenManager::new()),
+            token,
+            user_id,
+            fallback_member,
         }
+    }
+
+    fn manager_for(&self, member_party_id: CantonId) -> Arc<MockTokenManager> {
+        Arc::new(MockTokenManager::new(
+            self.token.clone(),
+            self.user_id.clone(),
+            member_party_id,
+        ))
     }
 
     /// Get mock token manager for a party, using its configured member_party_id
     pub async fn get(&self, party_id: &CantonId) -> Arc<MockTokenManager> {
         let creds = self.party_credentials.read().await;
-        match creds.iter().find(|p| p.dec_party_id == *party_id) {
-            Some(c) => Arc::new(MockTokenManager::with_member_party_id(
-                c.member_party_id.clone(),
-            )),
-            None => self.fallback.clone(),
-        }
+        let member = creds
+            .iter()
+            .find(|p| p.dec_party_id == *party_id)
+            .map(|c| c.member_party_id.clone())
+            .unwrap_or_else(|| self.fallback_member.clone());
+        self.manager_for(member)
     }
 
     /// Get mock token manager by string ID
     pub async fn get_by_str(&self, party_id: &str) -> Arc<MockTokenManager> {
         match CantonId::parse(party_id) {
             Ok(id) => self.get(&id).await,
-            Err(_) => self.fallback.clone(),
+            Err(_) => self.manager_for(self.fallback_member.clone()),
         }
     }
 }

--- a/crates/decman/src/auth/mock.rs
+++ b/crates/decman/src/auth/mock.rs
@@ -13,9 +13,11 @@ use crate::{
 };
 
 /// Static mock token. Kept as the fallback if runtime minting ever fails, and
-/// as the reference the inbound `MockValidator` recognises. Equivalent to the
-/// default-configured runtime token (HS256, secret `unsafe`, aud
-/// `https://canton.network.global`, sub `ledger-api-user`).
+/// as the reference the inbound `MockValidator` recognises. Matches the
+/// default-configured runtime token on alg/secret/aud/sub (HS256, secret
+/// `unsafe`, aud `https://canton.network.global`, sub `ledger-api-user`) but
+/// carries a fixed `iat`, so it is not byte-for-byte identical to a freshly
+/// minted one.
 pub const MOCK_TOKEN: &str = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOiJodHRwczovL2NhbnRvbi5uZXR3b3JrLmdsb2JhbCIsImlhdCI6MTc2Mzc0ODcwMiwic3ViIjoibGVkZ2VyLWFwaS11c2VyIn0.vpkfH4SoM9AZqbE38W4hrvl3xxy69jYs4u8gveskw9k";
 
 /// Default subject/user id, used by the inbound `MockValidator` and as the

--- a/crates/decman/src/auth/mock.rs
+++ b/crates/decman/src/auth/mock.rs
@@ -65,7 +65,9 @@ fn mint_unsafe_token(
 
 /// Mint the unsafe token and resolve its subject, from the configured
 /// secret/audience/subject. Falls back to the static [`MOCK_TOKEN`] if encoding
-/// fails. Never logs the secret.
+/// fails, warning loudly when a custom secret is in play — the fallback is
+/// signed with the default secret and would not match Canton. Never logs the
+/// secret.
 fn mint_credentials(cfg: &InsecureAuthConfig) -> (String, String) {
     match mint_unsafe_token(&cfg.secret, &cfg.audience, &cfg.subject) {
         Ok(token) => {
@@ -75,6 +77,20 @@ fn mint_credentials(cfg: &InsecureAuthConfig) -> (String, String) {
                 cfg.subject
             );
             (token, cfg.subject.clone())
+        }
+        // HS256 encoding effectively never fails, so this only fires on a real
+        // problem. The static fallback is signed with the default `unsafe`
+        // secret, so it substitutes cleanly only when the operator kept that
+        // default; with a custom secret it will NOT match Canton and would fail
+        // confusingly downstream, so flag that explicitly instead of masking it.
+        Err(e) if cfg.secret != InsecureAuthConfig::default().secret => {
+            tracing::error!(
+                "Failed to mint unsafe Canton HMAC token from the configured \
+                 DECPM_CANTON_HMAC_SECRET: {e}. Falling back to the default-secret static \
+                 token, which will NOT match your secret and will fail Canton auth — fix \
+                 DECPM_CANTON_HMAC_SECRET."
+            );
+            (MOCK_TOKEN.to_string(), MOCK_USER_ID.to_string())
         }
         Err(e) => {
             tracing::error!("Failed to mint unsafe Canton HMAC token: {e}; using static fallback");

--- a/crates/decman/src/auth/mod.rs
+++ b/crates/decman/src/auth/mod.rs
@@ -17,9 +17,7 @@ use tokio::sync::RwLock;
 
 pub use mock::{MockAuthRegistry, MockTokenManager};
 pub use validator::{Principal, TokenValidator, ValidationError};
-#[cfg(any(test, feature = "test-mode"))]
-pub use validators::MockValidator;
-pub use validators::{JwtValidator, OidcIntrospectionValidator};
+pub use validators::{JwtValidator, MockValidator, OidcIntrospectionValidator};
 
 use crate::{
     canton_id::CantonId,

--- a/crates/decman/src/auth/validator.rs
+++ b/crates/decman/src/auth/validator.rs
@@ -10,9 +10,7 @@ use std::sync::Arc;
 
 use thiserror::Error;
 
-#[cfg(any(test, feature = "test-mode"))]
-use super::validators::MockValidator;
-use super::validators::{JwtValidator, OidcIntrospectionValidator};
+use super::validators::{JwtValidator, MockValidator, OidcIntrospectionValidator};
 
 #[derive(Error, Debug)]
 pub enum ValidationError {
@@ -101,10 +99,10 @@ pub enum TokenValidator {
     /// RFC 7662 introspection against a real OIDC provider. Kept for
     /// deployments where local signature verification is not feasible.
     OidcIntrospection(Arc<OidcIntrospectionValidator>),
-    /// Permissive dev/test validator (admin-by-default, accepts any
-    /// token). Compiled in only behind `cfg(any(test, feature = "test-mode"))`
-    /// so a production binary cannot accidentally enable it.
-    #[cfg(any(test, feature = "test-mode"))]
+    /// Permissive dev validator (admin-by-default, accepts any token).
+    /// Always compiled, but selected only at runtime when the server is
+    /// started with `--insecure` (or under tests). A production binary must
+    /// never be launched with that flag.
     Mock(Arc<MockValidator>),
 }
 
@@ -120,7 +118,6 @@ impl TokenValidator {
         match self {
             Self::Jwt(v) => v.validate(token).await,
             Self::OidcIntrospection(v) => v.validate(token).await,
-            #[cfg(any(test, feature = "test-mode"))]
             Self::Mock(v) => v.validate(token).await,
         }
     }

--- a/crates/decman/src/auth/validators/mock.rs
+++ b/crates/decman/src/auth/validators/mock.rs
@@ -3,14 +3,14 @@ use crate::auth::{
     validator::{Principal, ValidationError},
 };
 
-/// Inbound validator used when the binary is built with the `test-mode`
-/// Cargo feature (or under `cargo test`).
+/// Permissive inbound validator, selected at runtime in insecure mode
+/// (`--insecure` / `DECPM_INSECURE`, or under `cargo test`).
 ///
-/// Accepts either the hardcoded mock token or an empty/missing token, so
-/// test-mode UX (swagger, unauthenticated curls) keeps working while the
+/// Accepts either the hardcoded mock token or an empty/missing token, so the
+/// insecure-mode UX (swagger, unauthenticated curls) works while the
 /// middleware plumbing is still exercised end-to-end. The returned principal
 /// carries the admin role so gated endpoints (`PUT /party-config`, `POST /kick`)
-/// are reachable from tests.
+/// are reachable without a real IdP.
 pub struct MockValidator {
     admin_role: String,
 }

--- a/crates/decman/src/auth/validators/mock.rs
+++ b/crates/decman/src/auth/validators/mock.rs
@@ -6,7 +6,8 @@ use crate::auth::{
 /// Permissive inbound validator, selected at runtime in insecure mode
 /// (`--insecure` / `DECPM_INSECURE`, or under `cargo test`).
 ///
-/// Accepts either the hardcoded mock token or an empty/missing token, so the
+/// Accepts *any* token, including an empty/missing one — validation always
+/// succeeds and only logs when the token differs from the mock token. So the
 /// insecure-mode UX (swagger, unauthenticated curls) works while the
 /// middleware plumbing is still exercised end-to-end. The returned principal
 /// carries the admin role so gated endpoints (`PUT /party-config`, `POST /kick`)

--- a/crates/decman/src/auth/validators/mod.rs
+++ b/crates/decman/src/auth/validators/mod.rs
@@ -1,10 +1,8 @@
 mod common;
 mod jwt;
-#[cfg(any(test, feature = "test-mode"))]
 mod mock;
 mod oidc_introspection;
 
 pub use jwt::JwtValidator;
-#[cfg(any(test, feature = "test-mode"))]
 pub use mock::MockValidator;
 pub use oidc_introspection::OidcIntrospectionValidator;

--- a/crates/decman/src/cli.rs
+++ b/crates/decman/src/cli.rs
@@ -143,6 +143,28 @@ pub enum Commands {
         #[arg(long, env = "DECPM_ALLOWED_ORIGIN")]
         allowed_origin: Option<String>,
 
+        // Insecure / no-IdP mode (local dev against an unsafe-auth Canton).
+        /// Run without an IdP: accept ANY inbound token and present an unsafe
+        /// HS256 token to Canton. Disables authentication — NEVER use in
+        /// production. Pair with an unsafe-auth Canton (see the HMAC flags).
+        #[arg(long, env = "DECPM_INSECURE", default_value_t = false)]
+        insecure: bool,
+
+        /// HMAC secret decman signs the unsafe Canton token with (insecure
+        /// mode). Must match Canton's unsafe auth-service secret. Default `unsafe`.
+        #[arg(long, env = "DECPM_CANTON_HMAC_SECRET")]
+        canton_hmac_secret: Option<String>,
+
+        /// `aud` claim for the unsafe Canton token (insecure mode). Must match
+        /// Canton's `target-audience`. Default `https://canton.network.global`.
+        #[arg(long, env = "DECPM_CANTON_HMAC_AUDIENCE")]
+        canton_hmac_audience: Option<String>,
+
+        /// `sub` claim / ledger user for the unsafe Canton token (insecure
+        /// mode). Default `ledger-api-user`.
+        #[arg(long, env = "DECPM_CANTON_HMAC_SUBJECT")]
+        canton_hmac_subject: Option<String>,
+
         // Timeouts
         /// Noise handshake timeout in seconds
         #[arg(long, env = "DECPM_TIMEOUT_HANDSHAKE")]

--- a/crates/decman/src/config.rs
+++ b/crates/decman/src/config.rs
@@ -214,6 +214,31 @@ impl NoiseRetryConfig {
     }
 }
 
+/// Settings for the unsafe HS256 ("HMAC") token decman presents to Canton
+/// when running in [`NodeConfig::insecure`] mode. Point Canton's unsafe auth
+/// service at the same `secret`/`audience` to have it accept the token.
+///
+/// Never serialized (the `secret` must not leak); populated only from CLI/env.
+#[derive(Clone, Debug)]
+pub struct InsecureAuthConfig {
+    /// HS256 signing secret. Canton's conventional dev secret is `unsafe`.
+    pub secret: String,
+    /// `aud` claim.
+    pub audience: String,
+    /// `sub` claim, doubling as the ledger-api user id.
+    pub subject: String,
+}
+
+impl Default for InsecureAuthConfig {
+    fn default() -> Self {
+        Self {
+            secret: "unsafe".to_string(),
+            audience: "https://canton.network.global".to_string(),
+            subject: "ledger-api-user".to_string(),
+        }
+    }
+}
+
 /// Individual node configuration
 #[derive(Clone, Debug, Serialize, utoipa::ToSchema)]
 #[cfg_attr(feature = "typegen", derive(ts_rs::TS), ts(optional_fields))]
@@ -227,6 +252,14 @@ pub struct NodeConfig {
     /// Top-level Auth0 config for frontend website gating (mutually exclusive
     /// with `keycloak` — operator picks one via env vars at deploy time).
     pub auth0: Option<Auth0Config>,
+    /// Run without an IdP: accept any inbound token and mint an unsafe HS256
+    /// token for Canton. Never enable in production. Not serialized.
+    #[serde(skip)]
+    pub insecure: bool,
+    /// Unsafe token settings, used only when `insecure` is set. Not serialized
+    /// (carries the signing secret).
+    #[serde(skip)]
+    pub insecure_auth: InsecureAuthConfig,
     /// Root directory containing data/ subdirectory
     #[serde(skip)]
     root_dir: PathBuf,
@@ -241,6 +274,8 @@ impl Default for NodeConfig {
             noise_retry: NoiseRetryConfig::default(),
             keycloak: None,
             auth0: None,
+            insecure: false,
+            insecure_auth: InsecureAuthConfig::default(),
             root_dir: PathBuf::new(),
         }
     }

--- a/crates/decman/src/config.rs
+++ b/crates/decman/src/config.rs
@@ -327,7 +327,9 @@ pub struct KeycloakDefaults {
 }
 
 /// Canton Network environment
-#[derive(Clone, Copy, Debug, Deserialize, Serialize, utoipa::ToSchema, clap::ValueEnum)]
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize, utoipa::ToSchema, clap::ValueEnum,
+)]
 #[cfg_attr(feature = "typegen", derive(ts_rs::TS), ts(optional_fields))]
 #[serde(rename_all = "lowercase")]
 pub enum Network {

--- a/crates/decman/src/main.rs
+++ b/crates/decman/src/main.rs
@@ -82,6 +82,10 @@ async fn main() -> Result {
             noise_retry_max_attempts,
             noise_retry_backoff_ms,
             db_encryption_key,
+            insecure,
+            canton_hmac_secret,
+            canton_hmac_audience,
+            canton_hmac_subject,
             ..
         } => {
             if let Some(key) = db_encryption_key {
@@ -176,6 +180,17 @@ async fn main() -> Result {
             }
             if let Some(v) = noise_retry_backoff_ms {
                 config.noise_retry.backoff_ms = *v;
+            }
+
+            config.insecure = *insecure;
+            if let Some(v) = canton_hmac_secret {
+                config.insecure_auth.secret = v.clone();
+            }
+            if let Some(v) = canton_hmac_audience {
+                config.insecure_auth.audience = v.clone();
+            }
+            if let Some(v) = canton_hmac_subject {
+                config.insecure_auth.subject = v.clone();
             }
         }
     }

--- a/crates/decman/src/main.rs
+++ b/crates/decman/src/main.rs
@@ -183,14 +183,18 @@ async fn main() -> Result {
             }
 
             config.insecure = *insecure;
-            if let Some(v) = canton_hmac_secret {
-                config.insecure_auth.secret = v.clone();
-            }
-            if let Some(v) = canton_hmac_audience {
-                config.insecure_auth.audience = v.clone();
-            }
-            if let Some(v) = canton_hmac_subject {
-                config.insecure_auth.subject = v.clone();
+            // Only ingest the unsafe HMAC settings when insecure mode is on;
+            // in a secure run they do nothing, so don't store them.
+            if *insecure {
+                if let Some(v) = canton_hmac_secret {
+                    config.insecure_auth.secret = v.clone();
+                }
+                if let Some(v) = canton_hmac_audience {
+                    config.insecure_auth.audience = v.clone();
+                }
+                if let Some(v) = canton_hmac_subject {
+                    config.insecure_auth.subject = v.clone();
+                }
             }
         }
     }

--- a/crates/decman/src/server/middleware/auth.rs
+++ b/crates/decman/src/server/middleware/auth.rs
@@ -184,7 +184,7 @@ fn parse_bearer(header: &str) -> Option<&str> {
 }
 
 /// Paths that bypass auth entirely. Covers the SPA entry point, static
-/// assets, swagger (only mounted with the `test-mode` Cargo feature),
+/// assets, swagger (only mounted in insecure mode, `--insecure`),
 /// `/auth-config` which the login page fetches before the user has a
 /// token, and `/healthz` — a no-I/O liveness probe the frontend pings to
 /// time its own round-trip to this node (kept auth-free so the measurement

--- a/crates/decman/src/server/mod.rs
+++ b/crates/decman/src/server/mod.rs
@@ -1,8 +1,8 @@
 //! HTTP server and always-on Noise listener.
 //!
 //! Builds the actix-web application (REST API + embedded React UI; a Swagger UI
-//! is mounted only in test/dev builds, i.e. `cfg!(any(test, feature =
-//! "test-mode"))`), wires shared [`AppState`], and runs the long-lived Noise
+//! is mounted only when the node runs in insecure mode, i.e. `--insecure`),
+//! wires shared [`AppState`], and runs the long-lived Noise
 //! listener that
 //! handles inbound peer messages (invites, signing, health, cancellation)
 //! independently of any coordinator-driven workflow.
@@ -95,7 +95,7 @@ pub struct AppState {
     pub peer_job_sender: mpsc::UnboundedSender<PeerJob>,
     /// Pending invitations awaiting user acceptance
     pub pending_invitations: Arc<RwLock<Vec<PendingInvitation>>>,
-    /// Authentication registry (real Keycloak or mock for test mode)
+    /// Authentication registry (real Keycloak, or mock in insecure mode)
     pub auth: Arc<RwLock<Option<WorkflowAuth>>>,
     /// Inbound token validator — authenticates API callers.
     pub token_validator: TokenValidator,
@@ -116,7 +116,9 @@ pub struct AppState {
     /// `workflows.route(msg.instance)`, and `/workflows/{instance}/cancel`
     /// looks an entry up to abort its spawn.
     pub workflows: WorkflowRegistry,
-    /// Whether the server is running in test mode
+    /// Whether the server is running in insecure/permissive mode (`--insecure`
+    /// or tests): mock auth plus wildcard-token query filtering. Field name
+    /// kept as `test_mode` for continuity.
     pub test_mode: bool,
     /// Prefixes currently being refreshed from Canton (deduplication)
     pub refreshing_prefixes: Arc<RwLock<HashSet<String>>>,

--- a/crates/decman/src/server/mod.rs
+++ b/crates/decman/src/server/mod.rs
@@ -53,7 +53,7 @@ use crate::{
         AuthRegistry, JwtValidator, MockAuthRegistry, MockValidator, TokenValidator, WorkflowAuth,
     },
     canton_id::CantonId,
-    config::{NodeConfig, PartyCredentials},
+    config::{Network, NodeConfig, PartyCredentials},
     db::schema::{Commitable, SchemaRead, SchemaWrite},
     error::Result,
     noise::{
@@ -812,6 +812,23 @@ impl WorkflowTriggers {
     }
 }
 
+/// Refuse to boot with insecure mode enabled on anything but devnet.
+///
+/// Insecure mode disables authentication, so a stray `DECPM_INSECURE=true` on a
+/// testnet/mainnet node would silently turn off all auth with only a log line.
+/// This turns that footgun into a hard boot failure. Guards the runtime flag
+/// only — `cfg!(test)` / `feature = "test-mode"` builds force insecure on
+/// regardless of network and are expected to run off-devnet.
+fn ensure_insecure_allowed(insecure: bool, network: Network) -> Result {
+    if insecure && network != Network::Devnet {
+        anyhow::bail!(
+            "--insecure / DECPM_INSECURE is only permitted on the devnet network; \
+             refusing to start on {network:?}"
+        );
+    }
+    Ok(())
+}
+
 /// Start the HTTP server and a heartbeat system for peer status tracking
 pub async fn start_server(
     host: &str,
@@ -821,6 +838,10 @@ pub async fn start_server(
     admin_role: Option<String>,
     allowed_origin: Option<String>,
 ) -> Result {
+    // Fail fast before any setup: the runtime `--insecure` flag must never be
+    // honored off devnet (see `ensure_insecure_allowed`).
+    ensure_insecure_allowed(config.insecure, config.canton.network)?;
+
     // Insecure mode is a runtime decision: `--insecure` / `DECPM_INSECURE`
     // selects mock auth (accept any inbound token, present an unsafe HMAC token
     // to Canton) in any build. It is also forced on under `cargo test` and in
@@ -2302,4 +2323,27 @@ async fn list_local_packages(admin_api_url: &str) -> Result<Vec<u8>> {
         .collect();
 
     Ok(serde_json::to_vec(&packages)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ensure_insecure_allowed, Network};
+
+    #[test]
+    fn insecure_allowed_on_devnet() {
+        assert!(ensure_insecure_allowed(true, Network::Devnet).is_ok());
+    }
+
+    #[test]
+    fn insecure_refused_off_devnet() {
+        assert!(ensure_insecure_allowed(true, Network::Testnet).is_err());
+        assert!(ensure_insecure_allowed(true, Network::Mainnet).is_err());
+    }
+
+    #[test]
+    fn secure_allowed_on_any_network() {
+        assert!(ensure_insecure_allowed(false, Network::Devnet).is_ok());
+        assert!(ensure_insecure_allowed(false, Network::Testnet).is_ok());
+        assert!(ensure_insecure_allowed(false, Network::Mainnet).is_ok());
+    }
 }

--- a/crates/decman/src/server/mod.rs
+++ b/crates/decman/src/server/mod.rs
@@ -48,12 +48,10 @@ use tokio_noise::handshakes::nn_psk2::Responder;
 use utoipa_actix_web::AppExt;
 use utoipa_swagger_ui::SwaggerUi;
 
-#[cfg(not(any(test, feature = "test-mode")))]
-use crate::auth::{AuthRegistry, JwtValidator};
-#[cfg(any(test, feature = "test-mode"))]
-use crate::auth::{MockAuthRegistry, MockValidator};
 use crate::{
-    auth::{TokenValidator, WorkflowAuth},
+    auth::{
+        AuthRegistry, JwtValidator, MockAuthRegistry, MockValidator, TokenValidator, WorkflowAuth,
+    },
     canton_id::CantonId,
     config::{NodeConfig, PartyCredentials},
     db::schema::{Commitable, SchemaRead, SchemaWrite},
@@ -821,17 +819,21 @@ pub async fn start_server(
     admin_role: Option<String>,
     allowed_origin: Option<String>,
 ) -> Result {
-    // Test-mode is a compile-time decision: it's `true` iff the binary was
-    // built with `--features test-mode` (or under `cargo test`). Production
-    // binaries cannot run with mock auth — the `MockValidator` and
-    // `MockAuthRegistry` selections below are gated by the same cfg.
-    let test_mode = cfg!(any(test, feature = "test-mode"));
+    // Insecure mode is a runtime decision: `--insecure` / `DECPM_INSECURE`
+    // selects mock auth (accept any inbound token, present an unsafe HMAC token
+    // to Canton) in any build. It is also forced on under `cargo test` and in
+    // `--features test-mode` builds so those keep working without the flag.
+    // Downstream (`AppState.test_mode`, query filtering) this means "using the
+    // permissive wildcard token".
+    let insecure = config.insecure || cfg!(any(test, feature = "test-mode"));
 
-    if !test_mode {
-        tracing::info!(
-            "Running production build (no `test-mode` feature). Swagger UI disabled, \
-             real JWT validation in effect."
+    if insecure {
+        tracing::warn!(
+            "INSECURE MODE ENABLED: inbound auth accepts ANY token and Canton auth uses an \
+             unsafe HMAC token. Authentication is effectively disabled — never use in production."
         );
+    } else {
+        tracing::info!("Running with real JWT validation.");
     }
 
     // Make the admin-role policy explicit at boot so a single-user deployment
@@ -858,16 +860,13 @@ pub async fn start_server(
     });
     let party_credentials = Arc::new(RwLock::new(db_party_creds.clone()));
 
-    // Initialize auth based on mode
-    #[cfg(any(test, feature = "test-mode"))]
-    let auth = {
-        tracing::info!("Running in TEST MODE - using mock authentication");
-        Some(WorkflowAuth::Mock(Arc::new(MockAuthRegistry::new(
+    // Initialize outbound auth (the token DecMan presents to Canton) based on mode
+    let auth = if insecure {
+        Some(WorkflowAuth::Mock(Arc::new(MockAuthRegistry::with_config(
             party_credentials.clone(),
+            &config.insecure_auth,
         ))))
-    };
-    #[cfg(not(any(test, feature = "test-mode")))]
-    let auth = if db_party_creds.is_empty() {
+    } else if db_party_creds.is_empty() {
         tracing::info!("No party credentials configured, auth disabled");
         None
     } else {
@@ -894,14 +893,13 @@ pub async fn start_server(
         .expect("reqwest client build");
 
     // keycloak config plus any `party_credentials` rows. The permissive
-    // `MockValidator` is compiled in only behind `cfg(any(test, feature =
-    // "test-mode"))`, so a release binary cannot select it.
-    #[cfg(any(test, feature = "test-mode"))]
-    let token_validator = TokenValidator::Mock(Arc::new(MockValidator::new(
-        admin_role.clone().unwrap_or_default(),
-    )));
-    #[cfg(not(any(test, feature = "test-mode")))]
-    let token_validator = {
+    // `MockValidator` is selected only in insecure mode; production verifies
+    // real JWTs.
+    let token_validator = if insecure {
+        TokenValidator::Mock(Arc::new(MockValidator::new(
+            admin_role.clone().unwrap_or_default(),
+        )))
+    } else {
         let no_top_level_config = config.keycloak.is_none();
         let no_party_creds = party_credentials.read().await.is_empty();
         if no_top_level_config && no_party_creds {
@@ -955,7 +953,9 @@ pub async fn start_server(
         party_credentials: party_credentials.clone(),
         bootstrap_mu: Arc::new(Mutex::new(())),
         workflows: workflows.clone(),
-        test_mode,
+        // "test_mode" here means the permissive/wildcard-token mode; driven by
+        // `--insecure` (or tests). See the `insecure` binding above.
+        test_mode: insecure,
         refreshing_prefixes: Arc::new(RwLock::new(HashSet::new())),
         http_client,
     });
@@ -1165,7 +1165,7 @@ pub async fn start_server(
             .split_for_parts();
 
         let mut app = app.wrap(AuthMiddleware).wrap(cors);
-        if test_mode {
+        if insecure {
             app = app
                 .service(SwaggerUi::new("/swagger-ui/{_:.*}").url("/api-docs/openapi.json", api));
         }

--- a/crates/decman/src/server/mod.rs
+++ b/crates/decman/src/server/mod.rs
@@ -2327,7 +2327,7 @@ async fn list_local_packages(admin_api_url: &str) -> Result<Vec<u8>> {
 
 #[cfg(test)]
 mod tests {
-    use super::{ensure_insecure_allowed, Network};
+    use super::{Network, ensure_insecure_allowed};
 
     #[test]
     fn insecure_allowed_on_devnet() {

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -1,7 +1,43 @@
+# Local 3-node dec-party-manager dev stack.
+#
+# Builds the image from source (../Dockerfile). The build fetches private
+# DLC-link dependencies (canton-lib) over SSH via `--mount=type=ssh`, so you
+# need an ssh-agent running with a key that can read github.com/DLC-link/*:
+#   eval "$(ssh-agent -s)" && ssh-add ~/.ssh/<your-key>
+# NOTE: this build is currently broken with a GitHub SSH auth error — see
+# https://github.com/DLC-link/dec-party-manager/issues/221. Until it is fixed
+# you can run a prebuilt image instead by replacing each `build:` block with
+# `image: public.ecr.aws/dlc-link/canton-decparty-manager:<tag>`.
+#
+# Uses bridge networking (the Compose default) so it runs the same on Docker
+# Desktop for Mac, OrbStack, and Linux. Do NOT switch these to
+# `network_mode: host`: on Docker Desktop for Mac a host-networked container
+# runs inside Docker Desktop's Linux VM, so the published UI ports are dropped
+# and localhost:808x serves nothing.
+#
+# Prerequisites:
+#   1. Copy each remote/participant-N/.env.example to .env and fill it in.
+#   2. Run `just port-forward` on the host so the Canton Ledger/Admin APIs are
+#      reachable at localhost:5001/5002 (p1), 5011/5012 (p2), 5021/5022 (p3).
+#      The containers reach those forwards via host.docker.internal (below).
+#
+# Per-service overrides vs the .env files:
+#   - DECPM_CANTON_*_HOST -> host.docker.internal: in bridge networking a
+#     container's localhost is itself, so the .env's `localhost` can't reach the
+#     host's port-forwards. host.docker.internal points at the host. (The port
+#     numbers still come from each .env.)
+#   - DECPM_PUBLIC_ADDRESS -> the compose service name: the address a node
+#     advertises so its peers can dial its Noise listener over the shared
+#     bridge network.
+
 services:
   participant-1:
     platform: linux/amd64
-    image: public.ecr.aws/dlc-link/canton-decparty-manager:1.0.1
+    build:
+      context: ..
+      dockerfile: Dockerfile
+      ssh:
+        - default
     volumes:
       - ./remote/participant-1/data:/app/data
     ports:
@@ -21,7 +57,11 @@ services:
 
   participant-2:
     platform: linux/amd64
-    image: public.ecr.aws/dlc-link/canton-decparty-manager:1.0.1
+    build:
+      context: ..
+      dockerfile: Dockerfile
+      ssh:
+        - default
     volumes:
       - ./remote/participant-2/data:/app/data
     ports:
@@ -41,7 +81,11 @@ services:
 
   participant-3:
     platform: linux/amd64
-    image: public.ecr.aws/dlc-link/canton-decparty-manager:1.0.1
+    build:
+      context: ..
+      dockerfile: Dockerfile
+      ssh:
+        - default
     volumes:
       - ./remote/participant-3/data:/app/data
     ports:

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -1,63 +1,60 @@
 services:
   participant-1:
     platform: linux/amd64
-    build:
-      context: ..
-      dockerfile: Dockerfile
-      ssh:
-        - default
+    image: public.ecr.aws/dlc-link/canton-decparty-manager:1.0.1
     volumes:
       - ./remote/participant-1/data:/app/data
-    network_mode: host
     ports:
       - "8081:8081"
-      - "9001:9001"
     env_file:
       - ./remote/participant-1/.env
     environment:
       DECPM_DIR: /app
       DECPM_HOST: 0.0.0.0
       DECPM_PORT: "8081"
+      DECPM_CANTON_ADMIN_HOST: host.docker.internal
+      DECPM_CANTON_LEDGER_HOST: host.docker.internal
+      DECPM_PUBLIC_ADDRESS: participant-1
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     entrypoint: ["dec-party-manager", "serve"]
 
   participant-2:
     platform: linux/amd64
-    build:
-      context: ..
-      dockerfile: Dockerfile
-      ssh:
-        - default
+    image: public.ecr.aws/dlc-link/canton-decparty-manager:1.0.1
     volumes:
       - ./remote/participant-2/data:/app/data
-    network_mode: host
     ports:
       - "8082:8082"
-      - "9002:9002"
     env_file:
       - ./remote/participant-2/.env
     environment:
       DECPM_DIR: /app
       DECPM_HOST: 0.0.0.0
       DECPM_PORT: "8082"
+      DECPM_CANTON_ADMIN_HOST: host.docker.internal
+      DECPM_CANTON_LEDGER_HOST: host.docker.internal
+      DECPM_PUBLIC_ADDRESS: participant-2
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     entrypoint: ["dec-party-manager", "serve"]
 
   participant-3:
     platform: linux/amd64
-    build:
-      context: ..
-      dockerfile: Dockerfile
-      ssh:
-        - default
+    image: public.ecr.aws/dlc-link/canton-decparty-manager:1.0.1
     volumes:
       - ./remote/participant-3/data:/app/data
-    network_mode: host
     ports:
       - "8083:8083"
-      - "9003:9003"
     env_file:
       - ./remote/participant-3/.env
     environment:
       DECPM_DIR: /app
       DECPM_HOST: 0.0.0.0
       DECPM_PORT: "8083"
+      DECPM_CANTON_ADMIN_HOST: host.docker.internal
+      DECPM_CANTON_LEDGER_HOST: host.docker.internal
+      DECPM_PUBLIC_ADDRESS: participant-3
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     entrypoint: ["dec-party-manager", "serve"]

--- a/development/remote/participant-1/.env.example
+++ b/development/remote/participant-1/.env.example
@@ -26,6 +26,18 @@ DECPM_CANTON_SYNCHRONIZER=global
 DECPM_CANTON_NETWORK=devnet
 
 # ---------------------------------------------------------------------------
+# Insecure mode (LOCAL DEV ONLY) — skip Keycloak/Auth0 entirely.
+# Only works against a Canton configured with unsafe (shared-secret) auth. The
+# shared devnet above uses Keycloak, so leave this OFF there. When enabled, DecMan
+# accepts any inbound token and signs its own HS256 token for Canton.
+# NEVER set this in a shared or production deployment. See README "Insecure mode".
+# ---------------------------------------------------------------------------
+# DECPM_INSECURE=true
+# DECPM_CANTON_HMAC_SECRET=unsafe
+# DECPM_CANTON_HMAC_AUDIENCE=https://canton.network.global
+# DECPM_CANTON_HMAC_SUBJECT=ledger-api-user
+
+# ---------------------------------------------------------------------------
 # Shared Keycloak (same values across all three participants' .env files).
 # DECPM_KEYCLOAK_URL may be configured with or without the trailing `/auth`
 # servlet path — both forms are tolerated by src/auth/mod.rs::token_url

--- a/development/remote/participant-2/.env.example
+++ b/development/remote/participant-2/.env.example
@@ -26,6 +26,18 @@ DECPM_CANTON_SYNCHRONIZER=global
 DECPM_CANTON_NETWORK=devnet
 
 # ---------------------------------------------------------------------------
+# Insecure mode (LOCAL DEV ONLY) — skip Keycloak/Auth0 entirely.
+# Only works against a Canton configured with unsafe (shared-secret) auth. The
+# shared devnet above uses Keycloak, so leave this OFF there. When enabled, DecMan
+# accepts any inbound token and signs its own HS256 token for Canton.
+# NEVER set this in a shared or production deployment. See README "Insecure mode".
+# ---------------------------------------------------------------------------
+# DECPM_INSECURE=true
+# DECPM_CANTON_HMAC_SECRET=unsafe
+# DECPM_CANTON_HMAC_AUDIENCE=https://canton.network.global
+# DECPM_CANTON_HMAC_SUBJECT=ledger-api-user
+
+# ---------------------------------------------------------------------------
 # Shared Keycloak (same values across all three participants' .env files).
 # DECPM_KEYCLOAK_URL may be configured with or without the trailing `/auth`
 # servlet path — both forms are tolerated by src/auth/mod.rs::token_url

--- a/development/remote/participant-3/.env.example
+++ b/development/remote/participant-3/.env.example
@@ -26,6 +26,18 @@ DECPM_CANTON_SYNCHRONIZER=global
 DECPM_CANTON_NETWORK=devnet
 
 # ---------------------------------------------------------------------------
+# Insecure mode (LOCAL DEV ONLY) — skip Keycloak/Auth0 entirely.
+# Only works against a Canton configured with unsafe (shared-secret) auth. The
+# shared devnet above uses Keycloak, so leave this OFF there. When enabled, DecMan
+# accepts any inbound token and signs its own HS256 token for Canton.
+# NEVER set this in a shared or production deployment. See README "Insecure mode".
+# ---------------------------------------------------------------------------
+# DECPM_INSECURE=true
+# DECPM_CANTON_HMAC_SECRET=unsafe
+# DECPM_CANTON_HMAC_AUDIENCE=https://canton.network.global
+# DECPM_CANTON_HMAC_SUBJECT=ledger-api-user
+
+# ---------------------------------------------------------------------------
 # Shared Keycloak (same values across all three participants' .env files).
 # DECPM_KEYCLOAK_URL may be configured with or without the trailing `/auth`
 # servlet path — both forms are tolerated by src/auth/mod.rs::token_url

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -42,6 +42,9 @@ Bumping the tag in the Deployment manifest and re-applying is how you upgrade go
 
 The admin UI authenticates users through your identity provider using the **Authorization Code flow with PKCE**, so it needs a dedicated **public** client. Configure either Keycloak **or** Auth0 — the two providers are mutually exclusive at config-load time.
 
+> [!WARNING]
+> There is an `--insecure` / `DECPM_INSECURE` mode that bypasses the identity provider entirely (any inbound token is accepted and an unsafe shared-secret token is sent to Canton). It exists for local development against an unsafe-auth Canton and **must never be set in a production deployment.** Leave it unset (the default) for every environment described in this guide.
+
 ### Keycloak
 
 You need a **public** client in your realm. The client ID you choose here is what goes into `DECPM_KEYCLOAK_CLIENT_ID` in the Secret below; there is no client secret to copy because public SPA clients don't have one.

--- a/justfile
+++ b/justfile
@@ -13,13 +13,14 @@ gen-types:
     DECMAN_SKIP_FRONTEND=1 cargo run -q -p decman --features typegen --bin gen-types
     echo "Generated crates/decman/frontend/src/types.generated.ts"
 
-# Forward Canton ibtc-devnet participant 1..3 Ledger/Admin ports (KUBE_NS=catalyst-canton by default).
+# Forward Canton devnet participant 1..3 Ledger/Admin ports. Each node lives in
+# its own namespace (KUBE_NS_PREFIX=canton-node- by default -> canton-node-1..3).
 [group('canton')]
 port-forward:
     #!/usr/bin/env bash
     set -uo pipefail
 
-    ns="${KUBE_NS:-catalyst-canton}"
+    prefix="${KUBE_NS_PREFIX:-canton-node-}"
     pids=()
 
     cleanup() {
@@ -32,20 +33,19 @@ port-forward:
     trap cleanup INT TERM EXIT
 
     fwd() {
-        local tag=$1 svc=$2; shift 2
+        local tag=$1 ns=$2 svc=$3; shift 3
         kubectl port-forward -n "$ns" "svc/$svc" "$@" 2>&1 \
             | sed -u "s/^/[$tag] /" &
         pids+=($!)
     }
 
-    fwd p1 participant-ibtc-devnet-1 5001:5001 5002:5002
-    fwd p2 participant-ibtc-devnet-2 5011:5001 5012:5002
-    fwd p3 participant-ibtc-devnet-3 5021:5001 5022:5002
+    fwd p1 "${prefix}1" participant 5001:5001 5002:5002
+    fwd p2 "${prefix}2" participant 5011:5001 5012:5002
+    fwd p3 "${prefix}3" participant 5021:5001 5022:5002
 
-    echo "[port-forward] namespace: $ns"
-    echo "[port-forward]   participant 1  ->  localhost:5001 / 5002"
-    echo "[port-forward]   participant 2  ->  localhost:5011 / 5012"
-    echo "[port-forward]   participant 3  ->  localhost:5021 / 5022"
+    echo "[port-forward]   participant 1 (${prefix}1)  ->  localhost:5001 / 5002"
+    echo "[port-forward]   participant 2 (${prefix}2)  ->  localhost:5011 / 5012"
+    echo "[port-forward]   participant 3 (${prefix}3)  ->  localhost:5021 / 5022"
     echo "[port-forward] Ctrl-C to stop all."
 
     wait


### PR DESCRIPTION
## What

Adds a runtime `--insecure` / `DECPM_INSECURE` mode so a node can run without Keycloak/Auth0, for local dev against a Canton with unsafe (shared-secret) auth. When on, it accepts any inbound token and mints an HS256 Canton token from `DECPM_CANTON_HMAC_SECRET` / `_AUDIENCE` / `_SUBJECT` (defaults `unsafe` / `https://canton.network.global` / `ledger-api-user`).

This replaces the compile-time `test-mode` feature as the way to get mock auth. The mock validator and HMAC token path are now always compiled and selected at runtime by the flag, so no special build is needed. `test-mode` / `cargo test` still force it on for existing tests.

Also switches the dev `docker-compose.yml` off `network_mode: host` to bridge networking + `host.docker.internal` + service-name peers, so it runs the same on Docker Desktop for Mac (host mode silently drops published ports there), OrbStack, and Linux.

## Security

Trades the old "a release binary can't select mock auth" compile-time guarantee for a runtime flag. Default behavior is unchanged (real JWT validation); the node logs a loud warning at startup whenever insecure mode is on. The HMAC secret is never logged, and the two new config fields are `#[serde(skip)]` so the secret can't leak through `/node-config` or the generated frontend types.

## Testing

`cargo clippy --all-targets --all-features` clean. `gen-types` produces no diff. Flags verified in `serve --help`. Did not run the full suite or a live Canton handshake.
