### PR TITLE
feat(workflow): change dec party topology threshold

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1328,7 +1328,7 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "decman"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "actix-cors",
  "actix-web",

--- a/README.md
+++ b/README.md
@@ -253,8 +253,12 @@ curl http://localhost:8081/party-config/decparty::1220abc...
 
 1. Configure all participant nodes with each other's connection details via the `/network-config` API
 2. Start all participant servers
-3. On the coordinator's UI, click **Create Party** and enter a party ID prefix
-4. The coordinator invites peers and orchestrates:
+3. On the coordinator's UI, click **Create Party**, enter a party ID prefix, and
+   select the peers to invite
+4. Optionally adjust the **Threshold** — how many of the party's owners must sign
+   topology changes. It defaults to a majority (`ceil(owners / 2)`, shown and
+   editable in the dialog)
+5. The coordinator invites peers and orchestrates:
    - Cryptographic key generation (namespace + DAML signing keys)
    - Topology proposal creation (DNS and P2P mappings)
    - Multi-party signing
@@ -281,6 +285,23 @@ curl http://localhost:8081/party-config/decparty::1220abc...
    - Multi-party signing by remaining members
    - Proposal submission
 
+### Adding a Participant (Add Party)
+
+1. From a party card, click **Add member** and choose the participant to add
+2. The coordinator orchestrates:
+   - Key generation on the new member
+   - Updated topology proposals (added owner + P2P mapping) signed by all members
+   - ACS replication to the new member and clearing of its onboarding flag
+
+### Changing the Threshold (Change Threshold)
+
+1. From a party card, click **Change Threshold** and enter the new value
+2. The coordinator orchestrates:
+   - Export current namespace state
+   - Re-issue the DNS and P2P mappings with the new threshold (same members)
+   - Multi-party signing by a quorum of the current owners
+   - Proposal submission
+
 ## API Endpoints
 
 The table below is a curated subset. A complete, interactive API reference is available via the **Swagger UI at `/swagger-ui/`** (OpenAPI document at `/api-docs/openapi.json`) — but note these endpoints are only mounted in development/test builds (`--features test-mode`); the shipped release image does not expose them.
@@ -305,12 +326,18 @@ The table below is a curated subset. A complete, interactive API reference is av
 | `/contracts/status` | GET | Returns contracts progress |
 | `/kick` | POST | Starts kick workflow |
 | `/kick/status` | GET | Returns kick progress |
+| `/add-party` | POST | Starts add-party workflow |
+| `/add-party/status` | GET | Returns add-party progress |
+| `/change-threshold` | POST | Starts change-threshold workflow |
+| `/change-threshold/status` | GET | Returns change-threshold progress |
 | `/workflows` | GET | Lists workflow instances and their lifecycle state |
 | `/workflows/{instance_name}/dismiss` | POST | Dismisses a workflow instance |
 | `/workflows/{instance_name}/retry` | POST | Retries a failed workflow instance |
 | `/onboarding/cancel` | POST | Cancels the onboarding workflow |
 | `/contracts/cancel` | POST | Cancels the contracts workflow |
 | `/kick/cancel` | POST | Cancels the kick workflow |
+| `/add-party/cancel` | POST | Cancels the add-party workflow |
+| `/change-threshold/cancel` | POST | Cancels the change-threshold workflow |
 | `/dars/cancel` | POST | Cancels the DARs distribution workflow |
 | `/invitations` | GET | Returns pending workflow invitations |
 | `/invitations/accept` | POST | Accepts a pending invitation |

--- a/crates/common/src/api.rs
+++ b/crates/common/src/api.rs
@@ -178,6 +178,23 @@ pub struct AddPartyRequest {
     pub previous_threshold: i32,
 }
 
+/// Request to change the signing threshold of an existing decentralized party.
+/// Re-issues the namespace + party mappings with `new_threshold`; membership is
+/// unchanged.
+#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "typegen", derive(ts_rs::TS), ts(optional_fields))]
+pub struct ChangeThresholdRequest {
+    pub decentralized_party_id: CantonId,
+    pub new_threshold: i32,
+    /// The party's threshold *before* the change. Display-only — surfaced on
+    /// the workflow run card as "old → new". Defaults to 0 (rendered as just
+    /// the new value) when an older client omits it.
+    #[serde(default)]
+    pub previous_threshold: i32,
+}
+
 /// Request to create a new decentralized party
 #[derive(Clone, Debug, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
@@ -187,6 +204,13 @@ pub struct OnboardingRequest {
     pub party_id_prefix: String,
     /// List of peer IDs to invite to the decentralized party
     pub peer_ids: Vec<CantonId>,
+    /// Initial signing threshold for the new party (applied to both the
+    /// decentralized-namespace and party-to-participant mappings). Optional:
+    /// when omitted the coordinator falls back to the default majority
+    /// algorithm (`ceil(owner_count / 2)`, min 1). The frontend pre-fills this
+    /// with the same default so the operator can see and adjust it.
+    #[serde(default)]
+    pub threshold: Option<i32>,
 }
 
 /// Why a directed edge was reported missing. The frontend renders different
@@ -293,6 +317,11 @@ pub struct KeyStatusResponse {
 pub struct OnboardingInvitePayload {
     pub prefix: String,
     pub participants: Vec<CantonId>,
+    /// Initial signing threshold the coordinator will use, so the invitation
+    /// and run cards can show it before the proposals are built. `None` from
+    /// an older coordinator that predates the field (the card then omits it).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub threshold: Option<i32>,
     /// The coordinator's `workflow_runs` instance name for this run. Echoed
     /// back in `DeclineInvitationPayload` so the coordinator can tell a
     /// decline of THIS run apart from a stale invite of an earlier run.
@@ -366,6 +395,25 @@ pub struct AddPartyInvitePayload {
     pub previous_threshold: i32,
     /// The full post-add member set, so the peer card renders the same
     /// participant list the coordinator shows.
+    #[serde(default)]
+    pub participants: Vec<CantonId>,
+    /// The coordinator's run instance name (see `OnboardingInvitePayload`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflow_instance: Option<String>,
+}
+
+/// Payload sent inside an `InviteChangeThreshold` Noise message — gives the
+/// peer enough context to show "changing dec party Y threshold a→b" before the
+/// proposals arrive.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "typegen", derive(ts_rs::TS), ts(optional_fields))]
+pub struct ChangeThresholdInvitePayload {
+    pub dec_party_id: CantonId,
+    pub new_threshold: i32,
+    pub previous_threshold: i32,
+    /// The party's member set, so the peer card renders the same participant
+    /// list the coordinator shows.
     #[serde(default)]
     pub participants: Vec<CantonId>,
     /// The coordinator's run instance name (see `OnboardingInvitePayload`).

--- a/crates/common/src/types.rs
+++ b/crates/common/src/types.rs
@@ -261,6 +261,7 @@ pub enum WorkflowKind {
     Contracts,
     Dars,
     AddParty,
+    ChangeThreshold,
 }
 
 impl WorkflowKind {
@@ -271,6 +272,7 @@ impl WorkflowKind {
             Self::Contracts => "Contracts",
             Self::Dars => "Dars",
             Self::AddParty => "AddParty",
+            Self::ChangeThreshold => "ChangeThreshold",
         }
     }
 }
@@ -290,6 +292,7 @@ impl std::str::FromStr for WorkflowKind {
             "Contracts" => Ok(Self::Contracts),
             "Dars" => Ok(Self::Dars),
             "AddParty" => Ok(Self::AddParty),
+            "ChangeThreshold" => Ok(Self::ChangeThreshold),
             other => Err(anyhow::anyhow!("unknown workflow kind: {other}")),
         }
     }
@@ -303,6 +306,7 @@ impl From<InvitationType> for WorkflowKind {
             InvitationType::Contracts => Self::Contracts,
             InvitationType::Dars => Self::Dars,
             InvitationType::AddParty => Self::AddParty,
+            InvitationType::ChangeThreshold => Self::ChangeThreshold,
         }
     }
 }
@@ -428,6 +432,7 @@ pub enum InvitationType {
     Contracts,
     Dars,
     AddParty,
+    ChangeThreshold,
 }
 
 impl InvitationType {
@@ -439,6 +444,7 @@ impl InvitationType {
             Self::Contracts => "Contracts",
             Self::Dars => "Dars",
             Self::AddParty => "AddParty",
+            Self::ChangeThreshold => "ChangeThreshold",
         }
     }
 }
@@ -459,6 +465,7 @@ impl std::str::FromStr for InvitationType {
             "Contracts" => Ok(Self::Contracts),
             "Dars" => Ok(Self::Dars),
             "AddParty" => Ok(Self::AddParty),
+            "ChangeThreshold" => Ok(Self::ChangeThreshold),
             other => Err(anyhow::anyhow!("unknown invitation type: {other}")),
         }
     }

--- a/crates/decman-cli/src/api.rs
+++ b/crates/decman-cli/src/api.rs
@@ -833,6 +833,7 @@ impl DecmanClient {
             WorkflowKind::Contracts => "/contracts/cancel",
             WorkflowKind::Dars => "/dars/cancel",
             WorkflowKind::AddParty => "/add-party/cancel",
+            WorkflowKind::ChangeThreshold => "/change-threshold/cancel",
         };
         self.post(path, None)
     }

