### PR TITLE
docs: forward SSH key for docker builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ The application runs as an HTTP server with an embedded React frontend. Multiple
 
 - Rust toolchain (for building from source)
 - Access to Canton participant nodes (Admin API and Ledger API)
-- Docker (optional, for containerized deployment)
+- Docker (optional, for containerized deployment). Building the image also
+  requires an SSH key registered on a GitHub account — see
+  [Running with Docker](#running-with-docker)
 
 ### Running Locally
 
@@ -82,9 +84,18 @@ Open http://localhost:8081 in your browser.
 
 ### Running with Docker
 
+> **An SSH key is required to build the image.** The build compiles the
+> `canton-lib` Rust dependency, which Cargo fetches from GitHub over SSH, so
+> BuildKit needs an SSH key forwarded into the build via `--ssh`. `canton-lib`
+> is a **public** repository, so any SSH key registered on any GitHub account
+> works — no special repository access is required. Point `--ssh default=` at
+> your private key file, or pass just `--ssh default` to forward your running
+> `ssh-agent`.
+
 ```bash
-# Build the image
-docker build -t dec-party-manager .
+# Build the image (forward an SSH key registered on a GitHub account;
+# replace the key path with your own)
+docker build --ssh default=$HOME/.ssh/id_ed25519 -t dec-party-manager .
 
 # Run a single instance
 docker run -p 8080:8080 -v ./data:/data \
@@ -100,7 +111,12 @@ docker run -p 8080:8080 -v ./data:/data \
 
 ### Running Multiple Participants (Development)
 
+The Compose services build from the same `Dockerfile` and forward your
+`ssh-agent` (`ssh: default`), so add your GitHub-registered SSH key to the
+agent before bringing them up:
+
 ```bash
+ssh-add ~/.ssh/id_ed25519   # your GitHub-registered key
 cd development
 docker compose up
 ```
@@ -651,8 +667,9 @@ TypeScript imports won't resolve.
 Build and push to ECR:
 
 ```bash
-# Build
-docker build -t dec-party-manager .
+# Build (forward an SSH key to fetch the canton-lib dependency — see
+# "Running with Docker" above)
+docker build --ssh default=$HOME/.ssh/id_ed25519 -t dec-party-manager .
 
 # Tag for ECR
 docker tag dec-party-manager:latest public.ecr.aws/dlc-link/canton-decparty-manager:<version>

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -10,11 +10,14 @@ kicking a participant), see the [Use Cases](docs/USE_CASES.md).
 
 ## Quick Start with Docker
 
-Build the image locally, then run a single instance:
+Build the image locally, then run a single instance. The build fetches the
+`canton-lib` Rust dependency from GitHub over SSH, so forward an SSH key
+registered on a GitHub account via BuildKit's `--ssh` flag (`canton-lib` is
+public, so no special repository access is needed):
 
 ```bash
-# Build the image
-docker build -t dec-party-manager .
+# Build the image (replace the key path with your own GitHub-registered key)
+docker build --ssh default=$HOME/.ssh/id_ed25519 -t dec-party-manager .
 
 # Run
 docker run -p 8080:8080 -p 9000:9000 -v ./data:/data \


### PR DESCRIPTION
Building the image compiles the `canton-lib` Rust dependency, which cargo fetches over SSH. `canton-lib` is public, but GitHub SSH still requires a key, so a bare `docker build .` fails for anyone who hasn't forwarded one — which is what an external testnet operator just hit.

Documents forwarding an SSH key:
- `docker build --ssh default=<key> .` for the standalone build (README + USER_GUIDE)
- `ssh-add` before `docker compose up`, since the compose services use `ssh: default`

Docs only — no code or dependency changes. Any GitHub-registered key works; no repo access grant needed.