### PR TITLE
refact(workflow): dedup shared topology-workflow step helpers

### DIFF
--- a/crates/decman/src/workflow/add_party/steps/clear_onboarding.rs
+++ b/crates/decman/src/workflow/add_party/steps/clear_onboarding.rs
@@ -7,7 +7,7 @@ use canton_proto_rs::com::digitalasset::canton::{
     },
     protocol::v30::{PartyToParticipant, SignedTopologyTransaction, topology_mapping},
     topology::admin::v30::{
-        SignTransactionsRequest, StoreId, Synchronizer, store_id, synchronizer,
+        SignTransactionsRequest,
         topology_manager_write_service_client::TopologyManagerWriteServiceClient,
     },
 };
@@ -20,16 +20,12 @@ use crate::{
     error::Result,
     utils,
     workflow::{
-        add_party::{
-            AddPartyConfig,
-            steps::{
-                export_state::{encode_length_prefixed_message, fetch_p2p_mapping},
-                proposals::create::proposal_request,
-                proposals::submit::add_transactions_request,
-            },
-        },
+        add_party::{AddPartyConfig, steps::proposals::create::proposal_request},
         storage::{WorkflowStorage, artifact_kinds},
-        topology::{authorize_with_topology_retry, sign_transactions_with_topology_retry},
+        topology::{
+            add_transactions_request, authorize_with_topology_retry, dedupe_signatures,
+            fetch_p2p_mapping, sign_transactions_with_topology_retry, synchronizer_store_id,
+        },
     },
 };
 
@@ -159,7 +155,7 @@ pub async fn author_clear_proposal(
 ) -> Result<Option<Vec<u8>>> {
     Ok(create_clear_proposal(config, add_party_config)
         .await?
-        .map(|transaction| encode_length_prefixed_message(&transaction)))
+        .map(|transaction| utils::encode_length_prefixed_message(&transaction)))
 }
 
 /// Build the onboarding-flag clearing proposal — the current P2P mapping
