### PR TITLE
docs: add feedback form link and fix architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -679,3 +679,8 @@ for vulnerabilities, our [Security Policy](docs/SECURITY.md).
 ## License
 
 Licensed under the [Apache License 2.0](LICENSE).
+
+## Feedback
+
+Have feedback on the Decentralization Manager? Let us know via our
+[feedback form](https://bitsafe.typeform.com/decman-feedback).

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The application runs as an HTTP server with an embedded React frontend. Multiple
 ```
 ┌─────────────────┐     Noise Protocol      ┌─────────────────┐
 │  Participant 1  │◄───────────────────────►│  Participant 2  │
-│   (Coordinator) │                         │    (Peer)   │
+│   (Coordinator) │                         │     (Peer)      │
 │   HTTP :8081    │                         │   HTTP :8082    │
 │   Noise :9001   │                         │   Noise :9002   │
 └────────┬────────┘                         └────────┬────────┘


### PR DESCRIPTION
- Adds a Feedback section at the bottom of the README linking to the DecMan feedback form (bitsafe.typeform.com/decman-feedback). Requested by Gabi.
- Fixes the architecture diagram: Participant 2's `(Peer)` line was 4 chars short, pulling the box's right border out of alignment.