--- a/crates/decman/Cargo.toml
+++ b/crates/decman/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "decman"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/crates/decman/frontend/src/components/ChangeThresholdDialog.tsx
+++ b/crates/decman/frontend/src/components/ChangeThresholdDialog.tsx
@@ -1,0 +1,287 @@
+import { useState, useEffect, useCallback } from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  TextField,
+  Typography,
+  CircularProgress,
+  Alert,
+  Box,
+} from "@mui/material";
+import { API_BASE } from "../constants";
+import { authenticatedFetch } from "../api";
+import { useSnackbar } from "../contexts";
+import { fieldHelpAdornment } from "./FieldHelp";
+import type { ChangeThresholdRequest, ChangeThresholdStatusResponse } from "../types";
+
+interface ChangeThresholdDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onComplete: () => void;
+  partyId: string;
+  currentThreshold: number;
+  currentOwnerCount: number;
+}
+
+export const ChangeThresholdDialog = ({
+  open,
+  onClose,
+  onComplete,
+  partyId,
+  currentThreshold,
+  currentOwnerCount,
+}: ChangeThresholdDialogProps) => {
+  const [newThreshold, setNewThreshold] = useState(currentThreshold);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [status, setStatus] = useState<ChangeThresholdStatusResponse | null>(
+    null,
+  );
+  const { showSnackbar } = useSnackbar();
+
+  useEffect(() => {
+    // Seed with the current threshold each time the dialog opens with fresh
+    // party data; the user edits from there.
+    setNewThreshold(currentThreshold);
+  }, [currentThreshold, open]);
+
+  useEffect(() => {
+    if (!open) {
+      setError(null);
+      setStatus(null);
+      setLoading(false);
+    }
+  }, [open]);
+
+  const pollStatus = useCallback(async () => {
+    try {
+      const res = await authenticatedFetch(
+        `${API_BASE}/change-threshold/status`,
+      );
+      if (res.ok) {
+        const data: ChangeThresholdStatusResponse = await res.json();
+        if (data.status === "cancelled") {
+          showSnackbar("Change-threshold workflow cancelled");
+          onClose();
+          return;
+        }
+        setStatus(data);
+        if (data.status !== "inprogress") {
+          setLoading(false);
+          if (data.status === "completed") {
+            onComplete();
+          }
+        }
+      }
+    } catch {
+      // Ignore polling errors
+    }
+  }, [onComplete, onClose, showSnackbar]);
+
+  useEffect(() => {
+    let interval: number | undefined;
+
+    if (status?.status === "inprogress") {
+      pollStatus();
+      interval = window.setInterval(pollStatus, 2000);
+    }
+
+    return () => {
+      if (interval) clearInterval(interval);
+    };
+  }, [status?.status, pollStatus]);
+
+  const unchanged = newThreshold === currentThreshold;
+  const outOfRange = newThreshold < 1 || newThreshold > currentOwnerCount;
+
+  const handleSubmit = async () => {
+    setLoading(true);
+    setError(null);
+
+    const request: ChangeThresholdRequest = {
+      decentralized_party_id: partyId,
+      new_threshold: newThreshold,
+      previous_threshold: currentThreshold,
+    };
+
+    try {
+      const res = await authenticatedFetch(`${API_BASE}/change-threshold`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(request),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(
+          data.error || "Failed to start change-threshold workflow",
+        );
+      }
+
+      showSnackbar(
+        "Change-threshold workflow started — follow progress in the feed",
+      );
+      onClose();
+      // Jump to the feed so the user lands on the run they just started.
+      onComplete();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+      setLoading(false);
+    }
+  };
+
+  const [cancelling, setCancelling] = useState(false);
+  const handleCancelWorkflow = async () => {
+    setCancelling(true);
+    try {
+      const res = await authenticatedFetch(`${API_BASE}/change-threshold/cancel`, {
+        method: "POST",
+      });
+      if (res.ok) {
+        showSnackbar("Change-threshold workflow cancelled");
+        onClose();
+      } else {
+        const data = await res.json().catch(() => ({}));
+        setError(data.error || "Failed to cancel workflow");
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to cancel workflow");
+    } finally {
+      setCancelling(false);
+    }
+  };
+
+  const handleClose = () => {
+    if (!loading) {
+      onClose();
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Change Threshold</DialogTitle>
+      <DialogContent>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2, mt: 1 }}>
+          <Typography variant="body2" color="text.secondary">
+            Change the signing threshold of this decentralized party — how many
+            of its {currentOwnerCount} owners must sign topology changes.
+            Membership is unchanged. This action requires coordination with the
+            other participants.
+          </Typography>
+
+          <TextField
+            label="Decentralized Party ID"
+            value={partyId}
+            disabled
+            fullWidth
+            size="small"
+            slotProps={{
+              input: {
+                endAdornment: fieldHelpAdornment(
+                  "The decentralized party whose threshold is being changed. Pre-filled from the party you opened — not editable.",
+                  "Help for Decentralized Party ID",
+                ),
+              },
+            }}
+          />
+
+          <TextField
+            label="Current Threshold"
+            value={`${currentThreshold} of ${currentOwnerCount}`}
+            disabled
+            fullWidth
+            size="small"
+          />
+
+          <TextField
+            label="New Threshold"
+            type="number"
+            value={newThreshold}
+            onChange={(e) =>
+              setNewThreshold(Math.max(1, parseInt(e.target.value) || 1))
+            }
+            fullWidth
+            size="small"
+            disabled={loading}
+            error={unchanged || outOfRange}
+            slotProps={{
+              htmlInput: { min: 1, max: currentOwnerCount },
+              input: {
+                endAdornment: fieldHelpAdornment(
+                  "Number of owners that must sign topology changes for this party after the change. Must be between 1 and the number of owners, and different from the current threshold.",
+                  "Help for New Threshold",
+                ),
+              },
+            }}
+            helperText={
+              unchanged
+                ? "Pick a value different from the current threshold"
+                : outOfRange
+                  ? `Must be between 1 and ${currentOwnerCount}`
+                  : `New threshold (max: ${currentOwnerCount})`
+            }
+          />
+
+          {error && (
+            <Alert severity="error" onClose={() => setError(null)}>
+              {error}
+            </Alert>
+          )}
+
+          {status?.status === "inprogress" && (
+            <Alert severity="info" icon={<CircularProgress size={20} />}>
+              Change-threshold workflow in progress... This may take a few
+              minutes.
+            </Alert>
+          )}
+
+          {status?.status === "completed" && (
+            <Alert severity="success">
+              Party threshold has been successfully changed.
+            </Alert>
+          )}
+
+          {status?.status === "failed" && (
+            <Alert severity="error">
+              Change-threshold workflow failed: {status.error || "Unknown error"}
+            </Alert>
+          )}
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose} disabled={loading}>
+          {status?.status === "completed" ||
+          status?.status === "failed" ||
+          status?.status === "inprogress"
+            ? "Close"
+            : "Cancel"}
+        </Button>
+        {status?.status === "inprogress" && (
+          <Button
+            onClick={handleCancelWorkflow}
+            variant="outlined"
+            color="error"
+            disabled={cancelling}
+            startIcon={cancelling ? <CircularProgress size={16} /> : undefined}
+          >
+            {cancelling ? "Cancelling…" : "Cancel Workflow"}
+          </Button>
+        )}
+        {!status?.status ||
+        status.status === "idle" ||
+        status.status === "failed" ? (
+          <Button
+            onClick={handleSubmit}
+            variant="contained"
+            disabled={loading || unchanged || outOfRange}
+          >
+            {loading ? <CircularProgress size={20} /> : "Change Threshold"}
+          </Button>
+        ) : null}
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/crates/decman/frontend/src/components/OnboardingDialog.tsx
+++ b/crates/decman/frontend/src/components/OnboardingDialog.tsx
@@ -66,7 +66,23 @@ export const OnboardingDialog = ({
     new Set(),
   );
   const [loadingPeers, setLoadingPeers] = useState(false);
+  // Initial signing threshold. Defaults (visibly) to the same majority
+  // algorithm the server would use — `ceil(owners / 2)` — recomputed as the
+  // selected-peer set changes, until the operator edits the field.
+  const [threshold, setThreshold] = useState(1);
+  const [thresholdTouched, setThresholdTouched] = useState(false);
   const { showSnackbar } = useSnackbar();
+
+  // Owners = the selected peers plus this node (always an owner of a party it
+  // creates). The default threshold is the majority of that owner count.
+  const ownerCount = selectedPeerIds.size + 1;
+  const defaultThreshold = Math.max(1, Math.ceil(ownerCount / 2));
+
+  // Keep the field on the computed default until the operator touches it, so
+  // it always shows a sensible value as peers are checked/unchecked.
+  useEffect(() => {
+    if (!thresholdTouched) setThreshold(defaultThreshold);
+  }, [defaultThreshold, thresholdTouched]);
 
   // Fetch peers when dialog opens
   useEffect(() => {
@@ -114,6 +130,7 @@ export const OnboardingDialog = ({
       setLoading(false);
       setPartyIdPrefix("");
       setSelectedPeerIds(new Set());
+      setThresholdTouched(false);
     }
   }, [open]);
 
@@ -188,6 +205,11 @@ export const OnboardingDialog = ({
       return;
     }
 
+    if (threshold < 1 || threshold > ownerCount) {
+      setError(`Threshold must be between 1 and ${ownerCount}`);
+      return;
+    }
+
     setLoading(true);
     setError(null);
     setMeshErrors(null);
@@ -199,6 +221,7 @@ export const OnboardingDialog = ({
         body: JSON.stringify({
           party_id_prefix: partyIdPrefix.trim(),
           peer_ids: Array.from(selectedPeerIds),
+          threshold,
         }),
       });
 
@@ -366,6 +389,39 @@ export const OnboardingDialog = ({
             )}
           </Box>
 
+          <TextField
+            label="Threshold"
+            type="number"
+            value={threshold}
+            onChange={(e) => {
+              setThresholdTouched(true);
+              setThreshold(Math.max(1, parseInt(e.target.value) || 1));
+            }}
+            fullWidth
+            disabled={loading || status?.status === "inprogress"}
+            error={threshold < 1 || threshold > ownerCount}
+            slotProps={{
+              htmlInput: { min: 1, max: ownerCount },
+              input: {
+                endAdornment: fieldHelpAdornment(
+                  "The decentralized-namespace threshold: how many of the party's owners must sign topology changes (it's also set as the party-to-participant confirmation threshold). Owners are you plus the peers you invite. Defaults to a majority; edit to override. Separate from the governance threshold.",
+                  "Help for Threshold",
+                ),
+              },
+            }}
+            helperText={
+              threshold > ownerCount
+                ? `Must be at most ${ownerCount} (you + ${selectedPeerIds.size} peer${
+                    selectedPeerIds.size === 1 ? "" : "s"
+                  })`
+                : `Of ${ownerCount} owner${ownerCount === 1 ? "" : "s"} (you + ${
+                    selectedPeerIds.size
+                  } peer${
+                    selectedPeerIds.size === 1 ? "" : "s"
+                  }). Default: majority (${defaultThreshold}).`
+            }
+          />
+
           {error && !meshErrors && (
             <Alert severity="error" onClose={() => setError(null)}>
               {error}
@@ -488,7 +544,9 @@ export const OnboardingDialog = ({
               loading ||
               !partyIdPrefix.trim() ||
               !!partyPrefixError(partyIdPrefix.trim()) ||
-              selectedPeerIds.size === 0
+              selectedPeerIds.size === 0 ||
+              threshold < 1 ||
+              threshold > ownerCount
             }
           >
             {loading ? <CircularProgress size={20} /> : "Start Onboarding"}

--- a/crates/decman/frontend/src/components/PartyDetail.tsx
+++ b/crates/decman/frontend/src/components/PartyDetail.tsx
@@ -22,6 +22,7 @@ import {
 } from "@mui/material";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import EditIcon from "@mui/icons-material/Edit";
+import TuneIcon from "@mui/icons-material/Tune";
 import PersonAddIcon from "@mui/icons-material/PersonAdd";
 import PersonRemoveIcon from "@mui/icons-material/PersonRemove";
 import UploadFileIcon from "@mui/icons-material/UploadFile";
@@ -30,6 +31,7 @@ import RefreshIcon from "@mui/icons-material/Refresh";
 import { CopyableText } from "./CopyableText";
 import { TextHelp } from "./FieldHelp";
 import { AddPartyDialog } from "./AddPartyDialog";
+import { ChangeThresholdDialog } from "./ChangeThresholdDialog";
 import { KickDialog } from "./KickDialog";
 import { ContractsDialog } from "./ContractsDialog";
 import { PartyConfigDialog } from "./PartyConfigDialog";
@@ -186,6 +188,8 @@ export const PartyDetail = ({
 }: PartyDetailProps) => {
   const [kickDialogOpen, setKickDialogOpen] = useState(false);
   const [addDialogOpen, setAddDialogOpen] = useState(false);
+  const [changeThresholdDialogOpen, setChangeThresholdDialogOpen] =
+    useState(false);
   const [contractsDialogOpen, setContractsDialogOpen] = useState(false);
   const [configDialogOpen, setConfigDialogOpen] = useState(false);
   const [selectedParticipant, setSelectedParticipant] = useState("");
@@ -364,6 +368,17 @@ export const PartyDetail = ({
             {governanceType === "core_self"
               ? "New Proposal"
               : "Deploy Contracts"}
+          </Button>
+        )}
+        {isOwner && (
+          <Button
+            variant="outlined"
+            size="small"
+            startIcon={<TuneIcon />}
+            onClick={() => setChangeThresholdDialogOpen(true)}
+            disabled={!ADMIN_ACCESS}
+          >
+            Change Threshold
           </Button>
         )}
         {isOwner && rulesContract && (
@@ -725,6 +740,18 @@ export const PartyDetail = ({
         }}
         partyId={party.party_id}
         participantUids={party.participants.map((p) => p.participant_uid)}
+        currentThreshold={party.threshold}
+        currentOwnerCount={party.owners.length}
+      />
+
+      <ChangeThresholdDialog
+        open={changeThresholdDialogOpen}
+        onClose={() => setChangeThresholdDialogOpen(false)}
+        onComplete={() => {
+          onRefresh();
+          onNavigateToNotifications();
+        }}
+        partyId={party.party_id}
         currentThreshold={party.threshold}
         currentOwnerCount={party.owners.length}
       />

--- a/crates/decman/frontend/src/types.ts
+++ b/crates/decman/frontend/src/types.ts
@@ -42,3 +42,4 @@ export type OnboardingStatusResponse = WorkflowStatusResponse;
 export type ContractsStatusResponse = WorkflowStatusResponse;
 export type DarsStatusResponse = WorkflowStatusResponse;
 export type AddPartyStatusResponse = WorkflowStatusResponse;
+export type ChangeThresholdStatusResponse = WorkflowStatusResponse;

--- a/crates/decman/src/bin/gen_types.rs
+++ b/crates/decman/src/bin/gen_types.rs
@@ -59,6 +59,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         CancelConfirmationRequest,
         ChainAuditEntry,
         ChainAuditResponse,
+        ChangeThresholdInvitePayload,
+        ChangeThresholdRequest,
         Claim,
         ConnectionStatus,
         ContractDefinition,

--- a/crates/decman/src/noise/client.rs
+++ b/crates/decman/src/noise/client.rs
@@ -237,6 +237,19 @@ impl NoiseClient {
         .await
     }
 
+    /// Send the signed change-threshold DNS + P2P pair to the coordinator.
+    pub async fn send_change_threshold_signatures(
+        &self,
+        signatures_data: Vec<u8>,
+    ) -> Result<(), NoiseError> {
+        self.send_and_verify_ack(
+            MessageType::ChangeThresholdSignatures,
+            signatures_data,
+            "Sending change-threshold signatures to coordinator",
+        )
+        .await
+    }
+
     /// Upload the new member's `keys||participant_id` payload to the
     /// coordinator of an add-party run.
     pub async fn upload_add_party_keys(&self, keys_data: Vec<u8>) -> Result<(), NoiseError> {

--- a/crates/decman/src/noise/mod.rs
+++ b/crates/decman/src/noise/mod.rs
@@ -75,6 +75,9 @@ pub enum MessageType {
     /// Command: every peer signs the onboarding-flag clearing proposal
     /// (no-op when the payload carries the empty skip marker).
     SignClearOnboarding = 0x0024,
+    /// Command: every party member signs the change-threshold DNS + P2P
+    /// proposals.
+    SignChangeThreshold = 0x0025,
 
     // Invites (0x0010 - 0x001F)
     InviteOnboarding = 0x0010,
@@ -94,6 +97,9 @@ pub enum MessageType {
     /// Invite to participate in adding a new member to a decentralized
     /// party. Payload is a JSON `AddPartyInvitePayload`.
     InviteAddParty = 0x0017,
+    /// Invite to participate in changing a decentralized party's threshold.
+    /// Payload is a JSON `ChangeThresholdInvitePayload`.
+    InviteChangeThreshold = 0x0018,
 
     // Responses (0x0100 - 0x01FF)
     Ack = 0x0101,
@@ -125,6 +131,8 @@ pub enum MessageType {
     /// transaction, so the new member authors it and the coordinator only
     /// runs the signing round on it.
     AddPartyClearProposal = 0x0209,
+    /// Peer → coordinator: signed change-threshold DNS + P2P pair.
+    ChangeThresholdSignatures = 0x020A,
 
     // Chunked Transfer (0x0300 - 0x03FF)
     /// Command with chunked payload - payload contains: [command_type (2 bytes)] [total_size (4 bytes)] [chunk_count (4 bytes)]
@@ -194,6 +202,8 @@ impl TryFrom<u16> for MessageType {
             0x0022 => Ok(Self::ImportAcs),
             0x0023 => Ok(Self::ClearOnboardingFlag),
             0x0024 => Ok(Self::SignClearOnboarding),
+            0x0025 => Ok(Self::SignChangeThreshold),
+            0x0018 => Ok(Self::InviteChangeThreshold),
             0x0101 => Ok(Self::Ack),
             0x0102 => Ok(Self::Data),
             0x0103 => Ok(Self::Error),
@@ -214,6 +224,7 @@ impl TryFrom<u16> for MessageType {
             0x0207 => Ok(Self::AddPartySignatures),
             0x0208 => Ok(Self::AddPartyClearSignatures),
             0x0209 => Ok(Self::AddPartyClearProposal),
+            0x020A => Ok(Self::ChangeThresholdSignatures),
             0x0300 => Ok(Self::ChunkedCommand),
             0x0301 => Ok(Self::GetChunk),
             0x0302 => Ok(Self::Chunk),
@@ -1071,6 +1082,18 @@ mod tests {
             MessageType::AddPartySignatures,
             MessageType::AddPartyClearSignatures,
             MessageType::AddPartyClearProposal,
+        ] {
+            assert_eq!(MessageType::try_from(mt.to_u16())?, mt);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn change_threshold_message_types_round_trip() -> Result {
+        for mt in [
+            MessageType::SignChangeThreshold,
+            MessageType::InviteChangeThreshold,
+            MessageType::ChangeThresholdSignatures,
         ] {
             assert_eq!(MessageType::try_from(mt.to_u16())?, mt);
         }

--- a/crates/decman/src/noise/server.rs
+++ b/crates/decman/src/noise/server.rs
@@ -15,8 +15,9 @@ use crate::{
         peer_status::{LastSeen, bump},
     },
     workflow::{
-        WorkflowState, add_party::AddPartyStep, contracts::ContractsStep, dars::DarsStep,
-        kick::KickStep, onboarding::OnboardingStep, state::WorkflowStep,
+        WorkflowState, add_party::AddPartyStep, change_threshold::ChangeThresholdStep,
+        contracts::ContractsStep, dars::DarsStep, kick::KickStep, onboarding::OnboardingStep,
+        state::WorkflowStep,
     },
 };
 
@@ -75,6 +76,7 @@ pub enum ActiveWorkflow {
     Contracts(Arc<NoiseServer<ContractsStep>>),
     Dars(Arc<NoiseServer<DarsStep>>),
     AddParty(Arc<NoiseServer<AddPartyStep>>),
+    ChangeThreshold(Arc<NoiseServer<ChangeThresholdStep>>),
 }
 
 impl ActiveWorkflow {
@@ -90,6 +92,7 @@ impl ActiveWorkflow {
             Self::Contracts(s) => s.handle_command(peer_id, message).await,
             Self::Dars(s) => s.handle_command(peer_id, message).await,
             Self::AddParty(s) => s.handle_command(peer_id, message).await,
+            Self::ChangeThreshold(s) => s.handle_command(peer_id, message).await,
         }
     }
 }
@@ -291,6 +294,10 @@ impl<S: WorkflowStep + 'static> NoiseServer<S> {
             }
             MessageType::AddPartyClearProposal => {
                 self.handle_peer_data(peer_id, message.payload, "add-party clearing proposal")
+                    .await
+            }
+            MessageType::ChangeThresholdSignatures => {
+                self.handle_peer_data(peer_id, message.payload, "change-threshold signatures")
                     .await
             }
             MessageType::StatusUpdate => self.handle_status_update(peer_id, message.payload).await,
@@ -540,6 +547,7 @@ mod tests {
         assert!(command_carries_payload(MessageType::ImportAcs));
         assert!(command_carries_payload(MessageType::ClearOnboardingFlag));
         assert!(command_carries_payload(MessageType::SignClearOnboarding));
+        assert!(command_carries_payload(MessageType::SignChangeThreshold));
     }
 
     fn decline(kind: WorkflowKind, workflow_instance: Option<&str>) -> DeclineInvitationPayload {

--- a/crates/decman/src/server/handlers/invitations.rs
+++ b/crates/decman/src/server/handlers/invitations.rs
@@ -17,7 +17,8 @@ use crate::{
         },
     },
     workflow::{
-        AddPartyStep, ContractsStep, DarsStep, KickStep, OnboardingStep, state::WorkflowStep,
+        AddPartyStep, ChangeThresholdStep, ContractsStep, DarsStep, KickStep, OnboardingStep,
+        state::WorkflowStep,
     },
 };
 
@@ -63,6 +64,7 @@ fn step_total_for(kind: WorkflowKind) -> i64 {
         WorkflowKind::Contracts => ContractsStep::step_total(),
         WorkflowKind::Dars => DarsStep::step_total(),
         WorkflowKind::AddParty => AddPartyStep::step_total(),
+        WorkflowKind::ChangeThreshold => ChangeThresholdStep::step_total(),
     }
 }
 

--- a/crates/decman/src/server/handlers/mod.rs
+++ b/crates/decman/src/server/handlers/mod.rs
@@ -30,8 +30,9 @@ pub use parties::{
 };
 pub use party_config::{discover_member_party, get_party_config, save_party_config};
 pub use workflows::{
-    cancel_add_party, cancel_contracts, cancel_dars, cancel_kick, cancel_onboarding,
-    cancel_workflow_instance, dismiss_workflow, get_add_party_status, get_contracts_status,
-    get_dars_status, get_kick_status, get_onboarding_status, list_workflows, retry_workflow,
-    start_add_party, start_contracts, start_dars, start_kick, start_onboarding, upload_dars_local,
+    cancel_add_party, cancel_change_threshold, cancel_contracts, cancel_dars, cancel_kick,
+    cancel_onboarding, cancel_workflow_instance, dismiss_workflow, get_add_party_status,
+    get_change_threshold_status, get_contracts_status, get_dars_status, get_kick_status,
+    get_onboarding_status, list_workflows, retry_workflow, start_add_party, start_change_threshold,
+    start_contracts, start_dars, start_kick, start_onboarding, upload_dars_local,
 };

--- a/crates/decman/src/server/handlers/workflows.rs
+++ b/crates/decman/src/server/handlers/workflows.rs
@@ -28,18 +28,20 @@ use crate::{
         middleware::require_admin,
         respawn_coordinator,
         types::{
-            AddPartyInvitePayload, AddPartyRequest, ContractsInvitePayload, ContractsRequest,
-            DarsInvitePayload, DarsRequest, ErrorResponse, KickInvitePayload, KickRequest,
-            KickResponse, KickStatus, MessageResponse, MissingEdgeKind, MissingPeerEdge,
-            OnboardingInvitePayload, OnboardingMeshErrorResponse, OnboardingRequest,
-            OnboardingResponse, OnboardingStatus, SuccessResponse, WorkflowGuard, WorkflowInstance,
-            WorkflowKind, WorkflowProgress, WorkflowResponse, WorkflowRole, WorkflowRun,
-            WorkflowRunsResponse, WorkflowStatusResponse,
+            AddPartyInvitePayload, AddPartyRequest, ChangeThresholdInvitePayload,
+            ChangeThresholdRequest, ContractsInvitePayload, ContractsRequest, DarsInvitePayload,
+            DarsRequest, ErrorResponse, KickInvitePayload, KickRequest, KickResponse, KickStatus,
+            MessageResponse, MissingEdgeKind, MissingPeerEdge, OnboardingInvitePayload,
+            OnboardingMeshErrorResponse, OnboardingRequest, OnboardingResponse, OnboardingStatus,
+            SuccessResponse, WorkflowGuard, WorkflowInstance, WorkflowKind, WorkflowProgress,
+            WorkflowResponse, WorkflowRole, WorkflowRun, WorkflowRunsResponse,
+            WorkflowStatusResponse,
         },
     },
     utils,
     workflow::{
-        self, AddPartyStep, ContractsStep, DarsStep, KickStep, OnboardingStep, state::WorkflowStep,
+        self, AddPartyStep, ChangeThresholdStep, ContractsStep, DarsStep, KickStep, OnboardingStep,
+        state::WorkflowStep,
     },
 };
 
@@ -147,6 +149,7 @@ where
         WorkflowKind::Contracts => "contracts",
         WorkflowKind::Dars => "DARs",
         WorkflowKind::AddParty => "add-party",
+        WorkflowKind::ChangeThreshold => "change-threshold",
     };
 
     if !data.workflows.insert(instance.clone()) {
@@ -500,6 +503,7 @@ pub async fn start_kick(
             None, // No contracts config
             None, // No dars config
             None, // No add-party config
+            None, // No change-threshold config
             None, // No auth registry for kick
             last_seen,
             instance_for_coord,
@@ -971,6 +975,7 @@ pub async fn start_add_party(
             None, // No contracts config
             None, // No dars config
             Some(add_party_config),
+            None, // No change-threshold config
             workflow_auth,
             last_seen,
             instance_for_coord,
@@ -1127,6 +1132,376 @@ async fn send_add_party_invites(
 }
 
 // ============================================================================
+// Change-Threshold Workflow
+// ============================================================================
+
+/// Start a change-threshold workflow to change the signing threshold of an
+/// existing decentralized party (namespace + P2P), keeping its membership.
+#[utoipa::path(
+    tag = "Workflows",
+    request_body = ChangeThresholdRequest,
+    responses(
+        (status = 202, description = "Change-threshold workflow started", body = WorkflowResponse),
+        (status = 400, description = "Bad request", body = ErrorResponse),
+        (status = 409, description = "Workflow already in progress for this party", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    )
+)]
+#[post("/change-threshold")]
+pub async fn start_change_threshold(
+    http_req: HttpRequest,
+    data: web::Data<AppState>,
+    body: web::Json<ChangeThresholdRequest>,
+) -> impl Responder {
+    if let Err(resp) = require_admin(&http_req, data.admin_role.as_deref()) {
+        return resp;
+    }
+
+    tracing::info!(
+        "Change-threshold request received: party={}, threshold={}->{}",
+        body.decentralized_party_id,
+        body.previous_threshold,
+        body.new_threshold
+    );
+
+    let decentralized_party_id = body.decentralized_party_id.clone();
+
+    // Scope to the party's cached membership (same rationale as start_kick /
+    // start_add_party — the party can be a strict subset of the mesh).
+    let party_member_ids: HashSet<CantonId> = match data
+        .db
+        .get_dec_party_participants(&decentralized_party_id)
+        .await
+    {
+        Ok(rows) => rows
+            .iter()
+            .filter_map(|r| CantonId::parse(&r.participant_uid).ok())
+            .collect(),
+        Err(e) => {
+            tracing::error!("Failed to load dec party participants for change-threshold: {e}");
+            return HttpResponse::InternalServerError().json(ErrorResponse {
+                error: "Failed to load decentralized party members".to_string(),
+            });
+        }
+    };
+
+    if party_member_ids.is_empty() {
+        return HttpResponse::Conflict().json(ErrorResponse {
+            error: format!(
+                "No cached membership for {decentralized_party_id}. Try refreshing \
+                 /decentralized-parties first."
+            ),
+        });
+    }
+    if !party_member_ids.contains(data.config.participant_id()) {
+        return HttpResponse::BadRequest().json(ErrorResponse {
+            error: format!(
+                "This node is not a member of {decentralized_party_id}; only an existing \
+                 member can coordinate a threshold change"
+            ),
+        });
+    }
+    // Need at least one other member to reach a signing quorum — a solo-owner
+    // party has a fixed threshold of 1 and nothing to change.
+    if party_member_ids.len() < 2 {
+        return HttpResponse::BadRequest().json(ErrorResponse {
+            error: format!(
+                "Cannot change threshold: {decentralized_party_id} has only {n} member(s)",
+                n = party_member_ids.len()
+            ),
+        });
+    }
+
+    // Bound the new threshold by the member count. The deeper validation
+    // against the live DNS owner set (and the "already current" check) happens
+    // in ExportState.
+    let member_count = party_member_ids.len() as i32;
+    if body.new_threshold < 1 || body.new_threshold > member_count {
+        return HttpResponse::BadRequest().json(ErrorResponse {
+            error: format!(
+                "new_threshold must be between 1 and {member_count} (party member count); got {got}",
+                got = body.new_threshold,
+            ),
+        });
+    }
+
+    // Invitees: every member except self — they all sign.
+    let invitees: Vec<CantonId> = match data.db.get_all_peers().await {
+        Ok(peers) => peers
+            .into_iter()
+            .map(|p| p.participant_id)
+            .filter(|p| party_member_ids.contains(p) && p != data.config.participant_id())
+            .collect(),
+        Err(e) => {
+            tracing::error!("Failed to load peers for change-threshold: {e}");
+            return HttpResponse::InternalServerError().json(ErrorResponse {
+                error: "Failed to load peers".to_string(),
+            });
+        }
+    };
+
+    let timestamp = now_secs();
+    let instance_name = format!(
+        "{}-change-threshold-{timestamp}",
+        decentralized_party_id.prefix
+    );
+
+    let instance = WorkflowInstance::new(
+        instance_name.clone(),
+        WorkflowKind::ChangeThreshold,
+        WorkflowRole::Coordinator,
+    );
+    let change_state = &instance.http;
+
+    let change_config = workflow::ChangeThresholdConfig::new(
+        decentralized_party_id.clone(),
+        body.new_threshold,
+        body.previous_threshold,
+        instance_name.clone(),
+    );
+
+    // Refuse a second workflow targeting the SAME dec party (topology mutations
+    // must not interleave — see start_kick).
+    if let Some((run, kind)) =
+        find_inprogress_run_for_party(&data.db, &decentralized_party_id).await
+    {
+        return HttpResponse::Conflict().json(ErrorResponse {
+            error: format!(
+                "Party {decentralized_party_id} already has a {kind} workflow in flight \
+                 (run {run}); wait for it to finish or cancel it first"
+            ),
+        });
+    }
+
+    // Refuse to invite any peer that can't speak the concurrent-workflows wire
+    // format — NO invites are sent if even one invitee fails the version gate.
+    let incompatible = preflight_incompatible_peers(&data.config, &data.db, &invitees).await;
+    if !incompatible.is_empty() {
+        return HttpResponse::Conflict().json(ErrorResponse {
+            error: format_incompatible_peers(&incompatible),
+        });
+    }
+
+    if let Err(resp) = register_and_persist(
+        &data,
+        &instance,
+        ChangeThresholdStep::WaitingForPeers,
+        &change_config,
+        &invitees,
+        Some(decentralized_party_id.clone()),
+    )
+    .await
+    {
+        return resp;
+    }
+
+    let invitees_for_invites = invitees.clone();
+    *change_state.invited_peers.write().await = invitees;
+
+    let config = data.config.clone();
+    let db = data.db.clone();
+    let change_state_clone = instance.http.clone();
+    let instance_for_coord = instance.clone();
+    let workflows = data.workflows.clone();
+    let last_seen = data.last_seen.clone();
+    let instance_for_task = instance_name.clone();
+
+    // abort_handle/status/error are flipped under simultaneously-held locks —
+    // see start_dars for the cancel-race rationale.
+    let mut abort_guard = change_state.abort_handle.lock().await;
+    let mut status_guard = change_state.status.write().await;
+    let mut error_guard = change_state.error.write().await;
+
+    let join_handle = tokio::spawn(async move {
+        let _workflow_guard = WorkflowGuard::new(workflows, instance_for_task.clone());
+
+        let invite_result =
+            send_change_threshold_invites(&config, &db, &change_config, &invitees_for_invites)
+                .await;
+        if let Err(e) = invite_result {
+            tracing::error!("Failed to send change-threshold invites: {e}");
+            let msg = format!("Failed to send invites: {e}");
+            {
+                let mut status = change_state_clone.status.write().await;
+                let mut error = change_state_clone.error.write().await;
+                *status = WorkflowProgress::Failed;
+                *error = Some(msg.clone());
+            }
+            mark_run_failed(&db, &instance_for_task, &msg).await;
+            return;
+        }
+
+        // Give peers time to start their peer workflows
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        let result = workflow::start_coordinator(
+            config,
+            db.clone(),
+            workflow::WorkflowType::ChangeThreshold,
+            None, // No onboarding config
+            None, // No kick config
+            None, // No contracts config
+            None, // No dars config
+            None, // No add-party config
+            Some(change_config),
+            None, // No auth registry for change-threshold
+            last_seen,
+            instance_for_coord,
+        )
+        .await;
+
+        match result {
+            Ok(_) => {
+                {
+                    let mut status = change_state_clone.status.write().await;
+                    *status = WorkflowProgress::Completed;
+                }
+                tracing::info!("Change-threshold workflow completed successfully");
+                mark_run_completed(&db, &instance_for_task).await;
+            }
+            Err(e) => {
+                let msg = format!("{e}");
+                {
+                    let mut status = change_state_clone.status.write().await;
+                    let mut error = change_state_clone.error.write().await;
+                    *status = WorkflowProgress::Failed;
+                    *error = Some(msg.clone());
+                }
+                tracing::error!("Change-threshold workflow failed: {e}");
+                mark_run_failed(&db, &instance_for_task, &msg).await;
+            }
+        }
+    });
+    *abort_guard = Some(join_handle.abort_handle());
+    *status_guard = WorkflowProgress::InProgress;
+    *error_guard = None;
+    drop(error_guard);
+    drop(status_guard);
+    drop(abort_guard);
+
+    HttpResponse::Accepted().json(WorkflowResponse {
+        status: WorkflowProgress::InProgress,
+        message: "Change-threshold workflow started".to_string(),
+        instance_name,
+    })
+}
+
+/// Get the current status of the change-threshold workflow
+#[utoipa::path(
+    tag = "Workflows",
+    responses(
+        (status = 200, description = "Change-threshold workflow status", body = WorkflowStatusResponse)
+    )
+)]
+#[get("/change-threshold/status")]
+pub async fn get_change_threshold_status(data: web::Data<AppState>) -> impl Responder {
+    HttpResponse::Ok().json(kind_status(&data, WorkflowKind::ChangeThreshold).await)
+}
+
+#[utoipa::path(
+    tag = "Workflows",
+    responses(
+        (status = 200, description = "Workflow cancelled", body = MessageResponse),
+        (status = 409, description = "No workflow in progress", body = ErrorResponse)
+    )
+)]
+#[post("/change-threshold/cancel")]
+pub async fn cancel_change_threshold(
+    http_req: HttpRequest,
+    data: web::Data<AppState>,
+) -> impl Responder {
+    if let Err(resp) = require_admin(&http_req, data.admin_role.as_deref()) {
+        return resp;
+    }
+    cancel_workflow_state(&data, "Change-threshold", WorkflowKind::ChangeThreshold).await
+}
+
+/// Send change-threshold invites over Noise to every existing member.
+async fn send_change_threshold_invites(
+    config: &NodeConfig,
+    db: &SqlitePool,
+    change_config: &workflow::ChangeThresholdConfig,
+    invitees: &[CantonId],
+) -> Result {
+    let network_config = NetworkConfig::from_peers(db.get_all_peers().await?);
+    let keypair = NoiseKeypair::from_file(&config.key_file_path()).await?;
+
+    let current_participant_id = config.participant_id();
+    let invitee_set: HashSet<&CantonId> = invitees.iter().collect();
+    // The card shows the full member set: invitees + this node.
+    let mut participants = invitees.to_vec();
+    participants.push(current_participant_id.clone());
+    let payload = ChangeThresholdInvitePayload {
+        dec_party_id: change_config.decentralized_party_id.clone(),
+        new_threshold: change_config.new_threshold,
+        previous_threshold: change_config.previous_threshold,
+        participants,
+        workflow_instance: Some(change_config.instance_name.clone()),
+    };
+    let payload_bytes =
+        serde_json::to_vec(&payload).context("encode ChangeThresholdInvitePayload")?;
+    let invite_message = Message::new(MessageType::InviteChangeThreshold, payload_bytes);
+
+    for peer in &network_config.peers {
+        if !invitee_set.contains(&peer.participant_id)
+            || peer.participant_id == *current_participant_id
+        {
+            continue;
+        }
+
+        if peer.public_key.is_empty() {
+            tracing::warn!(
+                "Skipping change-threshold invite to {} - no public key configured",
+                peer.participant_id
+            );
+            continue;
+        }
+        let peer_pub_key = match parse_public_key(&peer.public_key) {
+            Ok(pk) => pk,
+            Err(e) => {
+                tracing::warn!(
+                    "Skipping change-threshold invite to {} - invalid public key: {e}",
+                    peer.participant_id
+                );
+                continue;
+            }
+        };
+
+        let psk = keypair.derive_psk(&peer_pub_key);
+        let identity = config.participant_id().to_string();
+
+        tracing::info!(
+            "Sending change-threshold invite to {} at {}:{}",
+            peer.participant_id,
+            peer.address,
+            peer.port
+        );
+
+        match send_noise_message(
+            &peer.address,
+            peer.port,
+            &psk,
+            identity.as_bytes(),
+            &invite_message,
+        )
+        .await
+        {
+            Ok(response) => {
+                interpret_invite_reply(&peer.participant_id, "change-threshold", &response)?;
+            }
+            Err(e) => {
+                tracing::error!(
+                    "Failed to send change-threshold invite to {}: {e}",
+                    peer.participant_id
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+// ============================================================================
 // Onboarding Workflow
 // ============================================================================
 
@@ -1219,8 +1594,26 @@ pub async fn start_onboarding(
         WorkflowRole::Coordinator,
     );
     let onboarding_state = &instance.http;
-    let onboarding_config =
-        workflow::OnboardingConfig::new(party_id_prefix.clone(), instance_name.clone());
+
+    // If the operator set an explicit initial threshold, bound it by the owner
+    // count (invited peers + this coordinator). Omitted => the coordinator uses
+    // the default majority algorithm once the owner set is resolved.
+    let owner_count = peer_ids.len() as i32 + 1;
+    if let Some(t) = body.threshold
+        && !(1..=owner_count).contains(&t)
+    {
+        return HttpResponse::BadRequest().json(ErrorResponse {
+            error: format!(
+                "threshold must be between 1 and {owner_count} (invited peers + this node); got {t}"
+            ),
+        });
+    }
+
+    let onboarding_config = workflow::OnboardingConfig::new(
+        party_id_prefix.clone(),
+        instance_name.clone(),
+        body.threshold,
+    );
 
     // Refuse onboarding when a party with this prefix already exists. The
     // human-readable prefix is the only piece of the party id the operator
@@ -1296,6 +1689,7 @@ pub async fn start_onboarding(
             &db,
             &peer_ids,
             &party_id_prefix,
+            onboarding_config.threshold,
             &instance_for_task,
         )
         .await;
@@ -1324,6 +1718,7 @@ pub async fn start_onboarding(
             None, // No contracts config
             None, // No dars config
             None, // No add-party config
+            None, // No change-threshold config
             None, // No auth registry for onboarding
             last_seen,
             instance_for_coord,
@@ -1474,14 +1869,22 @@ async fn send_onboarding_invites(
     db: &SqlitePool,
     peer_ids: &[CantonId],
     party_id_prefix: &str,
+    threshold: Option<i32>,
     instance_name: &str,
 ) -> Result {
     let network_config = NetworkConfig::from_peers(db.get_all_peers().await?);
     let keypair = NoiseKeypair::from_file(&config.key_file_path()).await?;
 
+    // Show the threshold the coordinator will actually use: the operator's
+    // choice, or the same majority default it falls back to (owners = invited
+    // peers + this coordinator).
+    let owners = peer_ids.len() + 1;
+    let effective_threshold = threshold.unwrap_or_else(|| owners.div_ceil(2).max(1) as i32);
+
     let payload = OnboardingInvitePayload {
         prefix: party_id_prefix.to_string(),
         participants: peer_ids.to_vec(),
+        threshold: Some(effective_threshold),
         workflow_instance: Some(instance_name.to_string()),
     };
     let payload_bytes = serde_json::to_vec(&payload)?;
@@ -1856,6 +2259,7 @@ pub async fn start_contracts(
             Some(contracts_config.clone()),
             None, // No dars config
             None, // No add-party config
+            None, // No change-threshold config
             workflow_auth,
             last_seen,
             instance_for_coord,
@@ -2123,6 +2527,7 @@ pub async fn start_dars(
             None, // No contracts config
             Some(dars_config),
             None, // No add-party config
+            None, // No change-threshold config
             None, // No auth
             last_seen,
             instance_for_coord,
@@ -2543,6 +2948,9 @@ fn enrich_from_config_json(run: &mut WorkflowRun) {
         new_threshold: Option<i32>,
         #[serde(default)]
         previous_threshold: Option<i32>,
+        // Onboarding config only: the initial threshold (no previous).
+        #[serde(default)]
+        threshold: Option<i32>,
         // Kick configs only.
         #[serde(default)]
         participant_id: Option<CantonId>,
@@ -2578,7 +2986,9 @@ fn enrich_from_config_json(run: &mut WorkflowRun) {
         if !shape.participants.is_empty() {
             run.participants = shape.participants;
         }
-        run.new_threshold = shape.new_threshold;
+        // Onboarding stores the initial threshold under `threshold`; kick /
+        // add-party use `new_threshold`. Either populates the card's value.
+        run.new_threshold = shape.new_threshold.or(shape.threshold);
         // Only surface a previous threshold when an older client actually
         // sent one (it defaults to 0); 0 means "unknown", render as new-only.
         run.previous_threshold = shape.previous_threshold.filter(|t| *t > 0);

--- a/crates/decman/src/server/mod.rs
+++ b/crates/decman/src/server/mod.rs
@@ -167,6 +167,7 @@ enum InvitationMeta {
     Kick(KickInvitePayload),
     Contracts(ContractsInvitePayload),
     AddParty(AddPartyInvitePayload),
+    ChangeThreshold(ChangeThresholdInvitePayload),
 }
 
 /// On boot, re-spawn any InProgress workflow runs that were interrupted by the
@@ -256,6 +257,7 @@ pub(crate) async fn respawn_coordinator(
     let mut contracts_config = None;
     let mut dars_config = None;
     let mut add_party_config = None;
+    let mut change_threshold_config = None;
     let parsed = match kind {
         WorkflowKind::Onboarding => {
             serde_json::from_str::<workflow::OnboardingConfig>(&run.config_json)
@@ -272,6 +274,10 @@ pub(crate) async fn respawn_coordinator(
         WorkflowKind::AddParty => {
             serde_json::from_str::<workflow::AddPartyConfig>(&run.config_json)
                 .map(|c| add_party_config = Some(c))
+        }
+        WorkflowKind::ChangeThreshold => {
+            serde_json::from_str::<workflow::ChangeThresholdConfig>(&run.config_json)
+                .map(|c| change_threshold_config = Some(c))
         }
     };
     if let Err(e) = parsed {
@@ -300,6 +306,7 @@ pub(crate) async fn respawn_coordinator(
         contracts_config,
         dars_config,
         add_party_config,
+        change_threshold_config,
         auth_snapshot,
         last_seen,
     );
@@ -322,6 +329,7 @@ fn spawn_coordinator_run(
     contracts_config: Option<workflow::ContractsConfig>,
     dars_config: Option<workflow::DarsConfig>,
     add_party_config: Option<workflow::AddPartyConfig>,
+    change_threshold_config: Option<workflow::ChangeThresholdConfig>,
     auth: Option<WorkflowAuth>,
     last_seen: LastSeen,
 ) -> tokio::task::JoinHandle<()> {
@@ -331,6 +339,7 @@ fn spawn_coordinator_run(
         WorkflowKind::Contracts => WorkflowType::Contracts,
         WorkflowKind::Dars => WorkflowType::Dars,
         WorkflowKind::AddParty => WorkflowType::AddParty,
+        WorkflowKind::ChangeThreshold => WorkflowType::ChangeThreshold,
     };
     tokio::spawn(async move {
         let instance_name = instance.instance_name.clone();
@@ -346,6 +355,7 @@ fn spawn_coordinator_run(
             contracts_config,
             dars_config,
             add_party_config,
+            change_threshold_config,
             auth,
             last_seen,
             instance.clone(),
@@ -466,6 +476,7 @@ impl WorkflowTriggers {
             InvitationMeta::Onboarding(p) => {
                 prefix = Some(p.prefix);
                 participants = p.participants;
+                new_threshold = p.threshold;
                 workflow_instance = p.workflow_instance;
             }
             InvitationMeta::Dars(p) => {
@@ -489,6 +500,13 @@ impl WorkflowTriggers {
             }
             InvitationMeta::AddParty(p) => {
                 new_participant = Some(p.new_participant);
+                new_threshold = Some(p.new_threshold);
+                previous_threshold = Some(p.previous_threshold);
+                dec_party_id = Some(p.dec_party_id);
+                participants = p.participants;
+                workflow_instance = p.workflow_instance;
+            }
+            InvitationMeta::ChangeThreshold(p) => {
                 new_threshold = Some(p.new_threshold);
                 previous_threshold = Some(p.previous_threshold);
                 dec_party_id = Some(p.dec_party_id);
@@ -1062,6 +1080,9 @@ pub async fn start_server(
             .service(handlers::start_add_party)
             .service(handlers::get_add_party_status)
             .service(handlers::cancel_add_party)
+            .service(handlers::start_change_threshold)
+            .service(handlers::get_change_threshold_status)
+            .service(handlers::cancel_change_threshold)
             .service(handlers::start_onboarding)
             .service(handlers::get_onboarding_status)
             .service(handlers::cancel_onboarding)
@@ -1680,6 +1701,7 @@ async fn handle_incoming_connection(
                         | MessageType::AddPartySignatures
                         | MessageType::AddPartyClearSignatures
                         | MessageType::AddPartyClearProposal
+                        | MessageType::ChangeThresholdSignatures
                         | MessageType::StatusUpdate
                         | MessageType::DeclineInvitation => {
                             // Route workflow-command traffic to the coordinator
@@ -1722,7 +1744,8 @@ async fn handle_incoming_connection(
                         | MessageType::InviteKick
                         | MessageType::InviteContracts
                         | MessageType::InviteDars
-                        | MessageType::InviteAddParty => {
+                        | MessageType::InviteAddParty
+                        | MessageType::InviteChangeThreshold => {
                             // Invites are accepted unconditionally: workflows are
                             // multi-instance now, so a node already coordinating or
                             // participating in runs can take part in more
@@ -1736,6 +1759,9 @@ async fn handle_incoming_connection(
                                 MessageType::InviteContracts => InvitationType::Contracts,
                                 MessageType::InviteDars => InvitationType::Dars,
                                 MessageType::InviteAddParty => InvitationType::AddParty,
+                                MessageType::InviteChangeThreshold => {
+                                    InvitationType::ChangeThreshold
+                                }
                                 _ => unreachable!(),
                             };
                             tracing::info!(
@@ -1805,6 +1831,19 @@ async fn handle_incoming_connection(
                                             Err(e) => {
                                                 tracing::warn!(
                                                     "Add-party invite payload was unparseable: {e}"
+                                                );
+                                                InvitationMeta::None
+                                            }
+                                        }
+                                    }
+                                    InvitationType::ChangeThreshold => {
+                                        match serde_json::from_slice::<ChangeThresholdInvitePayload>(
+                                            &msg.payload,
+                                        ) {
+                                            Ok(p) => InvitationMeta::ChangeThreshold(p),
+                                            Err(e) => {
+                                                tracing::warn!(
+                                                    "Change-threshold invite payload was unparseable: {e}"
                                                 );
                                                 InvitationMeta::None
                                             }

--- a/crates/decman/src/server/types.rs
+++ b/crates/decman/src/server/types.rs
@@ -16,9 +16,10 @@ use tokio::sync::RwLock;
 pub use common::api::{
     AddPartyInvitePayload, AddPartyRequest, AuditLogResponse, AuthStatus, AuthStatusResponse,
     AuthTestResponse, AuthTestResult, CancelConfirmationRequest, ChainAuditEntry,
-    ChainAuditResponse, Claim, ContractQueryResponse, ContractWithBlob, ContractsInvitePayload,
-    ContractsRequest, CredentialOfferInfo, CredentialOffersResponse, DarsInvitePayload,
-    DarsRequest, DecentralizedPartiesResponse, DeclineInvitationPayload, DisclosedContractInput,
+    ChainAuditResponse, ChangeThresholdInvitePayload, ChangeThresholdRequest, Claim,
+    ContractQueryResponse, ContractWithBlob, ContractsInvitePayload, ContractsRequest,
+    CredentialOfferInfo, CredentialOffersResponse, DarsInvitePayload, DarsRequest,
+    DecentralizedPartiesResponse, DeclineInvitationPayload, DisclosedContractInput,
     DiscoverMemberPartyRequest, DiscoverMemberPartyResponse, ErrorResponse,
     ExpireConfirmationRequest, GovernanceState, GovernanceStateResponse, GovernanceType,
     GrantRightsRequest, GrantRightsResponse, InstrumentAllowance, InstrumentId,

--- a/crates/decman/src/utils.rs
+++ b/crates/decman/src/utils.rs
@@ -105,6 +105,18 @@ pub fn read_first_message_from_bytes<M: Message + Default>(data: &[u8]) -> Resul
     Ok(message)
 }
 
+/// Encode a single protobuf message as `varint(len)||proto` — the same
+/// length-prefixed framing [`write_message_to_file`] writes to disk and
+/// [`read_first_message_from_bytes`] reads back. Workflows share this to build
+/// artefact / on-wire bytes without re-implementing the framing.
+pub fn encode_length_prefixed_message<M: Message>(message: &M) -> Vec<u8> {
+    let encoded = message.encode_to_vec();
+    let mut buffer = BytesMut::new();
+    prost::encoding::encode_varint(encoded.len() as u64, &mut buffer);
+    buffer.put_slice(&encoded);
+    buffer.to_vec()
+}
+
 /// Write multiple protobuf messages to a file
 ///
 /// Each message is prefixed with a varint indicating its length, matching Canton's format.

--- a/crates/decman/src/workflow/change_threshold/config.rs
+++ b/crates/decman/src/workflow/change_threshold/config.rs
@@ -1,0 +1,50 @@
+use std::marker::PhantomData;
+
+use serde::{Deserialize, Serialize};
+
+use crate::canton_id::CantonId;
+
+/// Configuration for the change-threshold workflow.
+///
+/// Changes the signing threshold of an existing decentralized party without
+/// altering its membership: the `DecentralizedNamespaceDefinition.threshold`
+/// (how many namespace owners must sign topology transactions) and the
+/// matching `PartyToParticipant.threshold` (party confirmation threshold) are
+/// re-issued with `new_threshold`, keeping the same owners/participants.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ChangeThresholdConfig {
+    /// Decentralized party whose threshold is being changed.
+    pub decentralized_party_id: CantonId,
+
+    /// New threshold to set on both the DNS and P2P mappings.
+    pub new_threshold: i32,
+
+    /// The party's threshold before the change. Display-only — carried through
+    /// to the workflow run card so the operator sees "old → new". Defaults to
+    /// 0 for configs persisted before this field existed.
+    #[serde(default)]
+    pub previous_threshold: i32,
+
+    /// Workflow instance name for artefact organisation
+    /// (e.g. "xyz-change-threshold-20260108-143052").
+    pub instance_name: String,
+
+    _p: PhantomData<()>,
+}
+
+impl ChangeThresholdConfig {
+    pub fn new(
+        decentralized_party_id: CantonId,
+        new_threshold: i32,
+        previous_threshold: i32,
+        instance_name: String,
+    ) -> Self {
+        Self {
+            decentralized_party_id,
+            new_threshold,
+            previous_threshold,
+            instance_name,
+            _p: PhantomData,
+        }
+    }
+}

--- a/crates/decman/src/workflow/change_threshold/coordinator.rs
+++ b/crates/decman/src/workflow/change_threshold/coordinator.rs
@@ -1,0 +1,176 @@
+use std::{collections::HashSet, sync::Arc};
+
+use anyhow::Context;
+
+use crate::{
+    config::{NetworkConfig, NodeConfig},
+    error::Result,
+    noise::server::{ActiveWorkflow, NoiseServer},
+    server::{WorkflowInstance, peer_status::LastSeen},
+    utils,
+    workflow::{
+        kick::coordinator::split_signed_kick_pair,
+        storage::{WorkflowStorage, artifact_kinds},
+    },
+};
+
+use super::{
+    ChangeThresholdConfig, ChangeThresholdStep,
+    steps::{create_proposals, export_state, submit_change},
+};
+
+pub async fn start_coordinator(
+    node_config: NodeConfig,
+    network_config: NetworkConfig,
+    change_config: ChangeThresholdConfig,
+    db: sqlx::SqlitePool,
+    last_seen: LastSeen,
+    instance: Arc<WorkflowInstance>,
+) -> Result {
+    tracing::info!("Initializing Noise server...");
+
+    // Every remaining party member signs — no exclusions.
+    let server = NoiseServer::new(
+        node_config.clone(),
+        network_config.clone(),
+        db.clone(),
+        change_config.instance_name.clone(),
+        ChangeThresholdStep::WaitingForPeers,
+        None,
+        last_seen,
+    )
+    .await?;
+
+    let workflow_state = server.get_workflow_state();
+    let server = Arc::new(server);
+
+    let coordinator_workflow = {
+        let workflow_state = workflow_state.clone();
+        let node_config = node_config.clone();
+        let change_config = change_config.clone();
+        let db = db.clone();
+        let instance_name = change_config.instance_name.clone();
+
+        tokio::spawn(async move {
+            let mut coordinator_completed_steps = HashSet::new();
+
+            loop {
+                let current_step = workflow_state.current_step().await;
+                tracing::debug!("Coordinator in step: {current_step:?}");
+
+                match current_step {
+                    ChangeThresholdStep::WaitingForPeers => {
+                        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+                    }
+                    ChangeThresholdStep::ExportState => {
+                        if !coordinator_completed_steps.contains(&ChangeThresholdStep::ExportState)
+                        {
+                            tracing::info!("Coordinator executing: Export state");
+                            export_state(&node_config, &db, &instance_name, &change_config).await?;
+                            coordinator_completed_steps.insert(ChangeThresholdStep::ExportState);
+                            workflow_state.advance_step().await;
+                        }
+                        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+                    }
+                    ChangeThresholdStep::CreateProposals => {
+                        tracing::info!("Coordinator executing: Create proposals");
+                        create_proposals(&node_config, &db, &instance_name, &change_config).await?;
+
+                        // Load proposals to send to peers with the
+                        // SignChangeThreshold command. Combine config + DNS +
+                        // P2P into a single length-prefixed payload (decoded as
+                        // 3 items by the peer).
+                        let dns_data = db
+                            .read_artifact(
+                                &instance_name,
+                                artifact_kinds::CHANGE_THRESHOLD_DNS_PROPOSAL,
+                                None,
+                            )
+                            .await?
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "CHANGE_THRESHOLD_DNS_PROPOSAL artifact missing after CreateProposals"
+                                )
+                            })?;
+                        let p2p_data = db
+                            .read_artifact(
+                                &instance_name,
+                                artifact_kinds::CHANGE_THRESHOLD_P2P_PROPOSAL,
+                                None,
+                            )
+                            .await?
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "CHANGE_THRESHOLD_P2P_PROPOSAL artifact missing after CreateProposals"
+                                )
+                            })?;
+
+                        let config_data = serde_json::to_vec(&change_config)
+                            .context("Failed to serialize change-threshold config")?;
+
+                        let payload =
+                            utils::encode_length_prefixed(&[&config_data, &dns_data, &p2p_data]);
+                        workflow_state.set_command_payload(payload).await;
+                        workflow_state.advance_step().await;
+                    }
+                    ChangeThresholdStep::SignProposals => {
+                        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+                    }
+                    ChangeThresholdStep::Submit => {
+                        tracing::info!("Coordinator executing: Submit change-threshold");
+
+                        // Each peer sent a single buffer of two length-prefixed
+                        // protobufs (DNS sig then P2P sig). Split that pair back
+                        // into per-peer artefacts so submit can list them by
+                        // kind and join by peer id. The kick splitter is
+                        // format-agnostic and shared for this.
+                        let peer_data = workflow_state.get_all_peer_data().await;
+                        for (peer_id, combined) in &peer_data {
+                            let (dns_blob, p2p_blob) = split_signed_kick_pair(combined)
+                                .with_context(|| {
+                                    format!(
+                                        "Failed to split signed change-threshold pair from \
+                                         peer {peer_id}"
+                                    )
+                                })?;
+                            let peer_key = peer_id.to_string();
+                            db.write_artifact(
+                                &instance_name,
+                                artifact_kinds::SIGNED_CHANGE_THRESHOLD_DNS,
+                                Some(&peer_key),
+                                &dns_blob,
+                            )
+                            .await?;
+                            db.write_artifact(
+                                &instance_name,
+                                artifact_kinds::SIGNED_CHANGE_THRESHOLD_P2P,
+                                Some(&peer_key),
+                                &p2p_blob,
+                            )
+                            .await?;
+                        }
+                        workflow_state.clear_peer_data().await;
+
+                        submit_change(&node_config, &db, &instance_name).await?;
+                        workflow_state.advance_step().await;
+                    }
+                    ChangeThresholdStep::Complete => {
+                        tracing::info!("Change-threshold workflow complete!");
+                        tracing::debug!("Waiting for peers to receive Disconnect command...");
+                        tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+                        break;
+                    }
+                }
+            }
+
+            Ok(())
+        })
+    };
+
+    crate::workflow::run_workflow_with_handler(
+        ActiveWorkflow::ChangeThreshold(server),
+        instance,
+        coordinator_workflow,
+    )
+    .await
+}

--- a/crates/decman/src/workflow/change_threshold/mod.rs
+++ b/crates/decman/src/workflow/change_threshold/mod.rs
@@ -1,0 +1,179 @@
+pub mod config;
+pub mod coordinator;
+pub mod peer;
+pub mod steps;
+
+pub use config::ChangeThresholdConfig;
+pub use steps::{create_proposals, export_state, sign_proposals, submit_change};
+
+use crate::{noise::MessageType, server::WorkflowKind, workflow::state::WorkflowStep};
+
+/// Change-threshold workflow steps (re-issuing an existing dec party's
+/// namespace + P2P threshold without changing its membership).
+///
+/// Structurally identical to the kick workflow minus the removal: the
+/// coordinator exports the current namespace, builds new DNS + P2P proposals
+/// carrying the new threshold (same owners/participants), the members sign a
+/// quorum, and the coordinator submits.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum ChangeThresholdStep {
+    /// Waiting for all peers to connect
+    WaitingForPeers,
+    /// Coordinator exports current namespace state
+    ExportState,
+    /// Coordinator creates the new-threshold proposals
+    CreateProposals,
+    /// Members sign the proposals
+    SignProposals,
+    /// Coordinator submits the change
+    Submit,
+    /// Workflow complete
+    Complete,
+}
+
+impl WorkflowStep for ChangeThresholdStep {
+    fn to_command(&self) -> Option<MessageType> {
+        match self {
+            Self::SignProposals => Some(MessageType::SignChangeThreshold),
+            Self::Complete => Some(MessageType::Disconnect),
+            Self::WaitingForPeers | Self::ExportState | Self::CreateProposals | Self::Submit => {
+                None
+            }
+        }
+    }
+
+    fn next(&self) -> Option<Self> {
+        match self {
+            Self::WaitingForPeers => Some(Self::ExportState),
+            Self::ExportState => Some(Self::CreateProposals),
+            Self::CreateProposals => Some(Self::SignProposals),
+            Self::SignProposals => Some(Self::Submit),
+            Self::Submit => Some(Self::Complete),
+            Self::Complete => None,
+        }
+    }
+
+    fn requires_peers(&self) -> bool {
+        *self == Self::SignProposals
+    }
+
+    fn is_waiting_for_peers(&self) -> bool {
+        *self == Self::WaitingForPeers
+    }
+
+    fn step_index(&self) -> i64 {
+        match self {
+            Self::WaitingForPeers => 0,
+            Self::ExportState => 1,
+            Self::CreateProposals => 2,
+            Self::SignProposals => 3,
+            Self::Submit => 4,
+            Self::Complete => 5,
+        }
+    }
+
+    fn step_total() -> i64 {
+        6
+    }
+
+    fn step_name(&self) -> &'static str {
+        match self {
+            Self::WaitingForPeers => "WaitingForPeers",
+            Self::ExportState => "ExportState",
+            Self::CreateProposals => "CreateProposals",
+            Self::SignProposals => "SignProposals",
+            Self::Submit => "Submit",
+            Self::Complete => "Complete",
+        }
+    }
+
+    fn try_from_step_name(name: &str) -> Option<Self> {
+        Some(match name {
+            "WaitingForPeers" => Self::WaitingForPeers,
+            "ExportState" => Self::ExportState,
+            "CreateProposals" => Self::CreateProposals,
+            "SignProposals" => Self::SignProposals,
+            "Submit" => Self::Submit,
+            "Complete" => Self::Complete,
+            _ => return None,
+        })
+    }
+
+    fn kind() -> WorkflowKind {
+        WorkflowKind::ChangeThreshold
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn steps_advance_in_order_to_completion() {
+        // Walking `next()` from the start lands on every step exactly once and
+        // terminates at `Complete`.
+        let mut step = ChangeThresholdStep::WaitingForPeers;
+        let mut seen = vec![step];
+        while let Some(next) = step.next() {
+            seen.push(next);
+            step = next;
+        }
+        assert_eq!(
+            seen,
+            vec![
+                ChangeThresholdStep::WaitingForPeers,
+                ChangeThresholdStep::ExportState,
+                ChangeThresholdStep::CreateProposals,
+                ChangeThresholdStep::SignProposals,
+                ChangeThresholdStep::Submit,
+                ChangeThresholdStep::Complete,
+            ]
+        );
+        assert_eq!(seen.len() as i64, ChangeThresholdStep::step_total());
+    }
+
+    #[test]
+    fn only_sign_step_requires_peers_and_carries_a_command() {
+        for step in [
+            ChangeThresholdStep::WaitingForPeers,
+            ChangeThresholdStep::ExportState,
+            ChangeThresholdStep::CreateProposals,
+            ChangeThresholdStep::SignProposals,
+            ChangeThresholdStep::Submit,
+            ChangeThresholdStep::Complete,
+        ] {
+            assert_eq!(
+                step.requires_peers(),
+                step == ChangeThresholdStep::SignProposals,
+                "{step:?} peer requirement"
+            );
+        }
+        assert_eq!(
+            ChangeThresholdStep::SignProposals.to_command(),
+            Some(MessageType::SignChangeThreshold)
+        );
+        assert_eq!(
+            ChangeThresholdStep::Complete.to_command(),
+            Some(MessageType::Disconnect)
+        );
+        assert_eq!(ChangeThresholdStep::CreateProposals.to_command(), None);
+    }
+
+    #[test]
+    fn step_names_round_trip() {
+        for step in [
+            ChangeThresholdStep::WaitingForPeers,
+            ChangeThresholdStep::ExportState,
+            ChangeThresholdStep::CreateProposals,
+            ChangeThresholdStep::SignProposals,
+            ChangeThresholdStep::Submit,
+            ChangeThresholdStep::Complete,
+        ] {
+            assert_eq!(
+                ChangeThresholdStep::try_from_step_name(step.step_name()),
+                Some(step)
+            );
+        }
+        assert_eq!(ChangeThresholdStep::try_from_step_name("Nope"), None);
+    }
+}

--- a/crates/decman/src/workflow/change_threshold/peer.rs
+++ b/crates/decman/src/workflow/change_threshold/peer.rs
@@ -1,0 +1,52 @@
+use sqlx::SqlitePool;
+
+use crate::{
+    config::NodeConfig,
+    error::Result,
+    noise::client::NoiseClient,
+    workflow::storage::{WorkflowStorage, artifact_kinds},
+};
+
+/// Send the locally-signed DNS + P2P change-threshold proposals to the
+/// coordinator.
+///
+/// The two artefacts (`SIGNED_CHANGE_THRESHOLD_DNS` and
+/// `SIGNED_CHANGE_THRESHOLD_P2P`) were written by `sign_proposals` as
+/// `varint(len)||proto` blobs. Concatenating them produces exactly the buffer
+/// the coordinator's submit step decodes as two protobuf messages.
+pub async fn send_change_threshold_signatures_to_coordinator(
+    client: &NoiseClient,
+    storage: &SqlitePool,
+    instance_name: &str,
+    node_config: &NodeConfig,
+) -> Result {
+    let node_id = node_config.participant_id().to_string();
+
+    let dns = storage
+        .read_artifact(
+            instance_name,
+            artifact_kinds::SIGNED_CHANGE_THRESHOLD_DNS,
+            Some(&node_id),
+        )
+        .await?
+        .ok_or_else(|| {
+            anyhow::anyhow!("SIGNED_CHANGE_THRESHOLD_DNS artifact missing for {node_id}")
+        })?;
+    let p2p = storage
+        .read_artifact(
+            instance_name,
+            artifact_kinds::SIGNED_CHANGE_THRESHOLD_P2P,
+            Some(&node_id),
+        )
+        .await?
+        .ok_or_else(|| {
+            anyhow::anyhow!("SIGNED_CHANGE_THRESHOLD_P2P artifact missing for {node_id}")
+        })?;
+
+    let mut payload = Vec::with_capacity(dns.len() + p2p.len());
+    payload.extend_from_slice(&dns);
+    payload.extend_from_slice(&p2p);
+
+    client.send_change_threshold_signatures(payload).await?;
+    Ok(())
+}

--- a/crates/decman/src/workflow/change_threshold/steps/export_state.rs
+++ b/crates/decman/src/workflow/change_threshold/steps/export_state.rs
@@ -1,0 +1,112 @@
+use canton_proto_rs::com::digitalasset::canton::topology::admin::v30::{
+    BaseQuery, ListDecentralizedNamespaceDefinitionRequest, StoreId, Synchronizer, base_query,
+    store_id, synchronizer, topology_manager_read_service_client::TopologyManagerReadServiceClient,
+};
+use sqlx::SqlitePool;
+
+use crate::{
+    config::NodeConfig,
+    error::Result,
+    utils,
+    workflow::{
+        change_threshold::ChangeThresholdConfig,
+        storage::{WorkflowStorage, artifact_kinds},
+    },
+};
+
+/// Export the current decentralized namespace state and validate the requested
+/// threshold against the live owner set.
+///
+/// Saves the current `DecentralizedNamespaceDefinition`
+/// (`CHANGE_THRESHOLD_NAMESPACE_DEF`) for `CreateProposals` to rewrite. Unlike
+/// the kick workflow there is no member to remove — the owner/participant sets
+/// are preserved and only the threshold changes.
+pub async fn export_state(
+    config: &NodeConfig,
+    storage: &SqlitePool,
+    instance_name: &str,
+    change_config: &ChangeThresholdConfig,
+) -> Result {
+    tracing::info!("Exporting current decentralized namespace state...");
+
+    let synchronizer_id = utils::get_synchronizer_id(config).await?;
+    tracing::debug!("Using synchronizer ID: {synchronizer_id}");
+
+    let namespace_hex = change_config.decentralized_party_id.namespace.to_hex();
+    tracing::info!("Querying namespace: {namespace_hex}");
+
+    let mut topology_read_client =
+        TopologyManagerReadServiceClient::connect(config.admin_api_url()).await?;
+
+    let request = tonic::Request::new(ListDecentralizedNamespaceDefinitionRequest {
+        base_query: Some(BaseQuery {
+            store: Some(StoreId {
+                store: Some(store_id::Store::Synchronizer(Synchronizer {
+                    kind: Some(synchronizer::Kind::PhysicalId(synchronizer_id.clone())),
+                })),
+            }),
+            proposals: false,
+            operation: 0,
+            time_query: Some(base_query::TimeQuery::HeadState(())),
+            filter_signed_key: String::new(),
+            protocol_version: None,
+        }),
+        filter_namespace: namespace_hex.clone(),
+    });
+
+    let response = topology_read_client
+        .list_decentralized_namespace_definition(request)
+        .await?
+        .into_inner();
+
+    if response.results.is_empty() {
+        anyhow::bail!("Namespace {namespace_hex} not found in topology");
+    }
+
+    let namespace_def = response
+        .results
+        .first()
+        .and_then(|r| r.item.as_ref())
+        .ok_or_else(|| anyhow::anyhow!("Namespace definition missing from response"))?;
+
+    let owner_count = namespace_def.owners.len();
+    tracing::info!(
+        "Found namespace with {owner_count} owners, threshold {threshold}",
+        threshold = namespace_def.threshold
+    );
+
+    // Validate the requested threshold against the *live* owner set. The HTTP
+    // handler bounds it against cached membership, but the topology is the
+    // source of truth — a threshold above the owner count can never be
+    // satisfied and would leave a stuck proposal.
+    if change_config.new_threshold < 1 || change_config.new_threshold > owner_count as i32 {
+        anyhow::bail!(
+            "new_threshold must be between 1 and {owner_count} (current namespace owner count); \
+             got {got}",
+            got = change_config.new_threshold,
+        );
+    }
+
+    if change_config.new_threshold == namespace_def.threshold {
+        anyhow::bail!(
+            "new_threshold {t} is already the current threshold — nothing to change",
+            t = change_config.new_threshold,
+        );
+    }
+
+    // Save namespace definition as a length-prefixed protobuf — same byte
+    // shape as the file written by `utils::write_message_to_file`.
+    let namespace_bytes = utils::encode_length_prefixed_message(namespace_def);
+    storage
+        .write_artifact(
+            instance_name,
+            artifact_kinds::CHANGE_THRESHOLD_NAMESPACE_DEF,
+            None,
+            &namespace_bytes,
+        )
+        .await?;
+    tracing::info!("Saved namespace definition to storage");
+
+    tracing::info!("State exported successfully to workflow storage");
+    Ok(())
+}

--- a/crates/decman/src/workflow/change_threshold/steps/mod.rs
+++ b/crates/decman/src/workflow/change_threshold/steps/mod.rs
@@ -1,0 +1,5 @@
+pub mod export_state;
+pub mod proposals;
+
+pub use export_state::export_state;
+pub use proposals::{create_proposals, sign_proposals, submit_change};

--- a/crates/decman/src/workflow/change_threshold/steps/proposals/create.rs
+++ b/crates/decman/src/workflow/change_threshold/steps/proposals/create.rs
@@ -1,0 +1,257 @@
+use canton_proto_rs::com::digitalasset::canton::{
+    protocol::v30::{
+        DecentralizedNamespaceDefinition, PartyToParticipant, TopologyMapping, enums,
+        topology_mapping,
+    },
+    topology::admin::v30::{
+        AuthorizeRequest, BaseQuery, ListPartyToParticipantRequest, StoreId, Synchronizer,
+        authorize_request, base_query, store_id, synchronizer,
+        topology_manager_read_service_client::TopologyManagerReadServiceClient,
+        topology_manager_write_service_client::TopologyManagerWriteServiceClient,
+    },
+};
+use sqlx::SqlitePool;
+
+use crate::{
+    canton_id::CantonId,
+    config::NodeConfig,
+    error::Result,
+    utils,
+    workflow::{
+        change_threshold::ChangeThresholdConfig,
+        storage::{WorkflowStorage, artifact_kinds},
+    },
+};
+
+/// Create the change-threshold proposals.
+///
+/// This step creates:
+/// - DNS proposal re-issuing the namespace with the new threshold (same
+///   owners) — `CHANGE_THRESHOLD_DNS_PROPOSAL`
+/// - P2P proposal re-issuing the party mapping with the new threshold (same
+///   participants) — `CHANGE_THRESHOLD_P2P_PROPOSAL`
+/// - New namespace definition — `CHANGE_THRESHOLD_NEW_NAMESPACE_DEF` (used by
+///   submit to poll the topology)
+/// - Full party id — `CHANGE_THRESHOLD_PARTY_ID` (used by submit)
+pub async fn create_proposals(
+    config: &NodeConfig,
+    storage: &SqlitePool,
+    instance_name: &str,
+    change_config: &ChangeThresholdConfig,
+) -> Result {
+    tracing::info!("Creating change-threshold proposals...");
+
+    // Read current namespace definition (length-prefixed protobuf, written by
+    // export_state).
+    let namespace_bytes = storage
+        .read_artifact(
+            instance_name,
+            artifact_kinds::CHANGE_THRESHOLD_NAMESPACE_DEF,
+            None,
+        )
+        .await?
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "CHANGE_THRESHOLD_NAMESPACE_DEF artifact missing — did ExportState run?"
+            )
+        })?;
+    let current_namespace_def: DecentralizedNamespaceDefinition =
+        utils::read_first_message_from_bytes(&namespace_bytes)?;
+
+    let new_threshold = change_config.new_threshold;
+    tracing::info!(
+        "Current namespace: {namespace}, threshold: {threshold} -> {new_threshold}, owners: {owners_count}",
+        namespace = current_namespace_def.decentralized_namespace,
+        threshold = current_namespace_def.threshold,
+        owners_count = current_namespace_def.owners.len()
+    );
+
+    // Keep the full owner set — only the threshold changes.
+    let new_namespace_def = DecentralizedNamespaceDefinition {
+        decentralized_namespace: current_namespace_def.decentralized_namespace.clone(),
+        threshold: new_threshold,
+        owners: current_namespace_def.owners.clone(),
+    };
+
+    // Party id: prefix (from the request) :: current namespace fingerprint.
+    // The namespace hash is over the owner set only, which is unchanged, so
+    // the party id is stable across the threshold change.
+    let party_id_str = format!(
+        "{party_id_prefix}::{namespace}",
+        party_id_prefix = change_config.decentralized_party_id.prefix,
+        namespace = current_namespace_def.decentralized_namespace
+    );
+    let party_id = CantonId::parse(&party_id_str)?;
+    tracing::info!("Party ID: {party_id}");
+
+    // Read the current P2P mapping so we re-issue it verbatim with only the
+    // threshold changed.
+    let synchronizer_id = utils::get_synchronizer_id(config).await?;
+    tracing::debug!("Using synchronizer ID: {synchronizer_id}");
+
+    let current_p2p = get_current_p2p_mapping(config, &synchronizer_id, &party_id).await?;
+    tracing::info!(
+        "Current P2P mapping has {count} participant(s), threshold {threshold}",
+        count = current_p2p.participants.len(),
+        threshold = current_p2p.threshold,
+    );
+
+    let new_p2p = PartyToParticipant {
+        party: party_id_str.clone(),
+        threshold: new_threshold.try_into()?,
+        participants: current_p2p.participants,
+        party_signing_keys: current_p2p.party_signing_keys,
+    };
+
+    // Create proposals using topology manager
+    let mut topology_client =
+        TopologyManagerWriteServiceClient::connect(config.admin_api_url()).await?;
+
+    // Create DNS proposal
+    tracing::info!("Creating DNS change-threshold proposal...");
+    let dns_request = tonic::Request::new(AuthorizeRequest {
+        r#type: Some(authorize_request::Type::Proposal(
+            authorize_request::Proposal {
+                change: enums::TopologyChangeOp::AddReplace as i32,
+                serial: 0,
+                mapping: Some(TopologyMapping {
+                    mapping: Some(topology_mapping::Mapping::DecentralizedNamespaceDefinition(
+                        new_namespace_def.clone(),
+                    )),
+                }),
+            },
+        )),
+        must_fully_authorize: false,
+        force_changes: vec![],
+        signed_by: vec![],
+        store: Some(StoreId {
+            store: Some(store_id::Store::Synchronizer(Synchronizer {
+                kind: Some(synchronizer::Kind::PhysicalId(synchronizer_id.clone())),
+            })),
+        }),
+        wait_to_become_effective: None,
+    });
+
+    let dns_response = topology_client.authorize(dns_request).await?.into_inner();
+    let dns_transaction = dns_response
+        .transaction
+        .ok_or_else(|| anyhow::anyhow!("No DNS transaction returned"))?;
+
+    // Create P2P proposal
+    tracing::info!("Creating P2P change-threshold proposal...");
+    let p2p_request = tonic::Request::new(AuthorizeRequest {
+        r#type: Some(authorize_request::Type::Proposal(
+            authorize_request::Proposal {
+                change: enums::TopologyChangeOp::AddReplace as i32,
+                serial: 0,
+                mapping: Some(TopologyMapping {
+                    mapping: Some(topology_mapping::Mapping::PartyToParticipant(new_p2p)),
+                }),
+            },
+        )),
+        must_fully_authorize: false,
+        force_changes: vec![],
+        signed_by: vec![],
+        store: Some(StoreId {
+            store: Some(store_id::Store::Synchronizer(Synchronizer {
+                kind: Some(synchronizer::Kind::PhysicalId(synchronizer_id.clone())),
+            })),
+        }),
+        wait_to_become_effective: None,
+    });
+
+    let p2p_response = topology_client.authorize(p2p_request).await?.into_inner();
+    let p2p_transaction = p2p_response
+        .transaction
+        .ok_or_else(|| anyhow::anyhow!("No P2P transaction returned"))?;
+
+    // Persist proposals + supporting data. Each protobuf is written with the
+    // same `varint(len)||proto` framing the file path used, so
+    // `read_first_message_from_bytes` works unchanged.
+    let dns_bytes = utils::encode_length_prefixed_message(&dns_transaction);
+    storage
+        .write_artifact(
+            instance_name,
+            artifact_kinds::CHANGE_THRESHOLD_DNS_PROPOSAL,
+            None,
+            &dns_bytes,
+        )
+        .await?;
+    tracing::info!("Saved DNS change-threshold proposal to storage");
+
+    let p2p_bytes = utils::encode_length_prefixed_message(&p2p_transaction);
+    storage
+        .write_artifact(
+            instance_name,
+            artifact_kinds::CHANGE_THRESHOLD_P2P_PROPOSAL,
+            None,
+            &p2p_bytes,
+        )
+        .await?;
+    tracing::info!("Saved P2P change-threshold proposal to storage");
+
+    let new_namespace_bytes = utils::encode_length_prefixed_message(&new_namespace_def);
+    storage
+        .write_artifact(
+            instance_name,
+            artifact_kinds::CHANGE_THRESHOLD_NEW_NAMESPACE_DEF,
+            None,
+            &new_namespace_bytes,
+        )
+        .await?;
+    tracing::info!("Saved new namespace definition to storage");
+
+    // Save party ID — plaintext with a trailing newline (submit trims it).
+    storage
+        .write_artifact(
+            instance_name,
+            artifact_kinds::CHANGE_THRESHOLD_PARTY_ID,
+            None,
+            format!("{party_id}\n").as_bytes(),
+        )
+        .await?;
+
+    tracing::info!("Change-threshold proposals created and saved successfully");
+    Ok(())
+}
+
+/// Get the current P2P mapping for the party.
+async fn get_current_p2p_mapping(
+    config: &NodeConfig,
+    synchronizer_id: &str,
+    party_id: &CantonId,
+) -> Result<PartyToParticipant> {
+    let party_id_str = party_id.to_string();
+    let mut topology_read_client =
+        TopologyManagerReadServiceClient::connect(config.admin_api_url()).await?;
+
+    let request = tonic::Request::new(ListPartyToParticipantRequest {
+        base_query: Some(BaseQuery {
+            store: Some(StoreId {
+                store: Some(store_id::Store::Synchronizer(Synchronizer {
+                    kind: Some(synchronizer::Kind::PhysicalId(synchronizer_id.to_string())),
+                })),
+            }),
+            proposals: false,
+            operation: 0,
+            time_query: Some(base_query::TimeQuery::HeadState(())),
+            filter_signed_key: String::new(),
+            protocol_version: None,
+        }),
+        filter_party: party_id_str,
+        filter_participant: String::new(),
+    });
+
+    let response = topology_read_client
+        .list_party_to_participant(request)
+        .await?
+        .into_inner();
+
+    let p2p = response
+        .results
+        .first()
+        .and_then(|r| r.item.as_ref())
+        .ok_or_else(|| anyhow::anyhow!("No P2P mapping found for party {party_id}"))?;
+
+    Ok(p2p.clone())
+}

--- a/crates/decman/src/workflow/change_threshold/steps/proposals/mod.rs
+++ b/crates/decman/src/workflow/change_threshold/steps/proposals/mod.rs
@@ -1,0 +1,7 @@
+pub mod create;
+pub mod sign;
+pub mod submit;
+
+pub use create::create_proposals;
+pub use sign::sign_proposals;
+pub use submit::submit_change;

--- a/crates/decman/src/workflow/change_threshold/steps/proposals/sign.rs
+++ b/crates/decman/src/workflow/change_threshold/steps/proposals/sign.rs
@@ -1,0 +1,92 @@
+use canton_proto_rs::com::digitalasset::canton::{
+    protocol::v30::SignedTopologyTransaction,
+    topology::admin::v30::{
+        SignTransactionsRequest, StoreId, Synchronizer, store_id, synchronizer,
+    },
+};
+use sqlx::SqlitePool;
+
+use crate::{
+    config::NodeConfig,
+    error::Result,
+    utils,
+    workflow::{
+        storage::{WorkflowStorage, artifact_kinds},
+        topology::sign_transactions_with_topology_retry,
+    },
+};
+
+/// Sign the change-threshold proposals.
+///
+/// Every party member signs both the DNS and P2P proposals. `proposal_data`
+/// contains both proposals received from the coordinator. Persists the
+/// per-peer signed DNS / P2P proposals as `SIGNED_CHANGE_THRESHOLD_DNS` /
+/// `SIGNED_CHANGE_THRESHOLD_P2P` (keyed by this node's participant id). Each
+/// artefact is `varint(len)||proto`, so concatenating them yields exactly the
+/// buffer the peer sends to the coordinator.
+pub async fn sign_proposals(
+    config: &NodeConfig,
+    storage: &SqlitePool,
+    instance_name: &str,
+    proposal_data: &[u8],
+) -> Result {
+    tracing::info!("Signing change-threshold proposals...");
+
+    let node_id = config.participant_id().to_string();
+    let synchronizer_id = utils::get_synchronizer_id(config).await?;
+    tracing::debug!("Using synchronizer ID: {synchronizer_id}");
+
+    // Parse the combined proposal data from the coordinator.
+    let items = utils::decode_length_prefixed(proposal_data, 2)?;
+    tracing::info!("Using change-threshold proposals from coordinator payload");
+
+    let dns_transaction: SignedTopologyTransaction =
+        utils::read_first_message_from_bytes(&items[0])?;
+    let p2p_transaction: SignedTopologyTransaction =
+        utils::read_first_message_from_bytes(&items[1])?;
+
+    let request = SignTransactionsRequest {
+        transactions: vec![dns_transaction, p2p_transaction],
+        signed_by: vec![],
+        store: Some(StoreId {
+            store: Some(store_id::Store::Synchronizer(Synchronizer {
+                kind: Some(synchronizer::Kind::PhysicalId(synchronizer_id)),
+            })),
+        }),
+        force_flags: vec![],
+    };
+
+    tracing::debug!("Calling SignTransactions RPC for change-threshold proposals...");
+    let response =
+        sign_transactions_with_topology_retry(config, request, "change-threshold").await?;
+
+    if response.transactions.len() != 2 {
+        anyhow::bail!(
+            "Expected 2 signed transactions (DNS and P2P), got {count}",
+            count = response.transactions.len()
+        );
+    }
+
+    let dns_bytes = utils::encode_length_prefixed_message(&response.transactions[0]);
+    let p2p_bytes = utils::encode_length_prefixed_message(&response.transactions[1]);
+
+    storage
+        .write_artifact(
+            instance_name,
+            artifact_kinds::SIGNED_CHANGE_THRESHOLD_DNS,
+            Some(&node_id),
+            &dns_bytes,
+        )
+        .await?;
+    storage
+        .write_artifact(
+            instance_name,
+            artifact_kinds::SIGNED_CHANGE_THRESHOLD_P2P,
+            Some(&node_id),
+            &p2p_bytes,
+        )
+        .await?;
+
+    tracing::info!("Change-threshold proposals signed successfully");
+    Ok(())
+}

--- a/crates/decman/src/workflow/change_threshold/steps/proposals/submit.rs
+++ b/crates/decman/src/workflow/change_threshold/steps/proposals/submit.rs
@@ -1,0 +1,333 @@
+use std::collections::HashMap;
+
+use canton_proto_rs::com::digitalasset::canton::{
+    protocol::v30::{DecentralizedNamespaceDefinition, SignedTopologyTransaction},
+    topology::admin::v30::{
+        AddTransactionsRequest, BaseQuery, ListDecentralizedNamespaceDefinitionRequest,
+        ListPartyToParticipantRequest, StoreId, Synchronizer, base_query, store_id, synchronizer,
+        topology_manager_read_service_client::TopologyManagerReadServiceClient,
+        topology_manager_write_service_client::TopologyManagerWriteServiceClient,
+    },
+};
+use sqlx::SqlitePool;
+use tokio::time;
+
+use crate::{
+    canton_id::CantonId,
+    config::NodeConfig,
+    consts::{
+        TOPOLOGY_PROPAGATION_DELAY_SECS, topology_retry_delay_secs, topology_retry_max_attempts,
+    },
+    error::Result,
+    utils,
+    workflow::storage::{WorkflowStorage, artifact_kinds},
+};
+
+/// Submit the change-threshold proposals to the synchronizer.
+///
+/// The coordinator aggregates the per-peer signatures onto its own proposals
+/// and submits the DNS mapping followed by the P2P mapping.
+pub async fn submit_change(
+    config: &NodeConfig,
+    storage: &SqlitePool,
+    instance_name: &str,
+) -> Result {
+    tracing::info!("Submitting change-threshold to synchronizer...");
+
+    let synchronizer_id = utils::get_synchronizer_id(config).await?;
+    tracing::debug!("Using synchronizer ID: {synchronizer_id}");
+
+    // Read original DNS proposal
+    let dns_bytes = storage
+        .read_artifact(
+            instance_name,
+            artifact_kinds::CHANGE_THRESHOLD_DNS_PROPOSAL,
+            None,
+        )
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("CHANGE_THRESHOLD_DNS_PROPOSAL artifact missing"))?;
+    let mut dns_transaction: SignedTopologyTransaction =
+        utils::read_first_message_from_bytes(&dns_bytes)?;
+
+    // Read original P2P proposal
+    let p2p_bytes = storage
+        .read_artifact(
+            instance_name,
+            artifact_kinds::CHANGE_THRESHOLD_P2P_PROPOSAL,
+            None,
+        )
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("CHANGE_THRESHOLD_P2P_PROPOSAL artifact missing"))?;
+    let mut p2p_transaction: SignedTopologyTransaction =
+        utils::read_first_message_from_bytes(&p2p_bytes)?;
+
+    // Gather per-peer signed proposals from storage, joining DNS and P2P by
+    // peer id so the two signatures stay paired.
+    let signed_dns = storage
+        .list_artifacts(instance_name, artifact_kinds::SIGNED_CHANGE_THRESHOLD_DNS)
+        .await?;
+    let signed_p2p: HashMap<String, Vec<u8>> = storage
+        .list_artifacts(instance_name, artifact_kinds::SIGNED_CHANGE_THRESHOLD_P2P)
+        .await?
+        .into_iter()
+        .collect();
+
+    tracing::info!(
+        "Found signed proposals from {count} peer(s)",
+        count = signed_dns.len()
+    );
+
+    if signed_dns.len() != signed_p2p.len() {
+        anyhow::bail!(
+            "Mismatched signed proposal counts: {dns} DNS vs {p2p} P2P",
+            dns = signed_dns.len(),
+            p2p = signed_p2p.len()
+        );
+    }
+
+    // Aggregate signatures from each peer onto the coordinator's proposals.
+    for (peer_id, dns_signed_bytes) in &signed_dns {
+        tracing::info!("Reading signatures from peer {peer_id}");
+
+        let dns_signed: SignedTopologyTransaction =
+            utils::read_first_message_from_bytes(dns_signed_bytes)?;
+        let p2p_signed_bytes = signed_p2p
+            .get(peer_id)
+            .ok_or_else(|| anyhow::anyhow!("Peer {peer_id} signed DNS but not P2P"))?;
+        let p2p_signed: SignedTopologyTransaction =
+            utils::read_first_message_from_bytes(p2p_signed_bytes)?;
+
+        dns_transaction.signatures.extend(dns_signed.signatures);
+        p2p_transaction.signatures.extend(p2p_signed.signatures);
+    }
+
+    tracing::info!(
+        "Final DNS proposal has {count} signature(s)",
+        count = dns_transaction.signatures.len()
+    );
+    tracing::info!(
+        "Final P2P proposal has {count} signature(s)",
+        count = p2p_transaction.signatures.len()
+    );
+
+    // Read new namespace definition for the topology-propagation poll.
+    let new_namespace_bytes = storage
+        .read_artifact(
+            instance_name,
+            artifact_kinds::CHANGE_THRESHOLD_NEW_NAMESPACE_DEF,
+            None,
+        )
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("CHANGE_THRESHOLD_NEW_NAMESPACE_DEF artifact missing"))?;
+    let new_namespace_def: DecentralizedNamespaceDefinition =
+        utils::read_first_message_from_bytes(&new_namespace_bytes)?;
+
+    // Read party ID
+    let party_id_bytes = storage
+        .read_artifact(
+            instance_name,
+            artifact_kinds::CHANGE_THRESHOLD_PARTY_ID,
+            None,
+        )
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("CHANGE_THRESHOLD_PARTY_ID artifact missing"))?;
+    let party_id_raw = String::from_utf8(party_id_bytes)?.trim().to_string();
+    let party_id = CantonId::parse(&party_id_raw)?;
+    tracing::info!("Party ID: {party_id}");
+
+    // Submit DNS proposal first
+    tracing::info!("Submitting DNS change-threshold proposal...");
+    let mut topology_write_client =
+        TopologyManagerWriteServiceClient::connect(config.admin_api_url()).await?;
+
+    let dns_request = tonic::Request::new(AddTransactionsRequest {
+        transactions: vec![dns_transaction],
+        force_changes: vec![],
+        store: Some(StoreId {
+            store: Some(store_id::Store::Synchronizer(Synchronizer {
+                kind: Some(synchronizer::Kind::PhysicalId(synchronizer_id.clone())),
+            })),
+        }),
+        wait_to_become_effective: None,
+    });
+
+    topology_write_client.add_transactions(dns_request).await?;
+    tracing::info!("DNS change-threshold proposal submitted");
+
+    // Wait for the DNS to reflect the NEW threshold. The namespace already
+    // exists (owners are unchanged), so we must poll on the threshold value
+    // itself, not mere existence, or the check passes before the change lands.
+    tracing::info!("Waiting for DNS change-threshold to take effect in topology...");
+    wait_for_dns_in_topology(
+        config,
+        &synchronizer_id,
+        &new_namespace_def.decentralized_namespace,
+        new_namespace_def.threshold,
+    )
+    .await?;
+    tracing::info!("DNS change-threshold confirmed in topology");
+
+    // Submit P2P proposal
+    tracing::info!("Submitting P2P change-threshold proposal...");
+    let p2p_request = tonic::Request::new(AddTransactionsRequest {
+        transactions: vec![p2p_transaction],
+        force_changes: vec![],
+        store: Some(StoreId {
+            store: Some(store_id::Store::Synchronizer(Synchronizer {
+                kind: Some(synchronizer::Kind::PhysicalId(synchronizer_id.clone())),
+            })),
+        }),
+        wait_to_become_effective: None,
+    });
+
+    topology_write_client.add_transactions(p2p_request).await?;
+    tracing::info!("P2P change-threshold proposal submitted");
+
+    // Wait for the P2P mapping to reflect the NEW threshold. The party id is
+    // stable, so — like the DNS above — poll on the threshold value, not mere
+    // existence.
+    tracing::info!("Waiting for P2P change-threshold to take effect in topology...");
+    wait_for_p2p_in_topology(
+        config,
+        &synchronizer_id,
+        &party_id,
+        new_namespace_def.threshold as u32,
+    )
+    .await?;
+    tracing::info!("P2P change-threshold confirmed in topology");
+
+    // Additional wait for topology propagation
+    let propagation_delay = time::Duration::from_secs(TOPOLOGY_PROPAGATION_DELAY_SECS);
+    tracing::info!("Waiting {propagation_delay:?} for Canton to propagate topology updates...");
+    time::sleep(propagation_delay).await;
+
+    tracing::info!("Change-threshold submitted and confirmed successfully");
+    Ok(())
+}
+
+/// Wait until the namespace's head-state threshold equals `expected_threshold`.
+///
+/// A change-threshold run keeps the same owners, so the
+/// `DecentralizedNamespaceDefinition` already exists before submission —
+/// polling on existence alone would return immediately, before the new
+/// threshold has propagated. We poll on the threshold value itself.
+async fn wait_for_dns_in_topology(
+    config: &NodeConfig,
+    synchronizer_id: &str,
+    namespace: &str,
+    expected_threshold: i32,
+) -> Result {
+    let mut topology_read_client =
+        TopologyManagerReadServiceClient::connect(config.admin_api_url()).await?;
+
+    let max_attempts = topology_retry_max_attempts();
+    let retry_delay = time::Duration::from_secs(topology_retry_delay_secs());
+
+    for attempt in 1..=max_attempts {
+        let request = tonic::Request::new(ListDecentralizedNamespaceDefinitionRequest {
+            base_query: Some(BaseQuery {
+                store: Some(StoreId {
+                    store: Some(store_id::Store::Synchronizer(Synchronizer {
+                        kind: Some(synchronizer::Kind::PhysicalId(synchronizer_id.to_string())),
+                    })),
+                }),
+                proposals: false,
+                operation: 0,
+                time_query: Some(base_query::TimeQuery::HeadState(())),
+                filter_signed_key: String::new(),
+                protocol_version: None,
+            }),
+            filter_namespace: namespace.to_string(),
+        });
+
+        let response = topology_read_client
+            .list_decentralized_namespace_definition(request)
+            .await?
+            .into_inner();
+
+        if response.results.iter().any(|r| {
+            r.item
+                .as_ref()
+                .is_some_and(|d| d.threshold == expected_threshold)
+        }) {
+            tracing::info!(
+                "DNS threshold {expected_threshold} confirmed in topology after {attempt} attempt(s)"
+            );
+            return Ok(());
+        }
+
+        if attempt < max_attempts {
+            tracing::debug!(
+                "DNS threshold not yet {expected_threshold}, attempt {attempt}/{max_attempts}, retrying in {retry_delay:?}..."
+            );
+            time::sleep(retry_delay).await;
+        }
+    }
+
+    anyhow::bail!(
+        "DNS threshold did not become {expected_threshold} in topology after {max_attempts} attempts"
+    )
+}
+
+/// Wait until the party mapping's head-state threshold equals
+/// `expected_threshold`. Like the DNS poll, the mapping already exists (the
+/// party id is stable), so we poll on the threshold value, not existence.
+async fn wait_for_p2p_in_topology(
+    config: &NodeConfig,
+    synchronizer_id: &str,
+    party_id: &CantonId,
+    expected_threshold: u32,
+) -> Result {
+    let party_id_str = party_id.to_string();
+    let mut topology_read_client =
+        TopologyManagerReadServiceClient::connect(config.admin_api_url()).await?;
+
+    let max_attempts = topology_retry_max_attempts();
+    let retry_delay = time::Duration::from_secs(topology_retry_delay_secs());
+
+    for attempt in 1..=max_attempts {
+        let request = tonic::Request::new(ListPartyToParticipantRequest {
+            base_query: Some(BaseQuery {
+                store: Some(StoreId {
+                    store: Some(store_id::Store::Synchronizer(Synchronizer {
+                        kind: Some(synchronizer::Kind::PhysicalId(synchronizer_id.to_string())),
+                    })),
+                }),
+                proposals: false,
+                operation: 0,
+                time_query: Some(base_query::TimeQuery::HeadState(())),
+                filter_signed_key: String::new(),
+                protocol_version: None,
+            }),
+            filter_party: party_id_str.clone(),
+            filter_participant: String::new(),
+        });
+
+        let response = topology_read_client
+            .list_party_to_participant(request)
+            .await?
+            .into_inner();
+
+        if response.results.iter().any(|r| {
+            r.item
+                .as_ref()
+                .is_some_and(|p| p.threshold == expected_threshold)
+        }) {
+            tracing::info!(
+                "P2P threshold {expected_threshold} confirmed in topology after {attempt} attempt(s)"
+            );
+            return Ok(());
+        }
+
+        if attempt < max_attempts {
+            tracing::debug!(
+                "P2P threshold not yet {expected_threshold}, attempt {attempt}/{max_attempts}, retrying in {retry_delay:?}..."
+            );
+            time::sleep(retry_delay).await;
+        }
+    }
+
+    anyhow::bail!(
+        "P2P threshold did not become {expected_threshold} in topology after {max_attempts} attempts"
+    )
+}

--- a/crates/decman/src/workflow/mod.rs
+++ b/crates/decman/src/workflow/mod.rs
@@ -1,4 +1,5 @@
 pub mod add_party;
+pub mod change_threshold;
 pub mod contracts;
 pub mod dars;
 pub mod kick;
@@ -34,6 +35,7 @@ use crate::{
 };
 
 pub use add_party::{AddPartyConfig, AddPartyStep};
+pub use change_threshold::{ChangeThresholdConfig, ChangeThresholdStep};
 pub use contracts::{ContractsConfig, ContractsStep};
 pub use dars::{DarsConfig, DarsStep};
 pub use kick::{KickConfig, KickStep};
@@ -48,6 +50,7 @@ pub enum WorkflowType {
     Dars,
     Kick,
     AddParty,
+    ChangeThreshold,
 }
 
 /// Result from a coordinator workflow, optionally containing the created party ID
@@ -67,6 +70,7 @@ pub async fn start_coordinator(
     contracts_config: Option<ContractsConfig>,
     dars_config: Option<DarsConfig>,
     add_party_config: Option<AddPartyConfig>,
+    change_threshold_config: Option<ChangeThresholdConfig>,
     workflow_auth: Option<WorkflowAuth>,
     last_seen: LastSeen,
     instance: Arc<WorkflowInstance>,
@@ -153,6 +157,23 @@ pub async fn start_coordinator(
                 network_config,
                 config,
                 workflow_auth,
+                db,
+                last_seen,
+                instance,
+            )
+            .await?;
+            Ok(CoordinatorResult {
+                created_party_id: None,
+            })
+        }
+        WorkflowType::ChangeThreshold => {
+            let config = change_threshold_config.ok_or_else(|| {
+                anyhow::anyhow!("ChangeThresholdConfig is required for ChangeThreshold workflow")
+            })?;
+            change_threshold::coordinator::start_coordinator(
+                node_config,
+                network_config,
+                config,
                 db,
                 last_seen,
                 instance,
@@ -603,6 +624,66 @@ pub async fn start_peer(
                     tracing::error!("Failed to send kick signatures to coordinator: {e}");
                 }
             }
+            MessageType::SignChangeThreshold => {
+                tracing::info!("Executing: Sign change-threshold proposals");
+                if payload.is_empty() {
+                    tracing::error!(
+                        "No change-threshold proposals payload received from coordinator"
+                    );
+                    continue;
+                }
+
+                let items = match utils::decode_length_prefixed(&payload, 3) {
+                    Ok(items) => items,
+                    Err(e) => {
+                        tracing::error!("Failed to decode SignChangeThreshold payload: {e}");
+                        continue;
+                    }
+                };
+
+                let _change_config: change_threshold::ChangeThresholdConfig =
+                    match serde_json::from_slice(&items[0]) {
+                        Ok(config) => config,
+                        Err(e) => {
+                            tracing::error!("Failed to deserialize change-threshold config: {e}");
+                            continue;
+                        }
+                    };
+
+                let proposal_data = utils::encode_length_prefixed(&[&items[1], &items[2]]);
+                if let Err(e) = change_threshold::sign_proposals(
+                    &node_config,
+                    &db,
+                    &instance_name,
+                    &proposal_data,
+                )
+                .await
+                {
+                    tracing::error!("Step execution failed: {e}");
+                    consecutive_step_failures += 1;
+                    if consecutive_step_failures >= MAX_CONSECUTIVE_STEP_FAILURES {
+                        anyhow::bail!(
+                            "Aborting peer: {MAX_CONSECUTIVE_STEP_FAILURES} consecutive step failures: {e}"
+                        );
+                    }
+                    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+                    continue;
+                }
+                consecutive_step_failures = 0;
+                if let Err(e) =
+                    change_threshold::peer::send_change_threshold_signatures_to_coordinator(
+                        &client,
+                        &db,
+                        &instance_name,
+                        &node_config,
+                    )
+                    .await
+                {
+                    tracing::error!(
+                        "Failed to send change-threshold signatures to coordinator: {e}"
+                    );
+                }
+            }
             MessageType::GenerateAddPartyKeys => {
                 tracing::info!("Executing: Generate add-party keys");
                 let Some(add_party_config) = decode_add_party_config(&payload) else {
@@ -1007,6 +1088,18 @@ fn peer_step_for_command(
                 AddPartyStep::step_total(),
             ))
         }
+        WorkflowKind::ChangeThreshold => {
+            let step = match command {
+                MessageType::SignChangeThreshold => ChangeThresholdStep::SignProposals,
+                MessageType::Disconnect => ChangeThresholdStep::Complete,
+                _ => return None,
+            };
+            Some((
+                step.step_name(),
+                step.step_index(),
+                ChangeThresholdStep::step_total(),
+            ))
+        }
     }
 }
 
@@ -1100,6 +1193,11 @@ mod tests {
             (WorkflowKind::AddParty, MessageType::ClearOnboardingFlag),
             (WorkflowKind::AddParty, MessageType::SignClearOnboarding),
             (WorkflowKind::AddParty, MessageType::Disconnect),
+            (
+                WorkflowKind::ChangeThreshold,
+                MessageType::SignChangeThreshold,
+            ),
+            (WorkflowKind::ChangeThreshold, MessageType::Disconnect),
         ];
         for (kind, command) in mapped {
             assert!(
@@ -1115,6 +1213,7 @@ mod tests {
             WorkflowKind::Contracts,
             WorkflowKind::Dars,
             WorkflowKind::AddParty,
+            WorkflowKind::ChangeThreshold,
         ] {
             assert!(peer_step_for_command(kind, MessageType::Wait).is_none());
             assert!(peer_step_for_command(kind, MessageType::Ping).is_none());
@@ -1127,6 +1226,12 @@ mod tests {
         assert!(peer_step_for_command(WorkflowKind::Dars, MessageType::SignSubmissions).is_none());
         assert!(peer_step_for_command(WorkflowKind::AddParty, MessageType::GenerateKeys).is_none());
         assert!(peer_step_for_command(WorkflowKind::Kick, MessageType::SignAddParty).is_none());
+        assert!(
+            peer_step_for_command(WorkflowKind::ChangeThreshold, MessageType::SignKick).is_none()
+        );
+        assert!(
+            peer_step_for_command(WorkflowKind::Kick, MessageType::SignChangeThreshold).is_none()
+        );
     }
 
     #[test]

--- a/crates/decman/src/workflow/onboarding/config.rs
+++ b/crates/decman/src/workflow/onboarding/config.rs
@@ -9,14 +9,21 @@ pub struct OnboardingConfig {
     pub party_id_prefix: String,
     /// Workflow instance name for directory organization (e.g., "xyz-network-creation")
     pub instance_name: String,
+    /// Operator-chosen initial threshold. `None` means "use the default
+    /// majority algorithm" (`ceil(owner_count / 2)`, min 1), computed by the
+    /// coordinator once the owner set is known. Defaults to `None` for configs
+    /// persisted before this field existed.
+    #[serde(default)]
+    pub threshold: Option<i32>,
     _p: PhantomData<()>,
 }
 
 impl OnboardingConfig {
-    pub fn new(party_id_prefix: String, instance_name: String) -> Self {
+    pub fn new(party_id_prefix: String, instance_name: String, threshold: Option<i32>) -> Self {
         Self {
             party_id_prefix,
             instance_name,
+            threshold,
             _p: PhantomData,
         }
     }

--- a/crates/decman/src/workflow/onboarding/steps/proposals/create.rs
+++ b/crates/decman/src/workflow/onboarding/steps/proposals/create.rs
@@ -141,11 +141,22 @@ pub async fn create_proposals(
         );
     }
 
-    // Step 5: Calculate threshold (majority)
-    let threshold = namespaces.len().div_ceil(2).max(1) as u32;
+    // Step 5: Determine threshold. Use the operator-configured value when set
+    // (validated against the resolved owner count — the topology is the source
+    // of truth); otherwise fall back to the default majority algorithm. The
+    // frontend pre-computes this same default, so an untouched field arrives
+    // here carrying the majority value.
+    let owner_count = namespaces.len();
+    let threshold = match onboarding_config.threshold {
+        Some(t) if (1..=owner_count as i32).contains(&t) => t as u32,
+        Some(t) => {
+            anyhow::bail!("configured threshold {t} out of range 1..={owner_count} (owner count)",)
+        }
+        None => owner_count.div_ceil(2).max(1) as u32,
+    };
     tracing::info!(
-        "Using threshold {threshold} for {count} participants",
-        count = namespaces.len()
+        "Using threshold {threshold} for {owner_count} participants (configured: {configured:?})",
+        configured = onboarding_config.threshold,
     );
 
     // Step 6: Compute decentralized namespace

--- a/crates/decman/src/workflow/storage.rs
+++ b/crates/decman/src/workflow/storage.rs
@@ -105,6 +105,26 @@ pub mod artifact_kinds {
     pub const ADD_PARTY_CLEAR_PROPOSAL: &str = "add_party_clear_proposal";
     /// Per-peer signed clearing proposal — single length-prefixed proto.
     pub const SIGNED_ADD_PARTY_CLEAR: &str = "signed_add_party_clear";
+
+    // Change-threshold (workflow_artifacts during a run)
+    /// Current decentralized namespace definition, exported in ExportState.
+    /// Length-prefixed proto.
+    pub const CHANGE_THRESHOLD_NAMESPACE_DEF: &str = "change_threshold_namespace_def";
+    /// Re-issued `DecentralizedNamespaceDefinition` (same owners, new
+    /// threshold) — used by submit to poll the topology. Length-prefixed proto.
+    pub const CHANGE_THRESHOLD_NEW_NAMESPACE_DEF: &str = "change_threshold_new_namespace_def";
+    /// Unsigned DNS threshold-change proposal (`SignedTopologyTransaction`)
+    /// produced by the coordinator in CreateProposals. Length-prefixed proto.
+    pub const CHANGE_THRESHOLD_DNS_PROPOSAL: &str = "change_threshold_dns_proposal";
+    /// Unsigned P2P threshold-change proposal produced alongside the DNS one.
+    pub const CHANGE_THRESHOLD_P2P_PROPOSAL: &str = "change_threshold_p2p_proposal";
+    /// Per-peer signed DNS threshold-change proposal — single length-prefixed
+    /// proto.
+    pub const SIGNED_CHANGE_THRESHOLD_DNS: &str = "signed_change_threshold_dns";
+    /// Per-peer signed P2P threshold-change proposal — same shape.
+    pub const SIGNED_CHANGE_THRESHOLD_P2P: &str = "signed_change_threshold_p2p";
+    /// Full party id (plaintext) — used by submit to poll the P2P mapping.
+    pub const CHANGE_THRESHOLD_PARTY_ID: &str = "change_threshold_party_id";
 }
 
 /// Identity-table artefact kinds. These survive the originating workflow run's

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -24,8 +24,8 @@ result = "1220" + hex(hash)   // Multihash SHA-256 prefix
 Key properties:
 - The hash is **immutable** -- it is computed once from the initial set of owners and never changes
 - Owners are sorted lexicographically before hashing for determinism
-- The threshold (minimum signers required) is `ceil(n/2)` by default; for even `n` this is a bare majority
-- Adding or removing members updates the `DecentralizedNamespaceDefinition` mapping but does not change the namespace hash itself
+- The threshold (minimum signers required) defaults to `ceil(n/2)` (a bare majority for even `n`), is configurable when the party is created, and can be changed later via the change-threshold workflow
+- Adding or removing members, or changing the threshold, updates the `DecentralizedNamespaceDefinition` mapping but does not change the namespace hash itself
 
 ### PartyToParticipant (P2P)
 
@@ -37,11 +37,11 @@ The PartyToParticipant topology mapping connects a decentralized party to its ho
 
 ### Threshold Model
 
-The system uses a majority threshold for both topology changes and governance actions:
+The system defaults to a majority threshold for both topology changes and governance actions:
 
 | Operation | Threshold |
 |-----------|-----------|
-| Topology changes (DNS/P2P) | `ceil(n/2)` of namespace owners must sign (bare majority for even `n`) |
+| Topology changes (DNS/P2P) | `ceil(n/2)` of namespace owners must sign by default (bare majority for even `n`); set at creation and adjustable via the change-threshold workflow |
 | Governance actions | Configurable per `GovernanceRules` or `VaultGovernanceRules` contract |
 
 ### Key Types


### PR DESCRIPTION
New ChangeThreshold workflow to change a dec party's signing threshold without touching membership. It re-issues the DNS and P2P mappings with the new threshold and gets a quorum of the current owners to sign (kick minus the removal).

Also makes the initial threshold configurable at party creation. The onboarding dialog pre-fills the majority default (ceil(owners/2)) and lets you override it; if left off, the server falls back to the same algorithm, so existing callers are unaffected.

Wired across the usual layers: noise message types, server handlers/routes/resume, invite dispatch, CLI cancel arm, a ChangeThreshold dialog plus a "Change Threshold" button on the party page, generated types. No DB migration (reuses the existing new/previous threshold fields).

The threshold change covers both the namespace threshold and the P2P confirmation threshold, same as kick.

Testing:
- clippy --all-targets and frontend tsc both clean
- unit tests for the step machine and noise round-trip
- IT phase change_threshold (2 -> 1) wired after add_party in governance_workflows

decman bumped to 1.2.1.