@@ -226,11 +222,7 @@ pub async fn sign_clear_proposal(
     let request = SignTransactionsRequest {
         transactions: vec![transaction],
         signed_by: vec![],
-        store: Some(StoreId {
-            store: Some(store_id::Store::Synchronizer(Synchronizer {
-                kind: Some(synchronizer::Kind::PhysicalId(synchronizer_id)),
-            })),
-        }),
+        store: Some(synchronizer_store_id(&synchronizer_id)),
         force_flags: vec![],
     };
 
@@ -248,7 +240,7 @@ pub async fn sign_clear_proposal(
             instance_name,
             artifact_kinds::SIGNED_ADD_PARTY_CLEAR,
             Some(&node_id),
-            &encode_length_prefixed_message(&response.transactions[0]),
+            &utils::encode_length_prefixed_message(&response.transactions[0]),
         )
         .await?;
 
@@ -304,11 +296,7 @@ pub async fn submit_clear_proposal(
         SignTransactionsRequest {
             transactions: vec![transaction.clone()],
             signed_by: vec![],
-            store: Some(StoreId {
-                store: Some(store_id::Store::Synchronizer(Synchronizer {
-                    kind: Some(synchronizer::Kind::PhysicalId(synchronizer_id.clone())),
-                })),
-            }),
+            store: Some(synchronizer_store_id(&synchronizer_id)),
             force_flags: vec![],
         },
         "add-party-clear coordinator",
@@ -318,7 +306,7 @@ pub async fn submit_clear_proposal(
         transaction.signatures.extend(coordinator_signed.signatures);
     }
 
-    super::proposals::submit::dedupe_signatures(&mut transaction);
+    dedupe_signatures(&mut transaction);
 
     let mut topology_write_client =
         TopologyManagerWriteServiceClient::connect(config.admin_api_url()).await?;

--- a/crates/decman/src/workflow/add_party/steps/export_state.rs
+++ b/crates/decman/src/workflow/add_party/steps/export_state.rs
@@ -1,23 +1,13 @@
-use bytes::{BufMut, BytesMut};
-use canton_proto_rs::com::digitalasset::canton::{
-    protocol::v30::{DecentralizedNamespaceDefinition, PartyToParticipant},
-    topology::admin::v30::{
-        BaseQuery, ListDecentralizedNamespaceDefinitionRequest, ListPartyToParticipantRequest,
-        StoreId, Synchronizer, base_query, store_id, synchronizer,
-        topology_manager_read_service_client::TopologyManagerReadServiceClient,
-    },
-};
-use prost::Message;
 use sqlx::SqlitePool;
 
 use crate::{
-    canton_id::CantonId,
     config::NodeConfig,
     error::Result,
     utils,
     workflow::{
         add_party::{AddPartyConfig, steps::generate_keys::current_ledger_offset},
         storage::{WorkflowStorage, artifact_kinds},
+        topology,
     },
 };
 
@@ -48,7 +38,7 @@ pub async fn export_state(
 
     let namespace_hex = add_party_config.decentralized_party_id.namespace.to_hex();
     let namespace_def =
-        fetch_namespace_definition(config, &synchronizer_id, &namespace_hex).await?;
+        topology::fetch_namespace_definition(config, &synchronizer_id, &namespace_hex).await?;
 
     tracing::info!(
         "Found namespace with {count} owners, threshold {threshold}",
@@ -57,7 +47,7 @@ pub async fn export_state(
     );
 
     let party_id = &add_party_config.decentralized_party_id;
-    let p2p_mapping = fetch_p2p_mapping(config, &synchronizer_id, party_id).await?;
+    let p2p_mapping = topology::fetch_p2p_mapping(config, &synchronizer_id, party_id).await?;
 
     let new_participant = &add_party_config.new_participant_id;
     if p2p_mapping
@@ -77,7 +67,7 @@ pub async fn export_state(
         );
     }
 
-    let namespace_bytes = encode_length_prefixed_message(&namespace_def);
+    let namespace_bytes = utils::encode_length_prefixed_message(&namespace_def);
     storage
         .write_artifact(
             instance_name,
@@ -109,88 +99,4 @@ pub async fn export_state(
 
     tracing::info!("Add-party state exported successfully");
     Ok(())
-}
-
-/// Fetch the current `DecentralizedNamespaceDefinition` from the synchronizer
-/// head state.
-pub(crate) async fn fetch_namespace_definition(
-    config: &NodeConfig,
-    synchronizer_id: &str,
-    namespace_hex: &str,
-) -> Result<DecentralizedNamespaceDefinition> {
-    let mut topology_read_client =
-        TopologyManagerReadServiceClient::connect(config.admin_api_url()).await?;
-
-    let request = tonic::Request::new(ListDecentralizedNamespaceDefinitionRequest {
-        base_query: Some(head_state_query(synchronizer_id)),
-        filter_namespace: namespace_hex.to_string(),
-    });
-
-    let response = topology_read_client
-        .list_decentralized_namespace_definition(request)
-        .await?
-        .into_inner();
-
-    response
-        .results
-        .first()
-        .and_then(|r| r.item.as_ref())
-        .cloned()
-        .ok_or_else(|| anyhow::anyhow!("Namespace {namespace_hex} not found in topology"))
-}
-
-/// Fetch the party's current `PartyToParticipant` mapping from the
-/// synchronizer head state.
-pub(crate) async fn fetch_p2p_mapping(
-    config: &NodeConfig,
-    synchronizer_id: &str,
-    party_id: &CantonId,
-) -> Result<PartyToParticipant> {
-    let mut topology_read_client =
-        TopologyManagerReadServiceClient::connect(config.admin_api_url()).await?;
-
-    let request = tonic::Request::new(ListPartyToParticipantRequest {
-        base_query: Some(head_state_query(synchronizer_id)),
-        filter_party: party_id.to_string(),
-        filter_participant: String::new(),
-    });
-
-    let response = topology_read_client
-        .list_party_to_participant(request)
-        .await?
-        .into_inner();
-
-    response
-        .results
-        .first()
-        .and_then(|r| r.item.as_ref())
-        .cloned()
-        .ok_or_else(|| anyhow::anyhow!("No P2P mapping found for party {party_id}"))
-}
-
-/// A head-state `BaseQuery` against the synchronizer store — the boilerplate
-/// every topology read in this workflow shares.
-pub(crate) fn head_state_query(synchronizer_id: &str) -> BaseQuery {
-    BaseQuery {
-        store: Some(StoreId {
-            store: Some(store_id::Store::Synchronizer(Synchronizer {
-                kind: Some(synchronizer::Kind::PhysicalId(synchronizer_id.to_string())),
-            })),
-        }),
-        proposals: false,
-        operation: 0,
-        time_query: Some(base_query::TimeQuery::HeadState(())),
-        filter_signed_key: String::new(),
-        protocol_version: None,
-    }
-}
-
-/// Encode a protobuf message as `varint(len)||proto`, the storage framing
-/// every artefact reader in this codebase expects.
-pub(crate) fn encode_length_prefixed_message<M: Message>(message: &M) -> Vec<u8> {
-    let encoded = message.encode_to_vec();
-    let mut buffer = BytesMut::new();
-    prost::encoding::encode_varint(encoded.len() as u64, &mut buffer);
-    buffer.put_slice(&encoded);
-    buffer.to_vec()
 }

--- a/crates/decman/src/workflow/add_party/steps/proposals/create.rs
+++ b/crates/decman/src/workflow/add_party/steps/proposals/create.rs
@@ -5,10 +5,7 @@ use canton_proto_rs::com::digitalasset::canton::{
         party_to_participant::{HostingParticipant, hosting_participant},
         topology_mapping,
     },
-    topology::admin::v30::{
-        AuthorizeRequest, ForceFlag, StoreId, Synchronizer, authorize_request, store_id,
-        synchronizer,
-    },
+    topology::admin::v30::{AuthorizeRequest, ForceFlag, authorize_request},
 };
 use sqlx::SqlitePool;
 
@@ -17,13 +14,10 @@ use crate::{
     error::Result,
     utils,
     workflow::{
-        add_party::{
-            AddPartyConfig,
-            steps::export_state::{encode_length_prefixed_message, fetch_p2p_mapping},
-        },
+        add_party::AddPartyConfig,
         onboarding::steps::proposals::create::decode_keys_payload,
         storage::{WorkflowStorage, artifact_kinds},
-        topology::authorize_with_topology_retry,
+        topology,
     },
 };
 
@@ -108,7 +102,7 @@ pub async fn create_proposals(
 
     let synchronizer_id = utils::get_synchronizer_id(config).await?;
     let party_id = &add_party_config.decentralized_party_id;
-    let current_p2p = fetch_p2p_mapping(config, &synchronizer_id, party_id).await?;
+    let current_p2p = topology::fetch_p2p_mapping(config, &synchronizer_id, party_id).await?;
 
     tracing::info!(
         "Current P2P mapping has {count} participant(s)",
@@ -148,7 +142,7 @@ pub async fn create_proposals(
     };
 
     tracing::info!("Creating DNS add-party proposal...");
-    let dns_response = authorize_with_topology_retry(
+    let dns_response = topology::authorize_with_topology_retry(
         config,
         proposal_request(
             &synchronizer_id,
@@ -162,7 +156,7 @@ pub async fn create_proposals(
         .ok_or_else(|| anyhow::anyhow!("No DNS transaction returned"))?;
 
     tracing::info!("Creating P2P add-party proposal...");
-    let p2p_response = authorize_with_topology_retry(
+    let p2p_response = topology::authorize_with_topology_retry(
         config,
         proposal_request(
             &synchronizer_id,
@@ -180,7 +174,7 @@ pub async fn create_proposals(
             instance_name,
             artifact_kinds::ADD_PARTY_DNS_PROPOSAL,
             None,
-            &encode_length_prefixed_message(&dns_transaction),
+            &utils::encode_length_prefixed_message(&dns_transaction),
         )
         .await?;
     storage
@@ -188,7 +182,7 @@ pub async fn create_proposals(
             instance_name,
             artifact_kinds::ADD_PARTY_P2P_PROPOSAL,
             None,
-            &encode_length_prefixed_message(&p2p_transaction),
+            &utils::encode_length_prefixed_message(&p2p_transaction),
         )
         .await?;
     storage
@@ -196,7 +190,7 @@ pub async fn create_proposals(
             instance_name,
             artifact_kinds::ADD_PARTY_NEW_NAMESPACE_DEF,
             None,
-            &encode_length_prefixed_message(&new_namespace_def),
+            &utils::encode_length_prefixed_message(&new_namespace_def),
         )
         .await?;
 
@@ -226,11 +220,7 @@ pub(crate) fn proposal_request(
         must_fully_authorize: false,
         force_changes: vec![ForceFlag::AllowUnvalidatedSigningKeys as i32],
         signed_by: vec![],
-        store: Some(StoreId {
-            store: Some(store_id::Store::Synchronizer(Synchronizer {
-                kind: Some(synchronizer::Kind::PhysicalId(synchronizer_id.to_string())),
-            })),
-        }),
+        store: Some(topology::synchronizer_store_id(synchronizer_id)),
         wait_to_become_effective: None,
     }
 }

--- a/crates/decman/src/workflow/add_party/steps/proposals/sign.rs
+++ b/crates/decman/src/workflow/add_party/steps/proposals/sign.rs
@@ -1,20 +1,9 @@
-use canton_proto_rs::com::digitalasset::canton::{
-    protocol::v30::SignedTopologyTransaction,
-    topology::admin::v30::{
-        SignTransactionsRequest, StoreId, Synchronizer, store_id, synchronizer,
-    },
-};
 use sqlx::SqlitePool;
 
 use crate::{
     config::NodeConfig,
     error::Result,
-    utils,
-    workflow::{
-        add_party::steps::export_state::encode_length_prefixed_message,
-        storage::{WorkflowStorage, artifact_kinds},
-        topology::sign_transactions_with_topology_retry,
-    },
+    workflow::{storage::artifact_kinds, topology},
 };
 
 /// All-peer step: sign both add-party proposals.
@@ -25,63 +14,23 @@ use crate::{
 /// host the party (Canton auto-selects the appropriate keys).
 ///
 /// `proposal_data` is the `[dns, p2p]` pair from the coordinator (the config
-/// item was already stripped by the peer loop). Persists per-peer
-/// `SIGNED_ADD_PARTY_DNS` / `SIGNED_ADD_PARTY_P2P` artefacts, each a single
-/// `varint(len)||proto` blob.
+/// item was already stripped by the peer loop). Delegates to
+/// [`topology::sign_dns_p2p_proposals`], persisting the per-peer results as
+/// `SIGNED_ADD_PARTY_DNS` / `SIGNED_ADD_PARTY_P2P`.
 pub async fn sign_proposals(
     config: &NodeConfig,
     storage: &SqlitePool,
     instance_name: &str,
     proposal_data: &[u8],
 ) -> Result {
-    tracing::info!("Signing add-party proposals...");
-
-    let node_id = config.participant_id().to_string();
-    let synchronizer_id = utils::get_synchronizer_id(config).await?;
-
-    let items = utils::decode_length_prefixed(proposal_data, 2)?;
-    let dns_transaction: SignedTopologyTransaction =
-        utils::read_first_message_from_bytes(&items[0])?;
-    let p2p_transaction: SignedTopologyTransaction =
-        utils::read_first_message_from_bytes(&items[1])?;
-
-    let request = SignTransactionsRequest {
-        transactions: vec![dns_transaction, p2p_transaction],
-        signed_by: vec![],
-        store: Some(StoreId {
-            store: Some(store_id::Store::Synchronizer(Synchronizer {
-                kind: Some(synchronizer::Kind::PhysicalId(synchronizer_id)),
-            })),
-        }),
-        force_flags: vec![],
-    };
-
-    let response = sign_transactions_with_topology_retry(config, request, "add-party").await?;
-
-    if response.transactions.len() != 2 {
-        anyhow::bail!(
-            "Expected 2 signed transactions (DNS and P2P), got {count}",
-            count = response.transactions.len()
-        );
-    }
-
-    storage
-        .write_artifact(
-            instance_name,
-            artifact_kinds::SIGNED_ADD_PARTY_DNS,
-            Some(&node_id),
-            &encode_length_prefixed_message(&response.transactions[0]),
-        )
-        .await?;
-    storage
-        .write_artifact(
-            instance_name,
-            artifact_kinds::SIGNED_ADD_PARTY_P2P,
-            Some(&node_id),
-            &encode_length_prefixed_message(&response.transactions[1]),
-        )
-        .await?;
-
-    tracing::info!("Add-party proposals signed successfully");
-    Ok(())
+    topology::sign_dns_p2p_proposals(
+        config,
+        storage,
+        instance_name,
+        proposal_data,
+        "add-party",
+        artifact_kinds::SIGNED_ADD_PARTY_DNS,
+        artifact_kinds::SIGNED_ADD_PARTY_P2P,
+    )
+    .await
 }

--- a/crates/decman/src/workflow/add_party/steps/proposals/submit.rs
+++ b/crates/decman/src/workflow/add_party/steps/proposals/submit.rs
@@ -1,29 +1,17 @@
-use std::collections::{HashMap, HashSet};
-
-use canton_proto_rs::com::digitalasset::canton::{
-    protocol::v30::{DecentralizedNamespaceDefinition, SignedTopologyTransaction},
-    topology::admin::v30::{
-        AddTransactionsRequest, StoreId, Synchronizer, store_id, synchronizer,
-        topology_manager_write_service_client::TopologyManagerWriteServiceClient,
-    },
-};
+use canton_proto_rs::com::digitalasset::canton::protocol::v30::DecentralizedNamespaceDefinition;
 use sqlx::SqlitePool;
 use tokio::time;
 
 use crate::{
     canton_id::CantonId,
     config::NodeConfig,
-    consts::{
-        TOPOLOGY_PROPAGATION_DELAY_SECS, topology_retry_delay_secs, topology_retry_max_attempts,
-    },
+    consts::{topology_retry_delay_secs, topology_retry_max_attempts},
     error::Result,
     utils,
     workflow::{
-        add_party::{
-            AddPartyConfig,
-            steps::export_state::{fetch_namespace_definition, fetch_p2p_mapping},
-        },
+        add_party::AddPartyConfig,
         storage::{WorkflowStorage, artifact_kinds},
+        topology,
     },
 };
 
@@ -31,10 +19,10 @@ use crate::{
 /// proposals and submit them — DNS first, then P2P — waiting after each for
 /// the updated mapping to land in the synchronizer head state.
 ///
-/// Unlike kick (where polling for mere existence suffices because the
-/// mapping briefly disappears), both mappings already exist here, so the
-/// waits check the COUNTS: DNS until the owner set has grown to the new
-/// size, P2P until the new participant appears.
+/// Unlike kick (where polling for mere existence suffices because the mapping
+/// briefly disappears), both mappings already exist here, so the waits check
+/// membership: DNS until the new member's fingerprint joins the owner set, P2P
+/// until the new participant appears.
 pub async fn submit_proposals(
     config: &NodeConfig,
     storage: &SqlitePool,
@@ -45,66 +33,23 @@ pub async fn submit_proposals(
 
     let synchronizer_id = utils::get_synchronizer_id(config).await?;
 
-    let dns_bytes = storage
-        .read_artifact(instance_name, artifact_kinds::ADD_PARTY_DNS_PROPOSAL, None)
-        .await?
-        .ok_or_else(|| anyhow::anyhow!("ADD_PARTY_DNS_PROPOSAL artifact missing"))?;
-    let mut dns_transaction: SignedTopologyTransaction =
-        utils::read_first_message_from_bytes(&dns_bytes)?;
-
-    let p2p_bytes = storage
-        .read_artifact(instance_name, artifact_kinds::ADD_PARTY_P2P_PROPOSAL, None)
-        .await?
-        .ok_or_else(|| anyhow::anyhow!("ADD_PARTY_P2P_PROPOSAL artifact missing"))?;
-    let mut p2p_transaction: SignedTopologyTransaction =
-        utils::read_first_message_from_bytes(&p2p_bytes)?;
-
-    let signed_dns = storage
-        .list_artifacts(instance_name, artifact_kinds::SIGNED_ADD_PARTY_DNS)
-        .await?;
-    let signed_p2p: HashMap<String, Vec<u8>> = storage
-        .list_artifacts(instance_name, artifact_kinds::SIGNED_ADD_PARTY_P2P)
-        .await?
-        .into_iter()
-        .collect();
-
-    tracing::info!(
-        "Found signed proposals from {count} peer(s)",
-        count = signed_dns.len()
-    );
-    if signed_dns.len() != signed_p2p.len() {
-        anyhow::bail!(
-            "Mismatched signed proposal counts: {dns} DNS vs {p2p} P2P",
-            dns = signed_dns.len(),
-            p2p = signed_p2p.len()
-        );
-    }
-
-    for (peer_id, dns_signed_bytes) in &signed_dns {
-        tracing::info!("Aggregating signatures from peer {peer_id}");
-        let dns_signed: SignedTopologyTransaction =
-            utils::read_first_message_from_bytes(dns_signed_bytes)?;
-        let p2p_signed_bytes = signed_p2p
-            .get(peer_id)
-            .ok_or_else(|| anyhow::anyhow!("Peer {peer_id} signed DNS but not P2P"))?;
-        let p2p_signed: SignedTopologyTransaction =
-            utils::read_first_message_from_bytes(p2p_signed_bytes)?;
-
-        dns_transaction.signatures.extend(dns_signed.signatures);
-        p2p_transaction.signatures.extend(p2p_signed.signatures);
-    }
+    let (mut dns_transaction, mut p2p_transaction) = topology::aggregate_dns_p2p_signatures(
+        storage,
+        instance_name,
+        topology::DnsP2pArtifactKinds {
+            dns_proposal: artifact_kinds::ADD_PARTY_DNS_PROPOSAL,
+            p2p_proposal: artifact_kinds::ADD_PARTY_P2P_PROPOSAL,
+            signed_dns: artifact_kinds::SIGNED_ADD_PARTY_DNS,
+            signed_p2p: artifact_kinds::SIGNED_ADD_PARTY_P2P,
+        },
+    )
+    .await?;
 
     // Dedupe by signing fingerprint: the coordinator's own signature is
     // already on the original proposals, and a retried peer may have signed
     // twice. Canton rejects duplicate signatures on a submitted transaction.
-    dedupe_signatures(&mut dns_transaction);
-    dedupe_signatures(&mut p2p_transaction);
-
-    tracing::info!(
-        "Final DNS proposal has {dns} signature(s), P2P has {p2p}",
-        dns = dns_transaction.signatures.len(),
-        p2p = p2p_transaction.signatures.len()
-    );
+    topology::dedupe_signatures(&mut dns_transaction);
+    topology::dedupe_signatures(&mut p2p_transaction);
 
     let new_namespace_bytes = storage
         .read_artifact(
@@ -117,73 +62,33 @@ pub async fn submit_proposals(
     let new_namespace_def: DecentralizedNamespaceDefinition =
         utils::read_first_message_from_bytes(&new_namespace_bytes)?;
 
-    let mut topology_write_client =
-        TopologyManagerWriteServiceClient::connect(config.admin_api_url()).await?;
-
-    tracing::info!("Submitting DNS add-party proposal...");
-    topology_write_client
-        .add_transactions(tonic::Request::new(add_transactions_request(
-            &synchronizer_id,
-            dns_transaction,
-        )))
-        .await?;
-
-    tracing::info!("Waiting for the grown DNS owner set to appear in topology...");
-    wait_for_owners(
+    topology::submit_dns_then_p2p(
         config,
         &synchronizer_id,
-        &new_namespace_def.decentralized_namespace,
-        &new_namespace_def.owners,
+        "add-party",
+        dns_transaction,
+        p2p_transaction,
+        || {
+            wait_for_owners(
+                config,
+                &synchronizer_id,
+                &new_namespace_def.decentralized_namespace,
+                &new_namespace_def.owners,
+            )
+        },
+        || {
+            wait_for_participant(
+                config,
+                &synchronizer_id,
+                &add_party_config.decentralized_party_id,
+                &add_party_config.new_participant_id,
+            )
+        },
     )
     .await?;
-
-    tracing::info!("Submitting P2P add-party proposal...");
-    topology_write_client
-        .add_transactions(tonic::Request::new(add_transactions_request(
-            &synchronizer_id,
-            p2p_transaction,
-        )))
-        .await?;
-
-    tracing::info!("Waiting for the new participant to appear in the P2P mapping...");
-    wait_for_participant(
-        config,
-        &synchronizer_id,
-        &add_party_config.decentralized_party_id,
-        &add_party_config.new_participant_id,
-    )
-    .await?;
-
-    let propagation_delay = time::Duration::from_secs(TOPOLOGY_PROPAGATION_DELAY_SECS);
-    tracing::info!("Waiting {propagation_delay:?} for Canton to propagate topology updates...");
-    time::sleep(propagation_delay).await;
 
     tracing::info!("Add-party proposals submitted and confirmed successfully");
     Ok(())
-}
-
-/// Drop duplicate signatures, keeping the first per signing fingerprint.
-pub(crate) fn dedupe_signatures(transaction: &mut SignedTopologyTransaction) {
-    let mut seen = HashSet::new();
-    transaction
-        .signatures
-        .retain(|sig| seen.insert(sig.signed_by.clone()));
-}
-
-pub(crate) fn add_transactions_request(
-    synchronizer_id: &str,
-    transaction: SignedTopologyTransaction,
-) -> AddTransactionsRequest {
-    AddTransactionsRequest {
-        transactions: vec![transaction],
-        force_changes: vec![],
-        store: Some(StoreId {
-            store: Some(store_id::Store::Synchronizer(Synchronizer {
-                kind: Some(synchronizer::Kind::PhysicalId(synchronizer_id.to_string())),
-            })),
-        }),
-        wait_to_become_effective: None,
-    }
 }
 
 /// Poll the synchronizer head state until the decentralized namespace lists
@@ -202,7 +107,8 @@ async fn wait_for_owners(
     let retry_delay = time::Duration::from_secs(topology_retry_delay_secs());
 
     for attempt in 1..=max_attempts {
-        let namespace_def = fetch_namespace_definition(config, synchronizer_id, namespace).await?;
+        let namespace_def =
+            topology::fetch_namespace_definition(config, synchronizer_id, namespace).await?;
         let present = expected_owners
             .iter()
             .filter(|owner| namespace_def.owners.contains(owner))
@@ -243,7 +149,7 @@ async fn wait_for_participant(
     let participant_str = participant.to_string();
 
     for attempt in 1..=max_attempts {
-        let p2p = fetch_p2p_mapping(config, synchronizer_id, party_id).await?;
+        let p2p = topology::fetch_p2p_mapping(config, synchronizer_id, party_id).await?;
         if p2p
             .participants
             .iter()

--- a/crates/decman/src/workflow/change_threshold/steps/proposals/create.rs
+++ b/crates/decman/src/workflow/change_threshold/steps/proposals/create.rs
@@ -4,9 +4,7 @@ use canton_proto_rs::com::digitalasset::canton::{
         topology_mapping,
     },
     topology::admin::v30::{
-        AuthorizeRequest, BaseQuery, ListPartyToParticipantRequest, StoreId, Synchronizer,
-        authorize_request, base_query, store_id, synchronizer,
-        topology_manager_read_service_client::TopologyManagerReadServiceClient,
+        AuthorizeRequest, authorize_request,
         topology_manager_write_service_client::TopologyManagerWriteServiceClient,
     },
 };
@@ -20,6 +18,7 @@ use crate::{
     workflow::{
         change_threshold::ChangeThresholdConfig,
         storage::{WorkflowStorage, artifact_kinds},
+        topology,
     },
 };
 
@@ -89,7 +88,7 @@ pub async fn create_proposals(
     let synchronizer_id = utils::get_synchronizer_id(config).await?;
     tracing::debug!("Using synchronizer ID: {synchronizer_id}");
 
-    let current_p2p = get_current_p2p_mapping(config, &synchronizer_id, &party_id).await?;
+    let current_p2p = topology::fetch_p2p_mapping(config, &synchronizer_id, &party_id).await?;
     tracing::info!(
         "Current P2P mapping has {count} participant(s), threshold {threshold}",
         count = current_p2p.participants.len(),
@@ -124,11 +123,7 @@ pub async fn create_proposals(
         must_fully_authorize: false,
         force_changes: vec![],
         signed_by: vec![],
-        store: Some(StoreId {
-            store: Some(store_id::Store::Synchronizer(Synchronizer {
-                kind: Some(synchronizer::Kind::PhysicalId(synchronizer_id.clone())),
-            })),
-        }),
+        store: Some(topology::synchronizer_store_id(&synchronizer_id)),
         wait_to_become_effective: None,
     });
 
@@ -152,11 +147,7 @@ pub async fn create_proposals(
         must_fully_authorize: false,
         force_changes: vec![],
         signed_by: vec![],
-        store: Some(StoreId {
-            store: Some(store_id::Store::Synchronizer(Synchronizer {
-                kind: Some(synchronizer::Kind::PhysicalId(synchronizer_id.clone())),
-            })),
-        }),
+        store: Some(topology::synchronizer_store_id(&synchronizer_id)),
         wait_to_become_effective: None,
     });
 
@@ -213,45 +204,4 @@ pub async fn create_proposals(
 
     tracing::info!("Change-threshold proposals created and saved successfully");
     Ok(())
-}
-
-/// Get the current P2P mapping for the party.
-async fn get_current_p2p_mapping(
-    config: &NodeConfig,
-    synchronizer_id: &str,
-    party_id: &CantonId,
-) -> Result<PartyToParticipant> {
-    let party_id_str = party_id.to_string();
-    let mut topology_read_client =
-        TopologyManagerReadServiceClient::connect(config.admin_api_url()).await?;
-
-    let request = tonic::Request::new(ListPartyToParticipantRequest {
-        base_query: Some(BaseQuery {
-            store: Some(StoreId {
-                store: Some(store_id::Store::Synchronizer(Synchronizer {
-                    kind: Some(synchronizer::Kind::PhysicalId(synchronizer_id.to_string())),
-                })),
-            }),
-            proposals: false,
-            operation: 0,
-            time_query: Some(base_query::TimeQuery::HeadState(())),
-            filter_signed_key: String::new(),
-            protocol_version: None,
-        }),
-        filter_party: party_id_str,
-        filter_participant: String::new(),
-    });
-
-    let response = topology_read_client
-        .list_party_to_participant(request)
-        .await?
-        .into_inner();
-
-    let p2p = response
-        .results
-        .first()
-        .and_then(|r| r.item.as_ref())
-        .ok_or_else(|| anyhow::anyhow!("No P2P mapping found for party {party_id}"))?;
-
-    Ok(p2p.clone())
 }

--- a/crates/decman/src/workflow/change_threshold/steps/proposals/sign.rs
+++ b/crates/decman/src/workflow/change_threshold/steps/proposals/sign.rs
@@ -1,92 +1,31 @@
-use canton_proto_rs::com::digitalasset::canton::{
-    protocol::v30::SignedTopologyTransaction,
-    topology::admin::v30::{
-        SignTransactionsRequest, StoreId, Synchronizer, store_id, synchronizer,
-    },
-};
 use sqlx::SqlitePool;
 
 use crate::{
     config::NodeConfig,
     error::Result,
-    utils,
-    workflow::{
-        storage::{WorkflowStorage, artifact_kinds},
-        topology::sign_transactions_with_topology_retry,
-    },
+    workflow::{storage::artifact_kinds, topology},
 };
 
 /// Sign the change-threshold proposals.
 ///
-/// Every party member signs both the DNS and P2P proposals. `proposal_data`
-/// contains both proposals received from the coordinator. Persists the
-/// per-peer signed DNS / P2P proposals as `SIGNED_CHANGE_THRESHOLD_DNS` /
-/// `SIGNED_CHANGE_THRESHOLD_P2P` (keyed by this node's participant id). Each
-/// artefact is `varint(len)||proto`, so concatenating them yields exactly the
-/// buffer the peer sends to the coordinator.
+/// Every party member signs both the DNS and P2P proposals. `proposal_data` is
+/// the `[dns, p2p]` pair received from the coordinator. Delegates to
+/// [`topology::sign_dns_p2p_proposals`], persisting the per-peer results as
+/// `SIGNED_CHANGE_THRESHOLD_DNS` / `SIGNED_CHANGE_THRESHOLD_P2P`.
 pub async fn sign_proposals(
     config: &NodeConfig,
     storage: &SqlitePool,
     instance_name: &str,
     proposal_data: &[u8],
 ) -> Result {
-    tracing::info!("Signing change-threshold proposals...");
-
-    let node_id = config.participant_id().to_string();
-    let synchronizer_id = utils::get_synchronizer_id(config).await?;
-    tracing::debug!("Using synchronizer ID: {synchronizer_id}");
-
-    // Parse the combined proposal data from the coordinator.
-    let items = utils::decode_length_prefixed(proposal_data, 2)?;
-    tracing::info!("Using change-threshold proposals from coordinator payload");
-
-    let dns_transaction: SignedTopologyTransaction =
-        utils::read_first_message_from_bytes(&items[0])?;
-    let p2p_transaction: SignedTopologyTransaction =
-        utils::read_first_message_from_bytes(&items[1])?;
-
-    let request = SignTransactionsRequest {
-        transactions: vec![dns_transaction, p2p_transaction],
-        signed_by: vec![],
-        store: Some(StoreId {
-            store: Some(store_id::Store::Synchronizer(Synchronizer {
-                kind: Some(synchronizer::Kind::PhysicalId(synchronizer_id)),
-            })),
-        }),
-        force_flags: vec![],
-    };
-
-    tracing::debug!("Calling SignTransactions RPC for change-threshold proposals...");
-    let response =
-        sign_transactions_with_topology_retry(config, request, "change-threshold").await?;
-
-    if response.transactions.len() != 2 {
-        anyhow::bail!(
-            "Expected 2 signed transactions (DNS and P2P), got {count}",
-            count = response.transactions.len()
-        );
-    }
-
-    let dns_bytes = utils::encode_length_prefixed_message(&response.transactions[0]);
-    let p2p_bytes = utils::encode_length_prefixed_message(&response.transactions[1]);
-
-    storage
-        .write_artifact(
-            instance_name,
-            artifact_kinds::SIGNED_CHANGE_THRESHOLD_DNS,
-            Some(&node_id),
-            &dns_bytes,
-        )
-        .await?;
-    storage
-        .write_artifact(
-            instance_name,
-            artifact_kinds::SIGNED_CHANGE_THRESHOLD_P2P,
-            Some(&node_id),
-            &p2p_bytes,
-        )
-        .await?;
-
-    tracing::info!("Change-threshold proposals signed successfully");
-    Ok(())
+    topology::sign_dns_p2p_proposals(
+        config,
+        storage,
+        instance_name,
+        proposal_data,
+        "change-threshold",
+        artifact_kinds::SIGNED_CHANGE_THRESHOLD_DNS,
+        artifact_kinds::SIGNED_CHANGE_THRESHOLD_P2P,
+    )
+    .await
 }

--- a/crates/decman/src/workflow/change_threshold/steps/proposals/submit.rs
+++ b/crates/decman/src/workflow/change_threshold/steps/proposals/submit.rs
@@ -1,12 +1,8 @@
-use std::collections::HashMap;
-
 use canton_proto_rs::com::digitalasset::canton::{
-    protocol::v30::{DecentralizedNamespaceDefinition, SignedTopologyTransaction},
+    protocol::v30::DecentralizedNamespaceDefinition,
     topology::admin::v30::{
-        AddTransactionsRequest, BaseQuery, ListDecentralizedNamespaceDefinitionRequest,
-        ListPartyToParticipantRequest, StoreId, Synchronizer, base_query, store_id, synchronizer,
+        ListDecentralizedNamespaceDefinitionRequest, ListPartyToParticipantRequest,
         topology_manager_read_service_client::TopologyManagerReadServiceClient,
-        topology_manager_write_service_client::TopologyManagerWriteServiceClient,
     },
 };
 use sqlx::SqlitePool;
@@ -15,18 +11,22 @@ use tokio::time;
 use crate::{
     canton_id::CantonId,
     config::NodeConfig,
-    consts::{
-        TOPOLOGY_PROPAGATION_DELAY_SECS, topology_retry_delay_secs, topology_retry_max_attempts,
-    },
+    consts::{topology_retry_delay_secs, topology_retry_max_attempts},
     error::Result,
     utils,
-    workflow::storage::{WorkflowStorage, artifact_kinds},
+    workflow::{
+        storage::{WorkflowStorage, artifact_kinds},
+        topology,
+    },
 };
 
 /// Submit the change-threshold proposals to the synchronizer.
 ///
 /// The coordinator aggregates the per-peer signatures onto its own proposals
-/// and submits the DNS mapping followed by the P2P mapping.
+/// and submits the DNS mapping followed by the P2P mapping. Both mappings
+/// already exist (owners and participants are unchanged), so the post-submit
+/// polls wait on the new threshold *value* rather than mere existence — else
+/// the check passes before the change lands.
 pub async fn submit_change(
     config: &NodeConfig,
     storage: &SqlitePool,
@@ -37,80 +37,20 @@ pub async fn submit_change(
     let synchronizer_id = utils::get_synchronizer_id(config).await?;
     tracing::debug!("Using synchronizer ID: {synchronizer_id}");
 
-    // Read original DNS proposal
-    let dns_bytes = storage
-        .read_artifact(
-            instance_name,
-            artifact_kinds::CHANGE_THRESHOLD_DNS_PROPOSAL,
-            None,
-        )
-        .await?
-        .ok_or_else(|| anyhow::anyhow!("CHANGE_THRESHOLD_DNS_PROPOSAL artifact missing"))?;
-    let mut dns_transaction: SignedTopologyTransaction =
-        utils::read_first_message_from_bytes(&dns_bytes)?;
+    let (dns_transaction, p2p_transaction) = topology::aggregate_dns_p2p_signatures(
+        storage,
+        instance_name,
+        topology::DnsP2pArtifactKinds {
+            dns_proposal: artifact_kinds::CHANGE_THRESHOLD_DNS_PROPOSAL,
+            p2p_proposal: artifact_kinds::CHANGE_THRESHOLD_P2P_PROPOSAL,
+            signed_dns: artifact_kinds::SIGNED_CHANGE_THRESHOLD_DNS,
+            signed_p2p: artifact_kinds::SIGNED_CHANGE_THRESHOLD_P2P,
+        },
+    )
+    .await?;
 
-    // Read original P2P proposal
-    let p2p_bytes = storage
-        .read_artifact(
-            instance_name,
-            artifact_kinds::CHANGE_THRESHOLD_P2P_PROPOSAL,
-            None,
-        )
-        .await?
-        .ok_or_else(|| anyhow::anyhow!("CHANGE_THRESHOLD_P2P_PROPOSAL artifact missing"))?;
-    let mut p2p_transaction: SignedTopologyTransaction =
-        utils::read_first_message_from_bytes(&p2p_bytes)?;
-
-    // Gather per-peer signed proposals from storage, joining DNS and P2P by
-    // peer id so the two signatures stay paired.
-    let signed_dns = storage
-        .list_artifacts(instance_name, artifact_kinds::SIGNED_CHANGE_THRESHOLD_DNS)
-        .await?;
-    let signed_p2p: HashMap<String, Vec<u8>> = storage
-        .list_artifacts(instance_name, artifact_kinds::SIGNED_CHANGE_THRESHOLD_P2P)
-        .await?
-        .into_iter()
-        .collect();
-
-    tracing::info!(
-        "Found signed proposals from {count} peer(s)",
-        count = signed_dns.len()
-    );
-
-    if signed_dns.len() != signed_p2p.len() {
-        anyhow::bail!(
-            "Mismatched signed proposal counts: {dns} DNS vs {p2p} P2P",
-            dns = signed_dns.len(),
-            p2p = signed_p2p.len()
-        );
-    }
-
-    // Aggregate signatures from each peer onto the coordinator's proposals.
-    for (peer_id, dns_signed_bytes) in &signed_dns {
-        tracing::info!("Reading signatures from peer {peer_id}");
-
-        let dns_signed: SignedTopologyTransaction =
-            utils::read_first_message_from_bytes(dns_signed_bytes)?;
-        let p2p_signed_bytes = signed_p2p
-            .get(peer_id)
-            .ok_or_else(|| anyhow::anyhow!("Peer {peer_id} signed DNS but not P2P"))?;
-        let p2p_signed: SignedTopologyTransaction =
-            utils::read_first_message_from_bytes(p2p_signed_bytes)?;
-
-        dns_transaction.signatures.extend(dns_signed.signatures);
-        p2p_transaction.signatures.extend(p2p_signed.signatures);
-    }
-
-    tracing::info!(
-        "Final DNS proposal has {count} signature(s)",
-        count = dns_transaction.signatures.len()
-    );
-    tracing::info!(
-        "Final P2P proposal has {count} signature(s)",
-        count = p2p_transaction.signatures.len()
-    );
-
-    // Read new namespace definition for the topology-propagation poll.
+    // Read the new namespace definition (for the target threshold) + party id
+    // needed by the post-submit topology polls.
     let new_namespace_bytes = storage
         .read_artifact(
             instance_name,
@@ -122,7 +62,6 @@ pub async fn submit_change(
     let new_namespace_def: DecentralizedNamespaceDefinition =
         utils::read_first_message_from_bytes(&new_namespace_bytes)?;
 
-    // Read party ID
     let party_id_bytes = storage
         .read_artifact(
             instance_name,
@@ -135,71 +74,30 @@ pub async fn submit_change(
     let party_id = CantonId::parse(&party_id_raw)?;
     tracing::info!("Party ID: {party_id}");
 
-    // Submit DNS proposal first
-    tracing::info!("Submitting DNS change-threshold proposal...");
-    let mut topology_write_client =
-        TopologyManagerWriteServiceClient::connect(config.admin_api_url()).await?;
-
-    let dns_request = tonic::Request::new(AddTransactionsRequest {
-        transactions: vec![dns_transaction],
-        force_changes: vec![],
-        store: Some(StoreId {
-            store: Some(store_id::Store::Synchronizer(Synchronizer {
-                kind: Some(synchronizer::Kind::PhysicalId(synchronizer_id.clone())),
-            })),
-        }),
-        wait_to_become_effective: None,
-    });
-
-    topology_write_client.add_transactions(dns_request).await?;
-    tracing::info!("DNS change-threshold proposal submitted");
-
-    // Wait for the DNS to reflect the NEW threshold. The namespace already
-    // exists (owners are unchanged), so we must poll on the threshold value
-    // itself, not mere existence, or the check passes before the change lands.
-    tracing::info!("Waiting for DNS change-threshold to take effect in topology...");
-    wait_for_dns_in_topology(
+    topology::submit_dns_then_p2p(
         config,
         &synchronizer_id,
-        &new_namespace_def.decentralized_namespace,
-        new_namespace_def.threshold,
+        "change-threshold",
+        dns_transaction,
+        p2p_transaction,
+        || {
+            wait_for_dns_in_topology(
+                config,
+                &synchronizer_id,
+                &new_namespace_def.decentralized_namespace,
+                new_namespace_def.threshold,
+            )
+        },
+        || {
+            wait_for_p2p_in_topology(
+                config,
+                &synchronizer_id,
+                &party_id,
+                new_namespace_def.threshold as u32,
+            )
+        },
     )
     .await?;
-    tracing::info!("DNS change-threshold confirmed in topology");
-
-    // Submit P2P proposal
-    tracing::info!("Submitting P2P change-threshold proposal...");
-    let p2p_request = tonic::Request::new(AddTransactionsRequest {
-        transactions: vec![p2p_transaction],
-        force_changes: vec![],
-        store: Some(StoreId {
-            store: Some(store_id::Store::Synchronizer(Synchronizer {
-                kind: Some(synchronizer::Kind::PhysicalId(synchronizer_id.clone())),
-            })),
-        }),
-        wait_to_become_effective: None,
-    });
-
-    topology_write_client.add_transactions(p2p_request).await?;
-    tracing::info!("P2P change-threshold proposal submitted");
-
-    // Wait for the P2P mapping to reflect the NEW threshold. The party id is
-    // stable, so — like the DNS above — poll on the threshold value, not mere
-    // existence.
-    tracing::info!("Waiting for P2P change-threshold to take effect in topology...");
-    wait_for_p2p_in_topology(
-        config,
-        &synchronizer_id,
-        &party_id,
-        new_namespace_def.threshold as u32,
-    )
-    .await?;
-    tracing::info!("P2P change-threshold confirmed in topology");
-
-    // Additional wait for topology propagation
-    let propagation_delay = time::Duration::from_secs(TOPOLOGY_PROPAGATION_DELAY_SECS);
-    tracing::info!("Waiting {propagation_delay:?} for Canton to propagate topology updates...");
-    time::sleep(propagation_delay).await;
 
     tracing::info!("Change-threshold submitted and confirmed successfully");
     Ok(())
@@ -225,18 +123,7 @@ async fn wait_for_dns_in_topology(
 
     for attempt in 1..=max_attempts {
         let request = tonic::Request::new(ListDecentralizedNamespaceDefinitionRequest {
-            base_query: Some(BaseQuery {
-                store: Some(StoreId {
-                    store: Some(store_id::Store::Synchronizer(Synchronizer {
-                        kind: Some(synchronizer::Kind::PhysicalId(synchronizer_id.to_string())),
-                    })),
-                }),
-                proposals: false,
-                operation: 0,
-                time_query: Some(base_query::TimeQuery::HeadState(())),
-                filter_signed_key: String::new(),
-                protocol_version: None,
-            }),
+            base_query: Some(topology::head_state_query(synchronizer_id)),
             filter_namespace: namespace.to_string(),
         });
 
@@ -287,18 +174,7 @@ async fn wait_for_p2p_in_topology(
 
     for attempt in 1..=max_attempts {
         let request = tonic::Request::new(ListPartyToParticipantRequest {
-            base_query: Some(BaseQuery {
-                store: Some(StoreId {
-                    store: Some(store_id::Store::Synchronizer(Synchronizer {
-                        kind: Some(synchronizer::Kind::PhysicalId(synchronizer_id.to_string())),
-                    })),
-                }),
-                proposals: false,
-                operation: 0,
-                time_query: Some(base_query::TimeQuery::HeadState(())),
-                filter_signed_key: String::new(),
-                protocol_version: None,
-            }),
+            base_query: Some(topology::head_state_query(synchronizer_id)),
             filter_party: party_id_str.clone(),
             filter_participant: String::new(),
         });

--- a/crates/decman/src/workflow/contracts/steps/prepare.rs
+++ b/crates/decman/src/workflow/contracts/steps/prepare.rs
@@ -1,11 +1,7 @@
-use bytes::{BufMut, BytesMut};
 use canton_proto_rs::com::daml::ledger::api::v2::{
     Command, CreateCommand, GenMap, Identifier, Optional, Record, RecordField, Value, command,
-    gen_map,
-    interactive::{PrepareSubmissionRequest, PrepareSubmissionResponse},
-    value,
+    gen_map, interactive::PrepareSubmissionRequest, value,
 };
-use prost::Message;
 use sqlx::SqlitePool;
 
 use crate::{
@@ -171,7 +167,7 @@ pub async fn prepare_submissions(
         // `utils::read_first_message_from_bytes` round-trip cleanly. This is
         // the exact byte shape `utils::write_messages_to_file(&[m], path)`
         // would have written for a single message.
-        let payload = encode_length_prefixed_message(&prepared_submission);
+        let payload = utils::encode_length_prefixed_message(&prepared_submission);
         let ordinal = format!("{idx:04}");
         tracing::debug!(
             "Saving prepared submission {index} to artifact peer key {ordinal}",
@@ -191,17 +187,6 @@ pub async fn prepare_submissions(
         count = contracts_config.contracts.len()
     );
     Ok(())
-}
-
-/// Encode a single protobuf message as `varint(len)||proto`, matching the
-/// byte layout produced by `utils::write_message_to_file`. Keeps the
-/// downstream `utils::read_first_message_from_bytes` reader unchanged.
-fn encode_length_prefixed_message(message: &PrepareSubmissionResponse) -> Vec<u8> {
-    let encoded = message.encode_to_vec();
-    let mut buffer = BytesMut::new();
-    prost::encoding::encode_varint(encoded.len() as u64, &mut buffer);
-    buffer.put_slice(&encoded);
-    buffer.to_vec()
 }
 
 /// Context for building field values in contract submissions

--- a/crates/decman/src/workflow/kick/steps/export_state.rs
+++ b/crates/decman/src/workflow/kick/steps/export_state.rs
@@ -1,10 +1,7 @@
-use bytes::{BufMut, BytesMut};
 use canton_proto_rs::com::digitalasset::canton::topology::admin::v30::{
-    BaseQuery, ListDecentralizedNamespaceDefinitionRequest, ListPartyToParticipantRequest, StoreId,
-    Synchronizer, base_query, store_id, synchronizer,
+    ListDecentralizedNamespaceDefinitionRequest, ListPartyToParticipantRequest,
     topology_manager_read_service_client::TopologyManagerReadServiceClient,
 };
-use prost::Message;
 use sqlx::SqlitePool;
 
 use crate::{
@@ -14,6 +11,7 @@ use crate::{
     workflow::{
         kick::KickConfig,
         storage::{WorkflowStorage, artifact_kinds},
+        topology,
     },
 };
 
@@ -42,18 +40,7 @@ pub async fn export_state(
         TopologyManagerReadServiceClient::connect(config.admin_api_url()).await?;
 
     let request = tonic::Request::new(ListDecentralizedNamespaceDefinitionRequest {
-        base_query: Some(BaseQuery {
-            store: Some(StoreId {
-                store: Some(store_id::Store::Synchronizer(Synchronizer {
-                    kind: Some(synchronizer::Kind::PhysicalId(synchronizer_id.clone())),
-                })),
-            }),
-            proposals: false,
-            operation: 0,
-            time_query: Some(base_query::TimeQuery::HeadState(())),
-            filter_signed_key: String::new(),
-            protocol_version: None,
-        }),
+        base_query: Some(topology::head_state_query(&synchronizer_id)),
         filter_namespace: namespace_hex.clone(),
     });
 
@@ -91,7 +78,7 @@ pub async fn export_state(
 
     // Save namespace definition as a length-prefixed protobuf — same byte
     // shape as the file written by `utils::write_message_to_file`.
-    let namespace_bytes = encode_length_prefixed_message(namespace_def);
+    let namespace_bytes = utils::encode_length_prefixed_message(namespace_def);
     storage
         .write_artifact(
             instance_name,
@@ -109,18 +96,7 @@ pub async fn export_state(
     tracing::info!("Querying P2P mapping for party: {party_id}");
 
     let p2p_request = tonic::Request::new(ListPartyToParticipantRequest {
-        base_query: Some(BaseQuery {
-            store: Some(StoreId {
-                store: Some(store_id::Store::Synchronizer(Synchronizer {
-                    kind: Some(synchronizer::Kind::PhysicalId(synchronizer_id.clone())),
-                })),
-            }),
-            proposals: false,
-            operation: 0,
-            time_query: Some(base_query::TimeQuery::HeadState(())),
-            filter_signed_key: String::new(),
-            protocol_version: None,
-        }),
+        base_query: Some(topology::head_state_query(&synchronizer_id)),
         filter_party: party_id.clone(),
         filter_participant: String::new(),
     });
@@ -206,15 +182,4 @@ pub async fn export_state(
 
     tracing::info!("State exported successfully to workflow storage");
     Ok(())
-}
-
-/// Encode a single protobuf message with a varint length prefix, matching the
-/// byte layout produced by `utils::write_message_to_file`. Used so reads via
-/// `utils::read_first_message_from_bytes` keep working unchanged.
-fn encode_length_prefixed_message<M: Message>(message: &M) -> Vec<u8> {
-    let encoded = message.encode_to_vec();
-    let mut buffer = BytesMut::new();
-    prost::encoding::encode_varint(encoded.len() as u64, &mut buffer);
-    buffer.put_slice(&encoded);
-    buffer.to_vec()
 }

--- a/crates/decman/src/workflow/kick/steps/proposals/create.rs
+++ b/crates/decman/src/workflow/kick/steps/proposals/create.rs
@@ -1,17 +1,13 @@
-use bytes::{BufMut, BytesMut};
 use canton_proto_rs::com::digitalasset::canton::{
     protocol::v30::{
         DecentralizedNamespaceDefinition, PartyToParticipant, TopologyMapping, enums,
         topology_mapping,
     },
     topology::admin::v30::{
-        AuthorizeRequest, BaseQuery, ListPartyToParticipantRequest, StoreId, Synchronizer,
-        authorize_request, base_query, store_id, synchronizer,
-        topology_manager_read_service_client::TopologyManagerReadServiceClient,
+        AuthorizeRequest, authorize_request,
         topology_manager_write_service_client::TopologyManagerWriteServiceClient,
     },
 };
-use prost::Message;
 use sqlx::SqlitePool;
 
 use crate::{
@@ -22,6 +18,7 @@ use crate::{
     workflow::{
         kick::KickConfig,
         storage::{WorkflowStorage, artifact_kinds},
+        topology,
     },
 };
 
@@ -112,7 +109,7 @@ pub async fn create_proposals(
     tracing::debug!("Using synchronizer ID: {synchronizer_id}");
 
     // Get current P2P mapping
-    let current_p2p = get_current_p2p_mapping(config, &synchronizer_id, &party_id).await?;
+    let current_p2p = topology::fetch_p2p_mapping(config, &synchronizer_id, &party_id).await?;
 
     tracing::info!(
         "Current P2P mapping has {count} participant(s)",
@@ -164,11 +161,7 @@ pub async fn create_proposals(
         must_fully_authorize: false,
         force_changes: vec![],
         signed_by: vec![],
-        store: Some(StoreId {
-            store: Some(store_id::Store::Synchronizer(Synchronizer {
-                kind: Some(synchronizer::Kind::PhysicalId(synchronizer_id.clone())),
-            })),
-        }),
+        store: Some(topology::synchronizer_store_id(&synchronizer_id)),
         wait_to_become_effective: None,
     });
 
@@ -192,11 +185,7 @@ pub async fn create_proposals(
         must_fully_authorize: false,
         force_changes: vec![],
         signed_by: vec![],
-        store: Some(StoreId {
-            store: Some(store_id::Store::Synchronizer(Synchronizer {
-                kind: Some(synchronizer::Kind::PhysicalId(synchronizer_id.clone())),
-            })),
-        }),
+        store: Some(topology::synchronizer_store_id(&synchronizer_id)),
         wait_to_become_effective: None,
     });
 
@@ -208,7 +197,7 @@ pub async fn create_proposals(
     // Persist proposals + supporting data to workflow storage. Each protobuf
     // is written with the same `varint(len)||proto` framing the original file
     // path used (so `read_first_message_from_bytes` works unchanged).
-    let dns_bytes = encode_length_prefixed_message(&dns_transaction);
+    let dns_bytes = utils::encode_length_prefixed_message(&dns_transaction);
     storage
         .write_artifact(
             instance_name,
@@ -219,7 +208,7 @@ pub async fn create_proposals(
         .await?;
     tracing::info!("Saved DNS kick proposal to storage");
 
-    let p2p_bytes = encode_length_prefixed_message(&p2p_transaction);
+    let p2p_bytes = utils::encode_length_prefixed_message(&p2p_transaction);
     storage
         .write_artifact(
             instance_name,
@@ -230,7 +219,7 @@ pub async fn create_proposals(
         .await?;
     tracing::info!("Saved P2P kick proposal to storage");
 
-    let new_namespace_bytes = encode_length_prefixed_message(&new_namespace_def);
+    let new_namespace_bytes = utils::encode_length_prefixed_message(&new_namespace_def);
     storage
         .write_artifact(
             instance_name,
@@ -254,55 +243,4 @@ pub async fn create_proposals(
 
     tracing::info!("Kick proposals created and saved successfully");
     Ok(())
-}
-
-/// Get the current P2P mapping for the party
-async fn get_current_p2p_mapping(
-    config: &NodeConfig,
-    synchronizer_id: &str,
-    party_id: &CantonId,
-) -> Result<PartyToParticipant> {
-    let party_id_str = party_id.to_string();
-    let mut topology_read_client =
-        TopologyManagerReadServiceClient::connect(config.admin_api_url()).await?;
-
-    let request = tonic::Request::new(ListPartyToParticipantRequest {
-        base_query: Some(BaseQuery {
-            store: Some(StoreId {
-                store: Some(store_id::Store::Synchronizer(Synchronizer {
-                    kind: Some(synchronizer::Kind::PhysicalId(synchronizer_id.to_string())),
-                })),
-            }),
-            proposals: false,
-            operation: 0,
-            time_query: Some(base_query::TimeQuery::HeadState(())),
-            filter_signed_key: String::new(),
-            protocol_version: None,
-        }),
-        filter_party: party_id_str,
-        filter_participant: String::new(),
-    });
-
-    let response = topology_read_client
-        .list_party_to_participant(request)
-        .await?
-        .into_inner();
-
-    let p2p = response
-        .results
-        .first()
-        .and_then(|r| r.item.as_ref())
-        .ok_or_else(|| anyhow::anyhow!("No P2P mapping found for party {party_id}"))?;
-
-    Ok(p2p.clone())
-}
-
-/// Encode a protobuf message as `varint(len)||proto`, matching the on-disk
-/// format `utils::write_message_to_file` produces.
-fn encode_length_prefixed_message<M: Message>(message: &M) -> Vec<u8> {
-    let encoded = message.encode_to_vec();
-    let mut buffer = BytesMut::new();
-    prost::encoding::encode_varint(encoded.len() as u64, &mut buffer);
-    buffer.put_slice(&encoded);
-    buffer.to_vec()
 }

--- a/crates/decman/src/workflow/kick/steps/proposals/sign.rs
+++ b/crates/decman/src/workflow/kick/steps/proposals/sign.rs
@@ -1,111 +1,31 @@
-use bytes::{BufMut, BytesMut};
-use canton_proto_rs::com::digitalasset::canton::{
-    protocol::v30::SignedTopologyTransaction,
-    topology::admin::v30::{
-        SignTransactionsRequest, StoreId, Synchronizer, store_id, synchronizer,
-    },
-};
-use prost::Message;
 use sqlx::SqlitePool;
 
 use crate::{
     config::NodeConfig,
     error::Result,
-    utils,
-    workflow::{
-        storage::{WorkflowStorage, artifact_kinds},
-        topology::sign_transactions_with_topology_retry,
-    },
+    workflow::{storage::artifact_kinds, topology},
 };
 
-/// Sign kick proposals
+/// Sign kick proposals.
 ///
-/// Each remaining member (not the kicked member) signs both proposals.
-/// `proposal_data` contains both DNS and P2P proposals received from coordinator.
-///
-/// Persists the per-peer signed DNS / P2P proposals as
-/// `SIGNED_KICK_DNS` / `SIGNED_KICK_P2P` artefacts (keyed by this node's
-/// participant id). The byte-shape per artefact is `varint(len)||proto`,
-/// matching the original on-disk format produced by `write_message_to_file`.
+/// Each remaining member (not the kicked member) signs both the DNS and P2P
+/// proposals. `proposal_data` is the `[dns, p2p]` pair received from the
+/// coordinator. Delegates to [`topology::sign_dns_p2p_proposals`], persisting
+/// the per-peer results as `SIGNED_KICK_DNS` / `SIGNED_KICK_P2P`.
 pub async fn sign_proposals(
     config: &NodeConfig,
     storage: &SqlitePool,
     instance_name: &str,
     proposal_data: &[u8],
 ) -> Result {
-    tracing::info!("Signing kick proposals...");
-
-    let node_id = config.participant_id().to_string();
-    let synchronizer_id = utils::get_synchronizer_id(config).await?;
-    tracing::debug!("Using synchronizer ID: {synchronizer_id}");
-
-    // Parse the combined proposal data from coordinator
-    let items = utils::decode_length_prefixed(proposal_data, 2)?;
-    tracing::info!("Using kick proposals from coordinator payload");
-
-    let dns_transaction: SignedTopologyTransaction =
-        utils::read_first_message_from_bytes(&items[0])?;
-    let p2p_transaction: SignedTopologyTransaction =
-        utils::read_first_message_from_bytes(&items[1])?;
-
-    let request = SignTransactionsRequest {
-        transactions: vec![dns_transaction, p2p_transaction],
-        signed_by: vec![],
-        store: Some(StoreId {
-            store: Some(store_id::Store::Synchronizer(Synchronizer {
-                kind: Some(synchronizer::Kind::PhysicalId(synchronizer_id)),
-            })),
-        }),
-        force_flags: vec![],
-    };
-
-    tracing::debug!("Calling SignTransactions RPC for kick proposals...");
-    let response = sign_transactions_with_topology_retry(config, request, "kick").await?;
-
-    if response.transactions.len() != 2 {
-        anyhow::bail!(
-            "Expected 2 signed transactions (DNS and P2P), got {count}",
-            count = response.transactions.len()
-        );
-    }
-
-    // Persist signed DNS + P2P as separate per-peer artefacts. Each is
-    // written as `varint(len)||proto` so the bytes that go on the wire to the
-    // coordinator (which is the concatenation of these two artefacts) are
-    // byte-identical to what `write_messages_to_file(&[dns, p2p], path)`
-    // produced before — Canton sees the exact same protobufs.
-    let dns_bytes = encode_length_prefixed_message(&response.transactions[0]);
-    let p2p_bytes = encode_length_prefixed_message(&response.transactions[1]);
-
-    storage
-        .write_artifact(
-            instance_name,
-            artifact_kinds::SIGNED_KICK_DNS,
-            Some(&node_id),
-            &dns_bytes,
-        )
-        .await?;
-    storage
-        .write_artifact(
-            instance_name,
-            artifact_kinds::SIGNED_KICK_P2P,
-            Some(&node_id),
-            &p2p_bytes,
-        )
-        .await?;
-
-    tracing::info!("Kick proposals signed successfully");
-    Ok(())
-}
-
-/// Encode a protobuf message as `varint(len)||proto`. Matches the on-disk
-/// format `utils::write_message_to_file` used to produce; concatenating the
-/// DNS and P2P encodings yields exactly the buffer the peer sends to the
-/// coordinator over Noise (i.e. the original combined-file bytes).
-fn encode_length_prefixed_message<M: Message>(message: &M) -> Vec<u8> {
-    let encoded = message.encode_to_vec();
-    let mut buffer = BytesMut::new();
-    prost::encoding::encode_varint(encoded.len() as u64, &mut buffer);
-    buffer.put_slice(&encoded);
-    buffer.to_vec()
+    topology::sign_dns_p2p_proposals(
+        config,
+        storage,
+        instance_name,
+        proposal_data,
+        "kick",
+        artifact_kinds::SIGNED_KICK_DNS,
+        artifact_kinds::SIGNED_KICK_P2P,
+    )
+    .await
 }

--- a/crates/decman/src/workflow/kick/steps/proposals/submit.rs
+++ b/crates/decman/src/workflow/kick/steps/proposals/submit.rs
@@ -1,12 +1,8 @@
-use std::collections::HashMap;
-
 use canton_proto_rs::com::digitalasset::canton::{
-    protocol::v30::{DecentralizedNamespaceDefinition, SignedTopologyTransaction},
+    protocol::v30::DecentralizedNamespaceDefinition,
     topology::admin::v30::{
-        AddTransactionsRequest, BaseQuery, ListDecentralizedNamespaceDefinitionRequest,
-        ListPartyToParticipantRequest, StoreId, Synchronizer, base_query, store_id, synchronizer,
+        ListDecentralizedNamespaceDefinitionRequest, ListPartyToParticipantRequest,
         topology_manager_read_service_client::TopologyManagerReadServiceClient,
-        topology_manager_write_service_client::TopologyManagerWriteServiceClient,
     },
 };
 use sqlx::SqlitePool;
@@ -15,90 +11,41 @@ use tokio::time;
 use crate::{
     canton_id::CantonId,
     config::NodeConfig,
-    consts::{
-        TOPOLOGY_PROPAGATION_DELAY_SECS, topology_retry_delay_secs, topology_retry_max_attempts,
-    },
+    consts::{topology_retry_delay_secs, topology_retry_max_attempts},
     error::Result,
     utils,
-    workflow::storage::{WorkflowStorage, artifact_kinds},
+    workflow::{
+        storage::{WorkflowStorage, artifact_kinds},
+        topology,
+    },
 };
 
-/// Submit kick to synchronizer
+/// Submit kick to synchronizer.
 ///
-/// Coordinator aggregates signatures and submits the kick.
+/// The coordinator aggregates the per-peer signatures onto its own proposals
+/// and submits the DNS mapping followed by the P2P mapping. A kicked owner's
+/// mapping briefly disappears from the head state, so both post-submit polls
+/// wait for mere existence of the updated mapping.
 pub async fn submit_kick(config: &NodeConfig, storage: &SqlitePool, instance_name: &str) -> Result {
     tracing::info!("Submitting kick to synchronizer...");
 
     let synchronizer_id = utils::get_synchronizer_id(config).await?;
     tracing::debug!("Using synchronizer ID: {synchronizer_id}");
 
-    // Read original DNS proposal
-    let dns_bytes = storage
-        .read_artifact(instance_name, artifact_kinds::KICK_DNS_PROPOSAL, None)
-        .await?
-        .ok_or_else(|| anyhow::anyhow!("KICK_DNS_PROPOSAL artifact missing"))?;
-    let mut dns_transaction: SignedTopologyTransaction =
-        utils::read_first_message_from_bytes(&dns_bytes)?;
+    let (dns_transaction, p2p_transaction) = topology::aggregate_dns_p2p_signatures(
+        storage,
+        instance_name,
+        topology::DnsP2pArtifactKinds {
+            dns_proposal: artifact_kinds::KICK_DNS_PROPOSAL,
+            p2p_proposal: artifact_kinds::KICK_P2P_PROPOSAL,
+            signed_dns: artifact_kinds::SIGNED_KICK_DNS,
+            signed_p2p: artifact_kinds::SIGNED_KICK_P2P,
+        },
+    )
+    .await?;
 
-    // Read original P2P proposal
-    let p2p_bytes = storage
-        .read_artifact(instance_name, artifact_kinds::KICK_P2P_PROPOSAL, None)
-        .await?
-        .ok_or_else(|| anyhow::anyhow!("KICK_P2P_PROPOSAL artifact missing"))?;
-    let mut p2p_transaction: SignedTopologyTransaction =
-        utils::read_first_message_from_bytes(&p2p_bytes)?;
-
-    // Gather per-peer signed proposals from storage. We list both kinds
-    // and join by peer id so DNS and P2P signatures stay paired the way
-    // the original combined-file format guaranteed.
-    let signed_dns = storage
-        .list_artifacts(instance_name, artifact_kinds::SIGNED_KICK_DNS)
-        .await?;
-    let signed_p2p: HashMap<String, Vec<u8>> = storage
-        .list_artifacts(instance_name, artifact_kinds::SIGNED_KICK_P2P)
-        .await?
-        .into_iter()
-        .collect();
-
-    tracing::info!(
-        "Found signed proposals from {count} peer(s)",
-        count = signed_dns.len()
-    );
-
-    if signed_dns.len() != signed_p2p.len() {
-        anyhow::bail!(
-            "Mismatched signed proposal counts: {dns} DNS vs {p2p} P2P",
-            dns = signed_dns.len(),
-            p2p = signed_p2p.len()
-        );
-    }
-
-    // Aggregate signatures from each peer
-    for (peer_id, dns_signed_bytes) in &signed_dns {
-        tracing::info!("Reading signatures from peer {peer_id}");
-
-        let dns_signed: SignedTopologyTransaction =
-            utils::read_first_message_from_bytes(dns_signed_bytes)?;
-        let p2p_signed_bytes = signed_p2p
-            .get(peer_id)
-            .ok_or_else(|| anyhow::anyhow!("Peer {peer_id} signed DNS but not P2P"))?;
-        let p2p_signed: SignedTopologyTransaction =
-            utils::read_first_message_from_bytes(p2p_signed_bytes)?;
-
-        dns_transaction.signatures.extend(dns_signed.signatures);
-        p2p_transaction.signatures.extend(p2p_signed.signatures);
-    }
-
-    tracing::info!(
-        "Final DNS proposal has {count} signature(s)",
-        count = dns_transaction.signatures.len()
-    );
-    tracing::info!(
-        "Final P2P proposal has {count} signature(s)",
-        count = p2p_transaction.signatures.len()
-    );
-
-    // Read new namespace definition for validation
+    // Read the new namespace definition + party id needed by the post-submit
+    // topology polls.
     let new_namespace_bytes = storage
         .read_artifact(instance_name, artifact_kinds::KICK_NEW_NAMESPACE_DEF, None)
         .await?
@@ -106,7 +53,6 @@ pub async fn submit_kick(config: &NodeConfig, storage: &SqlitePool, instance_nam
     let new_namespace_def: DecentralizedNamespaceDefinition =
         utils::read_first_message_from_bytes(&new_namespace_bytes)?;
 
-    // Read party ID
     let party_id_bytes = storage
         .read_artifact(instance_name, artifact_kinds::KICK_PARTY_ID, None)
         .await?
@@ -115,66 +61,28 @@ pub async fn submit_kick(config: &NodeConfig, storage: &SqlitePool, instance_nam
     let party_id = CantonId::parse(&party_id_raw)?;
     tracing::info!("Party ID: {party_id}");
 
-    // Submit DNS proposal first
-    tracing::info!("Submitting DNS kick proposal...");
-    let mut topology_write_client =
-        TopologyManagerWriteServiceClient::connect(config.admin_api_url()).await?;
-
-    let dns_request = tonic::Request::new(AddTransactionsRequest {
-        transactions: vec![dns_transaction],
-        force_changes: vec![],
-        store: Some(StoreId {
-            store: Some(store_id::Store::Synchronizer(Synchronizer {
-                kind: Some(synchronizer::Kind::PhysicalId(synchronizer_id.clone())),
-            })),
-        }),
-        wait_to_become_effective: None,
-    });
-
-    topology_write_client.add_transactions(dns_request).await?;
-    tracing::info!("DNS kick proposal submitted");
-
-    // Wait for DNS to propagate
-    tracing::info!("Waiting for DNS kick to appear in topology...");
-    wait_for_dns_in_topology(
+    topology::submit_dns_then_p2p(
         config,
         &synchronizer_id,
-        &new_namespace_def.decentralized_namespace,
+        "kick",
+        dns_transaction,
+        p2p_transaction,
+        || {
+            wait_for_dns_in_topology(
+                config,
+                &synchronizer_id,
+                &new_namespace_def.decentralized_namespace,
+            )
+        },
+        || wait_for_p2p_in_topology(config, &synchronizer_id, &party_id),
     )
     .await?;
-    tracing::info!("DNS kick confirmed in topology");
-
-    // Submit P2P proposal
-    tracing::info!("Submitting P2P kick proposal...");
-    let p2p_request = tonic::Request::new(AddTransactionsRequest {
-        transactions: vec![p2p_transaction],
-        force_changes: vec![],
-        store: Some(StoreId {
-            store: Some(store_id::Store::Synchronizer(Synchronizer {
-                kind: Some(synchronizer::Kind::PhysicalId(synchronizer_id.clone())),
-            })),
-        }),
-        wait_to_become_effective: None,
-    });
-
-    topology_write_client.add_transactions(p2p_request).await?;
-    tracing::info!("P2P kick proposal submitted");
-
-    // Wait for P2P to propagate
-    tracing::info!("Waiting for P2P kick to appear in topology...");
-    wait_for_p2p_in_topology(config, &synchronizer_id, &party_id).await?;
-    tracing::info!("P2P kick confirmed in topology");
-
-    // Additional wait for topology propagation
-    let propagation_delay = time::Duration::from_secs(TOPOLOGY_PROPAGATION_DELAY_SECS);
-    tracing::info!("Waiting {propagation_delay:?} for Canton to propagate topology updates...");
-    time::sleep(propagation_delay).await;
 
     tracing::info!("Kick submitted and confirmed successfully");
     Ok(())
 }
 
-/// Wait for DNS to appear in topology by polling
+/// Wait for the decentralized namespace to appear in the topology head state.
 async fn wait_for_dns_in_topology(
     config: &NodeConfig,
     synchronizer_id: &str,
@@ -188,18 +96,7 @@ async fn wait_for_dns_in_topology(
 
     for attempt in 1..=max_attempts {
         let request = tonic::Request::new(ListDecentralizedNamespaceDefinitionRequest {
-            base_query: Some(BaseQuery {
-                store: Some(StoreId {
-                    store: Some(store_id::Store::Synchronizer(Synchronizer {
-                        kind: Some(synchronizer::Kind::PhysicalId(synchronizer_id.to_string())),
-                    })),
-                }),
-                proposals: false,
-                operation: 0,
-                time_query: Some(base_query::TimeQuery::HeadState(())),
-                filter_signed_key: String::new(),
-                protocol_version: None,
-            }),
+            base_query: Some(topology::head_state_query(synchronizer_id)),
             filter_namespace: namespace.to_string(),
         });
 
@@ -224,7 +121,7 @@ async fn wait_for_dns_in_topology(
     anyhow::bail!("DNS did not appear in topology after {max_attempts} attempts")
 }
 
-/// Wait for P2P to appear in topology by polling
+/// Wait for the party's P2P mapping to appear in the topology head state.
 async fn wait_for_p2p_in_topology(
     config: &NodeConfig,
     synchronizer_id: &str,
@@ -239,18 +136,7 @@ async fn wait_for_p2p_in_topology(
 
     for attempt in 1..=max_attempts {
         let request = tonic::Request::new(ListPartyToParticipantRequest {
-            base_query: Some(BaseQuery {
-                store: Some(StoreId {
-                    store: Some(store_id::Store::Synchronizer(Synchronizer {
-                        kind: Some(synchronizer::Kind::PhysicalId(synchronizer_id.to_string())),
-                    })),
-                }),
-                proposals: false,
-                operation: 0,
-                time_query: Some(base_query::TimeQuery::HeadState(())),
-                filter_signed_key: String::new(),
-                protocol_version: None,
-            }),
+            base_query: Some(topology::head_state_query(synchronizer_id)),
             filter_party: party_id_str.clone(),
             filter_participant: String::new(),
         });

--- a/crates/decman/src/workflow/onboarding/steps/proposals/create.rs
+++ b/crates/decman/src/workflow/onboarding/steps/proposals/create.rs
@@ -1,6 +1,5 @@
 use std::collections::HashSet;
 
-use bytes::{BufMut, BytesMut};
 use canton_proto_rs::com::digitalasset::canton::{
     crypto::v30::{SigningKeysWithThreshold, SigningPublicKey},
     protocol::v30::{
@@ -308,19 +307,19 @@ pub async fn create_proposals(
 
     // Step 13: Persist proposals to storage. Each protobuf is written with the
     // same `varint(len)||proto` framing the original on-disk format used.
-    let dns_bytes = encode_length_prefixed_message(&dns_transaction);
+    let dns_bytes = utils::encode_length_prefixed_message(&dns_transaction);
     storage
         .write_artifact(instance_name, artifact_kinds::DNS_PROTO, None, &dns_bytes)
         .await?;
     tracing::info!("Saved DNS proposal to storage");
 
-    let p2p_bytes = encode_length_prefixed_message(&p2p_transaction);
+    let p2p_bytes = utils::encode_length_prefixed_message(&p2p_transaction);
     storage
         .write_artifact(instance_name, artifact_kinds::P2P_PROTO, None, &p2p_bytes)
         .await?;
     tracing::info!("Saved P2P proposal to storage");
 
-    let namespace_bytes = encode_length_prefixed_message(&namespace_def);
+    let namespace_bytes = utils::encode_length_prefixed_message(&namespace_def);
     storage
         .write_artifact(
             instance_name,
@@ -357,17 +356,6 @@ pub(crate) fn decode_keys_payload(payload: &[u8]) -> Result<Vec<SigningPublicKey
         cursor = rest;
     }
     Ok(keys)
-}
-
-/// Encode a protobuf message as `varint(len)||proto` — same framing
-/// `utils::write_message_to_file` produced, so existing readers like
-/// `read_first_message_from_bytes` round-trip cleanly.
-fn encode_length_prefixed_message<M: Message>(message: &M) -> Vec<u8> {
-    let encoded = message.encode_to_vec();
-    let mut buffer = BytesMut::new();
-    prost::encoding::encode_varint(encoded.len() as u64, &mut buffer);
-    buffer.put_slice(&encoded);
-    buffer.to_vec()
 }
 
 /// Compute decentralized namespace from individual namespaces

--- a/crates/decman/src/workflow/topology.rs
+++ b/crates/decman/src/workflow/topology.rs
@@ -7,17 +7,36 @@
 //! topology store is reconciling. This module owns the retry policy so
 //! callers don't reach across workflow boundaries to share it.
 
-use std::time::Duration;
-
-use canton_proto_rs::com::digitalasset::canton::topology::admin::v30::{
-    AuthorizeRequest, AuthorizeResponse, SignTransactionsRequest, SignTransactionsResponse,
-    topology_manager_write_service_client::TopologyManagerWriteServiceClient,
+use std::{
+    collections::{HashMap, HashSet},
+    future::Future,
+    time::Duration,
 };
 
+use canton_proto_rs::com::digitalasset::canton::{
+    protocol::v30::{
+        DecentralizedNamespaceDefinition, PartyToParticipant, SignedTopologyTransaction,
+    },
+    topology::admin::v30::{
+        AddTransactionsRequest, AuthorizeRequest, AuthorizeResponse, BaseQuery,
+        ListDecentralizedNamespaceDefinitionRequest, ListPartyToParticipantRequest,
+        SignTransactionsRequest, SignTransactionsResponse, StoreId, Synchronizer, base_query,
+        store_id, synchronizer,
+        topology_manager_read_service_client::TopologyManagerReadServiceClient,
+        topology_manager_write_service_client::TopologyManagerWriteServiceClient,
+    },
+};
+use sqlx::SqlitePool;
+
 use crate::{
+    canton_id::CantonId,
     config::NodeConfig,
-    consts::{topology_retry_delay_secs, topology_retry_max_attempts},
+    consts::{
+        TOPOLOGY_PROPAGATION_DELAY_SECS, topology_retry_delay_secs, topology_retry_max_attempts,
+    },
     error::Result,
+    utils,
+    workflow::storage::WorkflowStorage,
 };
 
 /// Call `sign_transactions` on the participant's TopologyManagerWriteService,
@@ -156,6 +175,340 @@ fn is_topology_signing_key_not_ready(status: &tonic::Status) -> bool {
         .contains("TOPOLOGY_NO_APPROPRIATE_SIGNING_KEY_IN_STORE")
 }
 
+// ---------------------------------------------------------------------------
+// Shared topology-transaction request builders
+// ---------------------------------------------------------------------------
+
+/// A [`StoreId`] targeting the physical synchronizer store — the target every
+/// topology read and write in these workflows uses.
+pub fn synchronizer_store_id(synchronizer_id: &str) -> StoreId {
+    StoreId {
+        store: Some(store_id::Store::Synchronizer(Synchronizer {
+            kind: Some(synchronizer::Kind::PhysicalId(synchronizer_id.to_string())),
+        })),
+    }
+}
+
+/// A head-state [`BaseQuery`] against the synchronizer store — the boilerplate
+/// every topology read in these workflows shares.
+pub fn head_state_query(synchronizer_id: &str) -> BaseQuery {
+    BaseQuery {
+        store: Some(synchronizer_store_id(synchronizer_id)),
+        proposals: false,
+        operation: 0,
+        time_query: Some(base_query::TimeQuery::HeadState(())),
+        filter_signed_key: String::new(),
+        protocol_version: None,
+    }
+}
+
+/// An [`AddTransactionsRequest`] submitting a single signed transaction to the
+/// synchronizer store.
+pub fn add_transactions_request(
+    synchronizer_id: &str,
+    transaction: SignedTopologyTransaction,
+) -> AddTransactionsRequest {
+    AddTransactionsRequest {
+        transactions: vec![transaction],
+        force_changes: vec![],
+        store: Some(synchronizer_store_id(synchronizer_id)),
+        wait_to_become_effective: None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared head-state topology reads
+// ---------------------------------------------------------------------------
+
+/// Fetch the party's current `PartyToParticipant` mapping from the
+/// synchronizer head state. Errors if the party has no mapping.
+pub async fn fetch_p2p_mapping(
+    config: &NodeConfig,
+    synchronizer_id: &str,
+    party_id: &CantonId,
+) -> Result<PartyToParticipant> {
+    let mut topology_read_client =
+        TopologyManagerReadServiceClient::connect(config.admin_api_url()).await?;
+
+    let request = tonic::Request::new(ListPartyToParticipantRequest {
+        base_query: Some(head_state_query(synchronizer_id)),
+        filter_party: party_id.to_string(),
+        filter_participant: String::new(),
+    });
+
+    let response = topology_read_client
+        .list_party_to_participant(request)
+        .await?
+        .into_inner();
+
+    response
+        .results
+        .first()
+        .and_then(|r| r.item.as_ref())
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("No P2P mapping found for party {party_id}"))
+}
+
+/// Fetch the current `DecentralizedNamespaceDefinition` from the synchronizer
+/// head state. Errors if the namespace is not present.
+pub async fn fetch_namespace_definition(
+    config: &NodeConfig,
+    synchronizer_id: &str,
+    namespace_hex: &str,
+) -> Result<DecentralizedNamespaceDefinition> {
+    let mut topology_read_client =
+        TopologyManagerReadServiceClient::connect(config.admin_api_url()).await?;
+
+    let request = tonic::Request::new(ListDecentralizedNamespaceDefinitionRequest {
+        base_query: Some(head_state_query(synchronizer_id)),
+        filter_namespace: namespace_hex.to_string(),
+    });
+
+    let response = topology_read_client
+        .list_decentralized_namespace_definition(request)
+        .await?
+        .into_inner();
+
+    response
+        .results
+        .first()
+        .and_then(|r| r.item.as_ref())
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("Namespace {namespace_hex} not found in topology"))
+}
+
+// ---------------------------------------------------------------------------
+// Shared DNS + P2P proposal steps (kick / add-party / change-threshold)
+// ---------------------------------------------------------------------------
+
+/// Sign the DNS + P2P topology proposal pair for a topology-changing workflow.
+///
+/// `proposal_data` is the `[dns, p2p]` length-prefixed pair the coordinator
+/// sent (each element a `varint(len)||SignedTopologyTransaction` blob). Signs
+/// both with the participant's topology keys — retrying the transient
+/// `TOPOLOGY_NO_APPROPRIATE_SIGNING_KEY_IN_STORE` via
+/// [`sign_transactions_with_topology_retry`] — and persists the signed results
+/// as `dns_artifact_kind` / `p2p_artifact_kind`, keyed by this node's
+/// participant id. Each artefact is a single `varint(len)||proto` blob, so the
+/// coordinator reads them back with `utils::read_first_message_from_bytes` and
+/// the on-wire bytes stay byte-identical to the original combined-file format.
+///
+/// `label` is a short workflow tag (`"kick"`, `"add-party"`,
+/// `"change-threshold"`) included in log lines and the sign-retry diagnostics.
+pub async fn sign_dns_p2p_proposals(
+    config: &NodeConfig,
+    storage: &SqlitePool,
+    instance_name: &str,
+    proposal_data: &[u8],
+    label: &str,
+    dns_artifact_kind: &str,
+    p2p_artifact_kind: &str,
+) -> Result {
+    tracing::info!("Signing {label} proposals...");
+
+    let node_id = config.participant_id().to_string();
+    let synchronizer_id = utils::get_synchronizer_id(config).await?;
+    tracing::debug!("Using synchronizer ID: {synchronizer_id}");
+
+    let items = utils::decode_length_prefixed(proposal_data, 2)?;
+    let dns_transaction: SignedTopologyTransaction =
+        utils::read_first_message_from_bytes(&items[0])?;
+    let p2p_transaction: SignedTopologyTransaction =
+        utils::read_first_message_from_bytes(&items[1])?;
+
+    let request = SignTransactionsRequest {
+        transactions: vec![dns_transaction, p2p_transaction],
+        signed_by: vec![],
+        store: Some(synchronizer_store_id(&synchronizer_id)),
+        force_flags: vec![],
+    };
+
+    tracing::debug!("Calling SignTransactions RPC for {label} proposals...");
+    let response = sign_transactions_with_topology_retry(config, request, label).await?;
+
+    if response.transactions.len() != 2 {
+        anyhow::bail!(
+            "Expected 2 signed transactions (DNS and P2P), got {count}",
+            count = response.transactions.len()
+        );
+    }
+
+    // Persist signed DNS + P2P as separate per-peer artefacts, each
+    // `varint(len)||proto`, so their concatenation is byte-identical to what
+    // `write_messages_to_file(&[dns, p2p], path)` produced before.
+    storage
+        .write_artifact(
+            instance_name,
+            dns_artifact_kind,
+            Some(&node_id),
+            &utils::encode_length_prefixed_message(&response.transactions[0]),
+        )
+        .await?;
+    storage
+        .write_artifact(
+            instance_name,
+            p2p_artifact_kind,
+            Some(&node_id),
+            &utils::encode_length_prefixed_message(&response.transactions[1]),
+        )
+        .await?;
+
+    tracing::info!("{label} proposals signed successfully");
+    Ok(())
+}
+
+/// The four artefact kinds a topology submit joins when aggregating peer
+/// signatures: the coordinator's original DNS / P2P proposals and the per-peer
+/// signed DNS / P2P blobs.
+pub struct DnsP2pArtifactKinds<'a> {
+    pub dns_proposal: &'a str,
+    pub p2p_proposal: &'a str,
+    pub signed_dns: &'a str,
+    pub signed_p2p: &'a str,
+}
+
+/// Aggregate every peer's signatures onto the coordinator's original DNS and
+/// P2P proposals.
+///
+/// Reads the coordinator's `dns_proposal` / `p2p_proposal` artefacts, then
+/// joins the per-peer `signed_dns` / `signed_p2p` artefacts by peer id so the
+/// two signatures for each peer stay paired the way the original combined-file
+/// format guaranteed. Returns the two proposals with all peer signatures
+/// merged in (the coordinator's own signature is already on the originals).
+///
+/// Callers that may resubmit — where a peer could sign twice or the
+/// coordinator's own signature could be re-added — should run
+/// [`dedupe_signatures`] on the results before submitting.
+pub async fn aggregate_dns_p2p_signatures(
+    storage: &SqlitePool,
+    instance_name: &str,
+    kinds: DnsP2pArtifactKinds<'_>,
+) -> Result<(SignedTopologyTransaction, SignedTopologyTransaction)> {
+    let dns_bytes = storage
+        .read_artifact(instance_name, kinds.dns_proposal, None)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("{kind} artifact missing", kind = kinds.dns_proposal))?;
+    let mut dns_transaction: SignedTopologyTransaction =
+        utils::read_first_message_from_bytes(&dns_bytes)?;
+
+    let p2p_bytes = storage
+        .read_artifact(instance_name, kinds.p2p_proposal, None)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("{kind} artifact missing", kind = kinds.p2p_proposal))?;
+    let mut p2p_transaction: SignedTopologyTransaction =
+        utils::read_first_message_from_bytes(&p2p_bytes)?;
+
+    // Join DNS and P2P signatures by peer id so each peer's pair stays paired.
+    let signed_dns = storage
+        .list_artifacts(instance_name, kinds.signed_dns)
+        .await?;
+    let signed_p2p: HashMap<String, Vec<u8>> = storage
+        .list_artifacts(instance_name, kinds.signed_p2p)
+        .await?
+        .into_iter()
+        .collect();
+
+    tracing::info!(
+        "Found signed proposals from {count} peer(s)",
+        count = signed_dns.len()
+    );
+    if signed_dns.len() != signed_p2p.len() {
+        anyhow::bail!(
+            "Mismatched signed proposal counts: {dns} DNS vs {p2p} P2P",
+            dns = signed_dns.len(),
+            p2p = signed_p2p.len()
+        );
+    }
+
+    for (peer_id, dns_signed_bytes) in &signed_dns {
+        tracing::info!("Aggregating signatures from peer {peer_id}");
+        let dns_signed: SignedTopologyTransaction =
+            utils::read_first_message_from_bytes(dns_signed_bytes)?;
+        let p2p_signed_bytes = signed_p2p
+            .get(peer_id)
+            .ok_or_else(|| anyhow::anyhow!("Peer {peer_id} signed DNS but not P2P"))?;
+        let p2p_signed: SignedTopologyTransaction =
+            utils::read_first_message_from_bytes(p2p_signed_bytes)?;
+
+        dns_transaction.signatures.extend(dns_signed.signatures);
+        p2p_transaction.signatures.extend(p2p_signed.signatures);
+    }
+
+    tracing::info!(
+        "Final DNS proposal has {dns} signature(s), P2P has {p2p}",
+        dns = dns_transaction.signatures.len(),
+        p2p = p2p_transaction.signatures.len()
+    );
+
+    Ok((dns_transaction, p2p_transaction))
+}
+
+/// Drop duplicate signatures, keeping the first per signing fingerprint.
+///
+/// Canton rejects a submitted transaction carrying the same signature twice —
+/// which can happen when the coordinator's own signature is already on a
+/// proposal and a retried peer signs again.
+pub fn dedupe_signatures(transaction: &mut SignedTopologyTransaction) {
+    let mut seen = HashSet::new();
+    transaction
+        .signatures
+        .retain(|sig| seen.insert(sig.signed_by.clone()));
+}
+
+/// Submit the aggregated DNS mapping, await its workflow-specific
+/// confirmation, then submit the P2P mapping and await its confirmation,
+/// finishing with the shared topology-propagation delay.
+///
+/// The submission order (DNS before P2P) and the trailing propagation delay
+/// are identical across the topology workflows; only the post-submit
+/// head-state checks differ — kick polls for mere existence, change-threshold
+/// for the new threshold value, add-party for owner / participant membership —
+/// so each caller supplies those as `confirm_dns` / `confirm_p2p`.
+///
+/// `label` is a short workflow tag included in the log lines.
+pub async fn submit_dns_then_p2p<DnsFut, P2pFut>(
+    config: &NodeConfig,
+    synchronizer_id: &str,
+    label: &str,
+    dns_transaction: SignedTopologyTransaction,
+    p2p_transaction: SignedTopologyTransaction,
+    confirm_dns: impl FnOnce() -> DnsFut,
+    confirm_p2p: impl FnOnce() -> P2pFut,
+) -> Result
+where
+    DnsFut: Future<Output = Result>,
+    P2pFut: Future<Output = Result>,
+{
+    let mut topology_write_client =
+        TopologyManagerWriteServiceClient::connect(config.admin_api_url()).await?;
+
+    tracing::info!("Submitting DNS {label} proposal...");
+    topology_write_client
+        .add_transactions(tonic::Request::new(add_transactions_request(
+            synchronizer_id,
+            dns_transaction,
+        )))
+        .await?;
+    confirm_dns().await?;
+    tracing::info!("DNS {label} confirmed in topology");
+
+    tracing::info!("Submitting P2P {label} proposal...");
+    topology_write_client
+        .add_transactions(tonic::Request::new(add_transactions_request(
+            synchronizer_id,
+            p2p_transaction,
+        )))
+        .await?;
+    confirm_p2p().await?;
+    tracing::info!("P2P {label} confirmed in topology");
+
+    let propagation_delay = Duration::from_secs(TOPOLOGY_PROPAGATION_DELAY_SECS);
+    tracing::info!("Waiting {propagation_delay:?} for Canton to propagate topology updates...");
+    tokio::time::sleep(propagation_delay).await;
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -195,5 +548,49 @@ mod tests {
     fn rejects_empty_message() {
         let status = tonic::Status::internal("");
         assert!(!is_topology_signing_key_not_ready(&status));
+    }
+
+    #[test]
+    fn head_state_query_targets_synchronizer_head_state() {
+        let query = head_state_query("global::1220abcd::34-0");
+        assert!(!query.proposals);
+        assert!(matches!(
+            query.time_query,
+            Some(base_query::TimeQuery::HeadState(()))
+        ));
+        match query.store.and_then(|s| s.store) {
+            Some(store_id::Store::Synchronizer(s)) => assert_eq!(
+                s.kind,
+                Some(synchronizer::Kind::PhysicalId(
+                    "global::1220abcd::34-0".to_string()
+                ))
+            ),
+            other => panic!("expected synchronizer store, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dedupe_signatures_keeps_first_per_fingerprint() {
+        use canton_proto_rs::com::digitalasset::canton::crypto::v30::Signature;
+
+        let sig = |signed_by: &str| Signature {
+            signed_by: signed_by.to_string(),
+            ..Default::default()
+        };
+        // Fingerprints a and b repeat; dedupe must keep the first of each,
+        // preserving order — Canton rejects a duplicate signature outright.
+        let mut transaction = SignedTopologyTransaction {
+            signatures: vec![sig("a"), sig("b"), sig("a"), sig("c"), sig("b")],
+            ..Default::default()
+        };
+
+        dedupe_signatures(&mut transaction);
+
+        let kept: Vec<&str> = transaction
+            .signatures
+            .iter()
+            .map(|s| s.signed_by.as_str())
+            .collect();
+        assert_eq!(kept, ["a", "b", "c"]);
     }
 }


### PR DESCRIPTION
Follow-up to #231. The kick, add-party and change-threshold topology workflows duplicated the same step logic. Pulled it into `workflow::topology` and migrated all three together so the shared paths get exercised in one IT run.

What moved into `workflow::topology`:

- `sign_dns_p2p_proposals` for the DNS+P2P sign step (was 3 near-identical copies; the per-workflow `sign_proposals` are now thin wrappers passing a label + artifact kinds)
- `aggregate_dns_p2p_signatures` + `submit_dns_then_p2p` for the submit skeleton. The post-submit head-state polls genuinely differ (kick waits on existence, change-threshold on the threshold value, add-party on owner/participant membership), so those stay per-workflow and get passed in as closures.
- `fetch_p2p_mapping` (was kick/change-threshold `get_current_p2p_mapping` and add-party `fetch_p2p_mapping`), plus `fetch_namespace_definition`, `head_state_query`, `synchronizer_store_id`, `add_transactions_request`, `dedupe_signatures`
- the 6 remaining local `encode_length_prefixed_message` copies now call `utils::encode_length_prefixed_message` (kick x3, onboarding, contracts, add-party); #231 already did the change-threshold ones

Net ~400 lines removed, behaviour unchanged. `fmt` + `clippy --all-targets --all-features -D warnings` clean. Added unit tests for `dedupe_signatures` and `head_state_query`.

Since this touches the tested kick/add-party/change-threshold paths, it needs the workflow IT to run green.

Closes #233
