### PR TITLE
decman-cli: frontend parity, display fixes, mouse support

### DIFF
--- a/crates/decman-cli/src/api.rs
+++ b/crates/decman-cli/src/api.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, bail};
 use common::types::{
@@ -12,6 +12,8 @@ use reqwest::blocking::{Client, Response};
 use serde::Deserialize;
 use serde::de::DeserializeOwned;
 use serde_json::{Value, json};
+
+use crate::composer::{PickerOption, PickerSource};
 
 /// User credentials and optional IdP overrides for the OAuth2 password grant.
 ///
@@ -139,6 +141,7 @@ fn merge_peers(
     node: &NodeConfigResponse,
     peers: &[PeerConfig],
     statuses: &[ParticipantStatus],
+    self_latency_ms: Option<u64>,
 ) -> Vec<PeerView> {
     let by_id: HashMap<&str, &ParticipantStatus> =
         statuses.iter().map(|s| (s.id.as_str(), s)).collect();
@@ -162,7 +165,13 @@ fn merge_peers(
                 address: peer.address.clone(),
                 port: peer.port,
                 status,
-                latency_ms: live.and_then(|s| s.latency_ms),
+                // Peers report a measured round-trip; self uses our own
+                // API round-trip instead (a peer never probes itself).
+                latency_ms: if is_self {
+                    self_latency_ms
+                } else {
+                    live.and_then(|s| s.latency_ms)
+                },
                 version: live
                     .and_then(|s| s.version.clone())
                     .or_else(|| if is_self { node.version.clone() } else { None }),
@@ -185,7 +194,7 @@ fn merge_peers(
             address,
             port: node.node.port,
             status: Some(ConnectionStatus::CurrentNode),
-            latency_ms: None,
+            latency_ms: self_latency_ms,
             version: node.version.clone(),
             workflow: None,
             is_self: true,
@@ -343,6 +352,27 @@ pub struct GovernanceConfirmations {
 struct OperatorInfoResponse {
     #[serde(default)]
     party_id: String,
+}
+
+/// `/keys/status` response: whether this node's Noise keypair exists and, if so,
+/// its public key (the value peers configure to reach this node).
+#[derive(Clone, Debug, Deserialize)]
+pub struct KeyStatus {
+    #[serde(default)]
+    pub has_keys: bool,
+    #[serde(default)]
+    pub public_key: Option<String>,
+}
+
+/// `/network-info` response: the DSO identity this node is bound to. The
+/// `amulet_rules` blob is intentionally not deserialized (it is large and only
+/// needed server-side).
+#[derive(Clone, Debug, Deserialize)]
+pub struct NetworkInfo {
+    #[serde(default)]
+    pub dso_party_id: String,
+    #[serde(default)]
+    pub amulet_rules_cid: String,
 }
 
 /// Per-party IdP configuration, from `GET /party-config/{id}` (secrets are
@@ -537,6 +567,93 @@ fn short_id(id: &str) -> &str {
     id.split("::").next().unwrap_or(id)
 }
 
+/// The endpoint path and response envelope key for a picker source.
+fn source_endpoint(source: PickerSource) -> (&'static str, &'static str) {
+    match source {
+        PickerSource::Instruments => ("/instruments", "instruments"),
+        PickerSource::Vaults => ("/vaults", "vaults"),
+        PickerSource::ProviderServices => ("/services/provider", "services"),
+        PickerSource::UserServices => ("/services/user", "services"),
+        PickerSource::RegistrarServices => ("/services/registrar", "services"),
+        PickerSource::CredentialOffers => ("/credential-offers", "credential_offers"),
+        PickerSource::MintRequests => ("/governance/mint-requests", "mint_requests"),
+        PickerSource::BurnRequests => ("/governance/burn-requests", "burn_requests"),
+        PickerSource::TransferInstructions => {
+            ("/governance/transfer-instructions", "transfer_instructions")
+        }
+        PickerSource::TransferFactories => ("/transfer-factories", "transfer_factories"),
+    }
+}
+
+/// Read a string field off a JSON contract object (empty when absent).
+fn str_field(item: &Value, key: &str) -> String {
+    item.get(key)
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_owned()
+}
+
+/// A short, always-non-empty stand-in label for a contract with no better
+/// summary: the first characters of its id.
+fn short_cid(cid: &str) -> String {
+    let head: String = cid.chars().take(14).collect();
+    if cid.chars().count() > 14 {
+        format!("{head}…")
+    } else {
+        head
+    }
+}
+
+/// A one-line human summary for a fetched contract, formatted per source to
+/// mirror the web frontend's dropdown labels.
+fn picker_label(source: PickerSource, item: &Value) -> String {
+    let f = |key: &str| str_field(item, key);
+    let p = |key: &str| short_id(&f(key)).to_owned();
+    let label = match source {
+        PickerSource::Instruments => format!("{} · {}", f("instrument_id"), p("instrument_admin")),
+        PickerSource::Vaults => {
+            let (name, symbol) = (f("vault_name"), f("share_symbol"));
+            if symbol.is_empty() {
+                name
+            } else {
+                format!("{name} ({symbol})")
+            }
+        }
+        PickerSource::ProviderServices => format!("provider {}", p("provider")),
+        PickerSource::UserServices => format!("user {}", p("user")),
+        PickerSource::RegistrarServices => format!("registrar {}", p("registrar")),
+        PickerSource::CredentialOffers => format!("{} → {}", f("credential_id"), p("holder")),
+        PickerSource::MintRequests | PickerSource::BurnRequests => {
+            format!("{} {} → {}", f("amount"), f("instrument_id"), p("holder"))
+        }
+        PickerSource::TransferInstructions => format!(
+            "{} {} {}→{}",
+            f("amount"),
+            f("instrument_id"),
+            p("sender"),
+            p("receiver")
+        ),
+        PickerSource::TransferFactories => format!("admin {}", p("expected_admin")),
+    };
+    label.trim().to_owned()
+}
+
+/// Turn a JSON contract object into a [`PickerOption`], or `None` when it has no
+/// contract id (e.g. the synthetic shared-instrument transfer-factory rows).
+fn picker_option(source: PickerSource, item: &Value) -> Option<PickerOption> {
+    let value = str_field(item, "contract_id");
+    if value.is_empty() {
+        return None;
+    }
+    let label = picker_label(source, item);
+    let label = if label.chars().any(char::is_alphanumeric) {
+        label
+    } else {
+        short_cid(&value)
+    };
+    Some(PickerOption { value, label })
+}
+
 /// Per-party authentication status, from `/auth/status`. Internally tagged on
 /// the wire under `status`.
 #[derive(Clone, Debug, Deserialize)]
@@ -663,10 +780,19 @@ impl DecmanClient {
     /// Returns an error if login or either request fails, the API returns a
     /// non-success status, or a response cannot be parsed.
     pub fn fetch_peers(&mut self) -> Result<Vec<PeerView>> {
+        // Time one round-trip to our own API as the self-node latency (the web
+        // frontend shows the same "you" latency), so this node's row is not blank.
+        let start = Instant::now();
         let node: NodeConfigResponse = self.get_json("/node-config")?;
+        let self_latency_ms = u64::try_from(start.elapsed().as_millis()).ok();
         let config: NetworkConfigResponse = self.get_json("/network-config")?;
         let statuses: ParticipantsStatusResponse = self.get_json("/participants-status")?;
-        Ok(merge_peers(&node, &config.peers, &statuses.statuses))
+        Ok(merge_peers(
+            &node,
+            &config.peers,
+            &statuses.statuses,
+            self_latency_ms,
+        ))
     }
 
     /// Fetch the DAML packages (DARs) vetted on this node, sorted like the
@@ -814,6 +940,55 @@ impl DecmanClient {
             Some(json!({
                 "decentralized_party_id": party_id,
                 "participant_id": participant_id,
+                "new_threshold": new_threshold,
+                "previous_threshold": previous_threshold,
+            })),
+        )
+    }
+
+    /// Add a new member to an existing decentralized party, re-issuing the
+    /// namespace + party mappings with `new_threshold`. The new participant must
+    /// already be a configured peer of this node.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if login or the request fails, or the API rejects it
+    /// (e.g. the participant is already a member, or a workflow is in progress).
+    pub fn start_add_party(
+        &mut self,
+        party_id: &str,
+        new_participant_id: &str,
+        new_threshold: i32,
+        previous_threshold: i32,
+    ) -> Result<()> {
+        self.post(
+            "/add-party",
+            Some(json!({
+                "decentralized_party_id": party_id,
+                "new_participant_id": new_participant_id,
+                "new_threshold": new_threshold,
+                "previous_threshold": previous_threshold,
+            })),
+        )
+    }
+
+    /// Change the signing threshold of an existing decentralized party
+    /// (namespace + P2P), keeping its membership unchanged.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if login or the request fails, or the API rejects it
+    /// (e.g. a workflow is already in progress, or the party is solo-owned).
+    pub fn start_change_threshold(
+        &mut self,
+        party_id: &str,
+        new_threshold: i32,
+        previous_threshold: i32,
+    ) -> Result<()> {
+        self.post(
+            "/change-threshold",
+            Some(json!({
+                "decentralized_party_id": party_id,
                 "new_threshold": new_threshold,
                 "previous_threshold": previous_threshold,
             })),
@@ -1024,6 +1199,51 @@ impl DecmanClient {
     pub fn fetch_operator_info(&mut self) -> Result<String> {
         let response: OperatorInfoResponse = self.get_json("/operator-info")?;
         Ok(response.party_id)
+    }
+
+    /// Fetch this node's Noise key status (existence + public key).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if login or the request fails, the API returns a
+    /// non-success status, or the response cannot be parsed.
+    pub fn fetch_key_status(&mut self) -> Result<KeyStatus> {
+        self.get_json("/keys/status")
+    }
+
+    /// Fetch the DSO network identity this node is bound to.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if login or the request fails, the API returns a
+    /// non-success status (e.g. the DSO API is unreachable), or the response
+    /// cannot be parsed.
+    pub fn fetch_network_info(&mut self) -> Result<NetworkInfo> {
+        self.get_json("/network-info")
+    }
+
+    /// Fetch the selectable contracts for a composer picker field: the same
+    /// read endpoints the web frontend queries to populate its proposal-form
+    /// dropdowns, mapped to `(contract_id, label)` options.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if login or the request fails, the API returns a
+    /// non-success status, or the response cannot be parsed.
+    pub fn fetch_picker_options(
+        &mut self,
+        source: PickerSource,
+        party_id: &str,
+    ) -> Result<Vec<PickerOption>> {
+        let (path, key) = source_endpoint(source);
+        let response: Value = self.get_json_query(path, &[("party_id", party_id)])?;
+        Ok(response
+            .get(key)
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(|item| picker_option(source, item))
+            .collect())
     }
 
     /// Fetch the per-party IdP configuration for a dec party.
@@ -1603,13 +1823,15 @@ mod tests {
         )];
 
         // Act
-        let views = merge_peers(&node("self::1220"), &peers, &statuses);
+        let views = merge_peers(&node("self::1220"), &peers, &statuses, Some(7));
 
         // Assert — self first, peer status/latency/workflow mapped.
         assert_eq!(views.len(), 2);
         assert_eq!(views[0].name, "me");
         assert!(views[0].is_self);
         assert_eq!(views[0].status, Some(ConnectionStatus::CurrentNode));
+        // Self shows our own API round-trip latency, not a peer probe.
+        assert_eq!(views[0].latency_ms, Some(7));
         assert_eq!(views[1].name, "alpha");
         assert_eq!(views[1].status, Some(ConnectionStatus::Connected));
         assert_eq!(views[1].latency_ms, Some(12));
@@ -1627,13 +1849,14 @@ mod tests {
         }];
 
         // Act
-        let views = merge_peers(&node("self::1220"), &peers, &[]);
+        let views = merge_peers(&node("self::1220"), &peers, &[], Some(9));
 
         // Assert — self synthesized and listed first; missing status → None (Unknown).
         assert_eq!(views.len(), 2);
         assert!(views[0].is_self);
         assert_eq!(views[0].status, Some(ConnectionStatus::CurrentNode));
         assert_eq!(views[0].version.as_deref(), Some("0.9.1"));
+        assert_eq!(views[0].latency_ms, Some(9));
         assert!(!views[1].is_self);
         assert_eq!(views[1].name, "ghost");
         assert_eq!(views[1].status, None);
@@ -1666,6 +1889,56 @@ mod tests {
         // Assert
         let order: Vec<&str> = packages.iter().map(|p| p.package_id.as_str()).collect();
         assert_eq!(order, ["b", "a", "c"]);
+    }
+
+    #[test]
+    fn source_endpoint_maps_paths_and_envelope_keys() {
+        assert_eq!(
+            source_endpoint(PickerSource::MintRequests),
+            ("/governance/mint-requests", "mint_requests")
+        );
+        assert_eq!(source_endpoint(PickerSource::Vaults), ("/vaults", "vaults"));
+        assert_eq!(
+            source_endpoint(PickerSource::ProviderServices),
+            ("/services/provider", "services")
+        );
+    }
+
+    #[test]
+    fn picker_option_skips_empty_cid_and_labels_by_source() {
+        // A contract with no id (e.g. a synthetic transfer-factory row) is dropped.
+        assert!(picker_option(PickerSource::Vaults, &json!({ "vault_name": "v" })).is_none());
+
+        // Vault: name + share symbol.
+        let vault = picker_option(
+            PickerSource::Vaults,
+            &json!({ "contract_id": "00v", "vault_name": "Treasury", "share_symbol": "tSHR" }),
+        )
+        .expect("vault option");
+        assert_eq!(vault.value, "00v");
+        assert_eq!(vault.label, "Treasury (tSHR)");
+
+        // Mint request: amount, instrument, holder prefix.
+        let mint = picker_option(
+            PickerSource::MintRequests,
+            &json!({
+                "contract_id": "00m", "amount": "100", "instrument_id": "CBTC",
+                "holder": "alice::1220",
+            }),
+        )
+        .expect("mint option");
+        assert_eq!(mint.label, "100 CBTC → alice");
+    }
+
+    #[test]
+    fn picker_option_falls_back_to_short_cid_without_label_fields() {
+        let option = picker_option(
+            PickerSource::Instruments,
+            &json!({ "contract_id": "00abcdef0123456789" }),
+        )
+        .expect("instrument option");
+        // No instrument_id / admin → the label degrades to a truncated cid.
+        assert_eq!(option.label, "00abcdef012345…");
     }
 
     #[test]

--- a/crates/decman-cli/src/app.rs
+++ b/crates/decman-cli/src/app.rs
@@ -1904,7 +1904,9 @@ impl App {
             // Clicks only act on the plain tab view — overlays, the detail view
             // and search stay keyboard-driven (scroll still works there).
             MouseEventKind::Down(MouseButton::Left)
-                if matches!(self.overlay, Overlay::None) && self.detail.is_none() =>
+                if matches!(self.overlay, Overlay::None)
+                    && self.detail.is_none()
+                    && !self.searching =>
             {
                 self.on_click(mouse.column, mouse.row);
             }
@@ -3222,9 +3224,11 @@ impl App {
             );
             return;
         }
-        // Bound the threshold by the post-add member count (current + new one).
-        let member_count = i32::try_from(party.participants.len()).unwrap_or(i32::MAX);
-        let max_threshold = member_count.saturating_add(1);
+        // The signing threshold is over the namespace owners (like the kick
+        // flow) — not every participant is necessarily an owner. Bound it by the
+        // post-add owner count: the current owners plus the joining member.
+        let owner_count = i32::try_from(party.owners.len()).unwrap_or(i32::MAX);
+        let max_threshold = owner_count.saturating_add(1);
         self.overlay = Overlay::AddParty(AddPartyForm {
             party_id: party.party_id.to_string(),
             party_name: party_name(party).to_owned(),
@@ -3260,12 +3264,13 @@ impl App {
         let Some(party) = self.detail.as_ref() else {
             return;
         };
-        // A solo-owner party has a fixed threshold of 1 and nothing to change
-        // (mirrors the server's rejection).
-        let member_count = i32::try_from(party.participants.len()).unwrap_or(i32::MAX);
-        if member_count < 2 {
+        // The signing threshold is over the namespace owners (like the kick
+        // flow). A party with fewer than two owners has a fixed threshold of 1
+        // and nothing to change (mirrors the server's rejection).
+        let owner_count = i32::try_from(party.owners.len()).unwrap_or(i32::MAX);
+        if owner_count < 2 {
             self.overlay = Overlay::Message(
-                "Cannot change threshold: the party has only one member.".to_owned(),
+                "Cannot change threshold: the party has only one owner.".to_owned(),
             );
             return;
         }
@@ -3273,8 +3278,8 @@ impl App {
             party_id: party.party_id.to_string(),
             party_name: party_name(party).to_owned(),
             previous_threshold: party.threshold,
-            new_threshold: party.threshold.clamp(1, member_count),
-            max_threshold: member_count,
+            new_threshold: party.threshold.clamp(1, owner_count),
+            max_threshold: owner_count,
         });
     }
 

--- a/crates/decman-cli/src/app.rs
+++ b/crates/decman-cli/src/app.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::thread;
 use std::time::Duration;
@@ -5,7 +6,11 @@ use std::time::Duration;
 use anyhow::Result;
 use base64::prelude::*;
 use ratatui::DefaultTerminal;
-use ratatui::crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use ratatui::crossterm::event::{
+    self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseButton, MouseEvent,
+    MouseEventKind,
+};
+use ratatui::layout::Rect;
 use ratatui::widgets::TableState;
 use serde_json::{Value, json};
 
@@ -16,11 +21,12 @@ use common::types::{
 
 use crate::api::{
     AuthSettings, ChainAuditEntry, DecmanClient, DiscoverResult, DomainGovAction, ExecuteParams,
-    FeedItem, GovAction, GovConfirmation, GovState, GovernanceConfirmations, Holding, KnownMember,
-    PartyAuthStatus, PartyConfigView, PeerEntry, PeerView, party_name,
+    FeedItem, GovAction, GovConfirmation, GovState, GovernanceConfirmations, Holding, KeyStatus,
+    KnownMember, NetworkInfo, PartyAuthStatus, PartyConfigView, PeerEntry, PeerView, party_name,
 };
 use crate::composer::{
-    self, Composer, ComposerContext, ComposerSubmit, FieldKind, SelectOption, TypeOption,
+    self, Composer, ComposerContext, ComposerSubmit, FieldKind, PickerOption, PickerSource,
+    SelectOption, TypeOption,
 };
 use crate::config::Profile;
 use crate::ui;
@@ -54,25 +60,32 @@ pub fn run_login(terminal: &mut DefaultTerminal, profiles: &[Profile]) -> Result
     loop {
         terminal.draw(|frame| ui::draw_login(frame, profiles, &mut state))?;
 
-        let Event::Key(key) = event::read()? else {
-            continue;
+        let select_next = |state: &mut TableState| {
+            let next = state.selected().map_or(0, |i| (i + 1) % profiles.len());
+            state.select(Some(next));
         };
-        if key.kind != KeyEventKind::Press {
-            continue;
-        }
-        match (key.code, key.modifiers) {
-            (KeyCode::Char('q') | KeyCode::Esc, _) => return Ok(None),
-            (KeyCode::Char('c'), KeyModifiers::CONTROL) => return Ok(None),
-            (KeyCode::Down | KeyCode::Char('j'), _) => {
-                let next = state.selected().map_or(0, |i| (i + 1) % profiles.len());
-                state.select(Some(next));
-            }
-            (KeyCode::Up | KeyCode::Char('k'), _) => {
-                let len = profiles.len();
-                let previous = state.selected().map_or(0, |i| (i + len - 1) % len);
-                state.select(Some(previous));
-            }
-            (KeyCode::Enter, _) => return Ok(profiles.get(state.selected().unwrap_or(0)).cloned()),
+        let select_previous = |state: &mut TableState| {
+            let len = profiles.len();
+            let previous = state.selected().map_or(0, |i| (i + len - 1) % len);
+            state.select(Some(previous));
+        };
+
+        match event::read()? {
+            Event::Key(key) if key.kind == KeyEventKind::Press => match (key.code, key.modifiers) {
+                (KeyCode::Char('q') | KeyCode::Esc, _) => return Ok(None),
+                (KeyCode::Char('c'), KeyModifiers::CONTROL) => return Ok(None),
+                (KeyCode::Down | KeyCode::Char('j'), _) => select_next(&mut state),
+                (KeyCode::Up | KeyCode::Char('k'), _) => select_previous(&mut state),
+                (KeyCode::Enter, _) => {
+                    return Ok(profiles.get(state.selected().unwrap_or(0)).cloned());
+                }
+                _ => {}
+            },
+            Event::Mouse(mouse) => match mouse.kind {
+                MouseEventKind::ScrollDown => select_next(&mut state),
+                MouseEventKind::ScrollUp => select_previous(&mut state),
+                _ => {}
+            },
             _ => {}
         }
     }
@@ -114,6 +127,17 @@ pub enum Request {
         new_threshold: i32,
         previous_threshold: i32,
     },
+    AddParty {
+        party_id: String,
+        participant_id: String,
+        new_threshold: i32,
+        previous_threshold: i32,
+    },
+    ChangeThreshold {
+        party_id: String,
+        new_threshold: i32,
+        previous_threshold: i32,
+    },
     CancelWorkflow(WorkflowKind),
     RetryWorkflow(String),
     ChainAudit(String),
@@ -141,6 +165,12 @@ pub enum Request {
     PartyConfig(String),
     SavePartyConfig(Box<Value>),
     Discover(Box<Value>),
+    NodeInfo,
+    /// Fetch the selectable contracts for the picker fields of an open composer.
+    PickerOptions {
+        party_id: String,
+        sources: Vec<PickerSource>,
+    },
 }
 
 /// A result delivered by a background worker.
@@ -160,6 +190,16 @@ pub enum Update {
     NetworkPeers(Result<Vec<PeerEntry>, String>),
     PartyConfig(Result<Box<PartyConfigForm>, String>),
     Discovered(Result<DiscoverResult, String>),
+    NodeInfo(Box<NodeInfoData>),
+    /// Fetched picker options, keyed by the source they belong to.
+    PickerOptions(Vec<(PickerSource, Result<Vec<PickerOption>, String>)>),
+}
+
+/// This node's key status and DSO network identity, each fetched independently
+/// so one failing (e.g. the DSO API is unreachable) does not hide the other.
+pub struct NodeInfoData {
+    pub key: Result<KeyStatus, String>,
+    pub network: Result<NetworkInfo, String>,
 }
 
 /// A DAR file picked from disk for upload / distribution.
@@ -212,6 +252,31 @@ pub struct KickForm {
     pub selected: usize,
     pub new_threshold: i32,
     /// Highest threshold allowed after the kick (remaining owner count).
+    pub max_threshold: i32,
+}
+
+/// The add-party form: pick a configured peer that is not yet a member, and
+/// set the signing threshold for the party once it has joined.
+pub struct AddPartyForm {
+    pub party_id: String,
+    pub party_name: String,
+    pub previous_threshold: i32,
+    /// Configured peers not already in the party (self excluded).
+    pub candidates: Vec<KickCandidate>,
+    pub selected: usize,
+    pub new_threshold: i32,
+    /// Highest threshold allowed after the add (current members + the new one).
+    pub max_threshold: i32,
+}
+
+/// The change-threshold form: adjust the signing threshold of an existing
+/// party, keeping its membership unchanged.
+pub struct ChangeThresholdForm {
+    pub party_id: String,
+    pub party_name: String,
+    pub previous_threshold: i32,
+    pub new_threshold: i32,
+    /// Highest threshold allowed (the party's member count).
     pub max_threshold: i32,
 }
 
@@ -457,6 +522,10 @@ pub enum Overlay {
     Onboard(OnboardForm),
     /// The kick-participant form.
     Kick(KickForm),
+    /// The add-party form (add a new member to an existing party).
+    AddParty(AddPartyForm),
+    /// The change-threshold form (change a party's signing threshold).
+    ChangeThreshold(ChangeThresholdForm),
     /// A scrollable detail view of a feed item (workflow run or invitation).
     /// Boxed: a feed item (with its workflow run) is large relative to the
     /// other overlay variants.
@@ -488,6 +557,8 @@ pub enum Overlay {
     NetworkEdit(Box<NetworkEditState>),
     /// The per-party IdP configuration editor.
     PartyConfig(Box<PartyConfigForm>),
+    /// This node's key status and DSO network identity.
+    NodeInfo(Box<NodeInfoData>),
 }
 
 /// The selectable top-level views.
@@ -613,6 +684,22 @@ fn validate_prefix(prefix: &str) -> Result<(), String> {
         return Err("Party id prefix may only contain letters, digits, '-' and '_'.".to_owned());
     }
     Ok(())
+}
+
+/// The tab whose label on the panel's top border contains screen column
+/// `column`, mirroring the tab-bar layout in [`ui::tab_block`]: a leading space,
+/// then each tab title separated by a 3-column ` │ `.
+fn tab_at(body: Rect, column: u16) -> Option<Tab> {
+    let mut offset: u16 = 1; // the leading space before the first title
+    for tab in Tab::ALL {
+        let title_len = tab.title().chars().count() as u16;
+        let start = body.x + 1 + offset; // +1 for the top-left border corner
+        if column >= start && column < start + title_len {
+            return Some(tab);
+        }
+        offset += title_len + 3; // advance past the title and the ` │ ` divider
+    }
+    None
 }
 
 /// Keep a table's selection in range after its data changes.
@@ -811,6 +898,18 @@ fn handle_request(client: &mut DecmanClient, request: Request) -> Update {
         Request::Discover(body) => {
             Update::Discovered(client.discover_member_party(*body).map_err(err))
         }
+        Request::NodeInfo => Update::NodeInfo(Box::new(NodeInfoData {
+            key: client.fetch_key_status().map_err(err),
+            network: client.fetch_network_info().map_err(err),
+        })),
+        Request::PickerOptions { party_id, sources } => {
+            let mut options = Vec::with_capacity(sources.len());
+            for source in sources {
+                let result = client.fetch_picker_options(source, &party_id).map_err(err);
+                options.push((source, result));
+            }
+            Update::PickerOptions(options)
+        }
         Request::Onboard { prefix, peer_ids } => Update::Action(
             client
                 .start_onboarding(&prefix, &peer_ids)
@@ -831,6 +930,32 @@ fn handle_request(client: &mut DecmanClient, request: Request) -> Update {
                     previous_threshold,
                 )
                 .map(|()| "Kick started".to_owned())
+                .map_err(err),
+        ),
+        Request::AddParty {
+            party_id,
+            participant_id,
+            new_threshold,
+            previous_threshold,
+        } => Update::Action(
+            client
+                .start_add_party(
+                    &party_id,
+                    &participant_id,
+                    new_threshold,
+                    previous_threshold,
+                )
+                .map(|()| "Add-party started".to_owned())
+                .map_err(err),
+        ),
+        Request::ChangeThreshold {
+            party_id,
+            new_threshold,
+            previous_threshold,
+        } => Update::Action(
+            client
+                .start_change_threshold(&party_id, new_threshold, previous_threshold)
+                .map(|()| "Change-threshold started".to_owned())
                 .map_err(err),
         ),
         Request::CancelWorkflow(kind) => Update::Action(
@@ -1266,6 +1391,26 @@ fn next_select_value(options: &[SelectOption], current: &str, forward: bool) -> 
     options[next].value.to_owned()
 }
 
+/// The picker option value one step forward / back from `current`. When
+/// `current` matches no option (nothing picked yet, or a typed cid), the first
+/// press lands on the first option.
+fn next_picker_value(options: &[PickerOption], current: &str, forward: bool) -> String {
+    match options.iter().position(|option| option.value == current) {
+        None => options
+            .first()
+            .map_or_else(|| current.to_owned(), |o| o.value.clone()),
+        Some(index) => {
+            let len = options.len();
+            let next = if forward {
+                (index + 1) % len
+            } else {
+                (index + len - 1) % len
+            };
+            options[next].value.clone()
+        }
+    }
+}
+
 /// Handle a key in the composer form. Returns `true` when the form was
 /// submitted (Enter on the virtual submit row).
 fn composer_key(composer: &mut Composer, key: KeyEvent) -> bool {
@@ -1331,6 +1476,23 @@ fn composer_key(composer: &mut Composer, key: KeyEvent) -> bool {
                     _ => {}
                 }
             }
+            // ← / → cycle the fetched options; typing / backspace stay available
+            // so a cid can be pasted while the list loads or when it is empty.
+            FieldKind::Picker {
+                options, loaded, ..
+            } => match key.code {
+                KeyCode::Left if *loaded && !options.is_empty() => {
+                    field.value = next_picker_value(options, &field.value, false);
+                }
+                KeyCode::Right if *loaded && !options.is_empty() => {
+                    field.value = next_picker_value(options, &field.value, true);
+                }
+                KeyCode::Char(c) => field.value.push(c),
+                KeyCode::Backspace => {
+                    field.value.pop();
+                }
+                _ => {}
+            },
         }
     }
     false
@@ -1367,6 +1529,9 @@ pub struct App {
     can_logout: bool,
     /// The operator party id, prefetched for composer prefill (empty if unknown).
     operator_party: String,
+    /// The active tab panel's rect from the last frame, used to hit-test mouse
+    /// clicks (tab bar on the top border, table rows inside).
+    body_area: Rect,
     should_quit: bool,
     should_logout: bool,
 }
@@ -1402,9 +1567,16 @@ impl App {
             tick: 0,
             can_logout,
             operator_party: String::new(),
+            body_area: Rect::default(),
             should_quit: false,
             should_logout: false,
         }
+    }
+
+    /// Record the active tab panel's rect (called by the UI each frame) so mouse
+    /// clicks can be mapped back to a tab or table row.
+    pub fn set_body_area(&mut self, area: Rect) {
+        self.body_area = area;
     }
 
     /// Whether the party detail view is open.
@@ -1436,6 +1608,15 @@ impl App {
     /// The currently active tab.
     pub fn active_tab(&self) -> Tab {
         self.active_tab
+    }
+
+    /// The version of the node this session is managing, read off this node's
+    /// own peer row (`/node-config`). `None` until the first peer poll returns.
+    pub fn node_version(&self) -> Option<&str> {
+        self.peers
+            .iter()
+            .find(|peer| peer.is_self)
+            .and_then(|peer| peer.version.as_deref())
     }
 
     /// The active modal overlay (if any).
@@ -1659,6 +1840,33 @@ impl App {
                         }
                     }
                 }
+                Update::NodeInfo(data) => {
+                    if matches!(self.overlay, Overlay::Busy(_)) {
+                        self.overlay = Overlay::NodeInfo(data);
+                    }
+                }
+                // Fill in the open composer's picker fields. A failed fetch is
+                // treated as an empty list: the field is marked loaded and
+                // falls back to free-text cid entry.
+                Update::PickerOptions(results) => {
+                    if let Overlay::Composer(composer) = &mut self.overlay {
+                        for (source, result) in results {
+                            let loaded_options = result.unwrap_or_default();
+                            for field in &mut composer.fields {
+                                if let FieldKind::Picker {
+                                    source: field_source,
+                                    options,
+                                    loaded,
+                                } = &mut field.kind
+                                    && *field_source == source
+                                {
+                                    *options = loaded_options.clone();
+                                    *loaded = true;
+                                }
+                            }
+                        }
+                    }
+                }
                 // Ignore late detail results after the view was closed.
                 Update::Detail(data) if self.detail.is_some() => {
                     self.detail_data = Some(data);
@@ -1673,14 +1881,71 @@ impl App {
 
     /// Poll for the next terminal event (with a tick timeout) and dispatch it.
     fn handle_events(&mut self) -> Result<()> {
-        if event::poll(TICK)?
-            && let Event::Key(key) = event::read()?
-            && key.kind == KeyEventKind::Press
-        {
-            self.on_key(key);
+        if event::poll(TICK)? {
+            match event::read()? {
+                Event::Key(key) if key.kind == KeyEventKind::Press => self.on_key(key),
+                Event::Mouse(mouse) => self.on_mouse(mouse),
+                _ => {}
+            }
         }
 
         Ok(())
+    }
+
+    /// Dispatch a mouse event. The scroll wheel maps to the up/down keys so it
+    /// drives navigation in every context; a left click on the main view selects
+    /// a tab or table row.
+    fn on_mouse(&mut self, mouse: MouseEvent) {
+        match mouse.kind {
+            MouseEventKind::ScrollDown => {
+                self.on_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE))
+            }
+            MouseEventKind::ScrollUp => self.on_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE)),
+            // Clicks only act on the plain tab view — overlays, the detail view
+            // and search stay keyboard-driven (scroll still works there).
+            MouseEventKind::Down(MouseButton::Left)
+                if matches!(self.overlay, Overlay::None) && self.detail.is_none() =>
+            {
+                self.on_click(mouse.column, mouse.row);
+            }
+            _ => {}
+        }
+    }
+
+    /// Handle a left click at `(column, row)` on the main tab view: a click on
+    /// the tab bar (the panel's top border) switches tabs; a click on a table
+    /// row selects it, and on the Parties tab opens that party's detail.
+    fn on_click(&mut self, column: u16, row: u16) {
+        let body = self.body_area;
+        if body.width == 0 || body.height == 0 {
+            return;
+        }
+        // The tab labels live on the panel's top border line.
+        if row == body.y {
+            if let Some(tab) = tab_at(body, column) {
+                self.switch_to(tab);
+            }
+            return;
+        }
+        // Table rows: the block border + horizontal padding inset the content by
+        // two columns; the header sits on the first inner line, data rows below.
+        let inner_left = body.x + 2;
+        let inner_right = body.x + body.width.saturating_sub(2);
+        let first_row = body.y + 2;
+        let last_row = body.y + body.height.saturating_sub(1); // bottom border
+        if column < inner_left || column >= inner_right || row < first_row || row >= last_row {
+            return;
+        }
+        let visible_index = (row - first_row) as usize;
+        let len = self.current_len();
+        let index = self.current_table_mut().offset() + visible_index;
+        if index >= len {
+            return;
+        }
+        self.current_table_mut().select(Some(index));
+        if self.active_tab == Tab::Parties {
+            self.open_party_detail();
+        }
     }
 
     /// Dispatch a key press: overlay, then detail, then search, then main view.
@@ -1722,6 +1987,8 @@ impl App {
             (KeyCode::Char('n'), _) if self.active_tab == Tab::Parties => self.open_onboard(),
             // Edit the network peer configuration.
             (KeyCode::Char('e'), _) if self.active_tab == Tab::Peers => self.open_network_edit(),
+            // View this node's key status and DSO network identity.
+            (KeyCode::Char('i'), _) if self.active_tab == Tab::Peers => self.open_node_info(),
             // Workflows actions.
             (KeyCode::Char('a'), _) if self.active_tab == Tab::Workflows => {
                 self.invitation_action(true);
@@ -1750,6 +2017,8 @@ impl App {
             Distribute,
             Onboard,
             Kick,
+            AddParty,
+            ChangeThreshold,
             TestAuth,
             GovConfirm,
             GovExecute,
@@ -1826,6 +2095,36 @@ impl App {
                         form.selected += 1;
                     }
                 }
+                KeyCode::Left | KeyCode::Char('-') => {
+                    form.new_threshold = (form.new_threshold - 1).max(1);
+                }
+                KeyCode::Right | KeyCode::Char('+') => {
+                    form.new_threshold = (form.new_threshold + 1).min(form.max_threshold);
+                }
+                _ => {}
+            },
+            Overlay::AddParty(form) => match key.code {
+                KeyCode::Esc => act = Act::Close,
+                KeyCode::Enter => act = Act::AddParty,
+                KeyCode::Up | KeyCode::Char('k') => {
+                    form.selected = form.selected.saturating_sub(1);
+                }
+                KeyCode::Down | KeyCode::Char('j') => {
+                    if form.selected + 1 < form.candidates.len() {
+                        form.selected += 1;
+                    }
+                }
+                KeyCode::Left | KeyCode::Char('-') => {
+                    form.new_threshold = (form.new_threshold - 1).max(1);
+                }
+                KeyCode::Right | KeyCode::Char('+') => {
+                    form.new_threshold = (form.new_threshold + 1).min(form.max_threshold);
+                }
+                _ => {}
+            },
+            Overlay::ChangeThreshold(form) => match key.code {
+                KeyCode::Esc => act = Act::Close,
+                KeyCode::Enter => act = Act::ChangeThreshold,
                 KeyCode::Left | KeyCode::Char('-') => {
                     form.new_threshold = (form.new_threshold - 1).max(1);
                 }
@@ -2051,7 +2350,7 @@ impl App {
                     _ => {}
                 }
             }
-            Overlay::Message(_) | Overlay::Busy(_) => {
+            Overlay::NodeInfo(_) | Overlay::Message(_) | Overlay::Busy(_) => {
                 if matches!(key.code, KeyCode::Esc | KeyCode::Enter | KeyCode::Char('q')) {
                     act = Act::Close;
                 }
@@ -2065,6 +2364,8 @@ impl App {
             Act::Distribute => self.confirm_distribute(),
             Act::Onboard => self.confirm_onboard(),
             Act::Kick => self.confirm_kick(),
+            Act::AddParty => self.confirm_add_party(),
+            Act::ChangeThreshold => self.confirm_change_threshold(),
             Act::TestAuth => self.run_auth_test(),
             Act::GovConfirm => self.gov_confirm(),
             Act::GovExecute => self.gov_execute(),
@@ -2146,6 +2447,10 @@ impl App {
             KeyCode::Enter | KeyCode::Char(' ') => self.open_audit_json(),
             // Kick a participant from this party.
             KeyCode::Char('K') => self.open_kick(),
+            // Add a new member to this party.
+            KeyCode::Char('P') => self.open_add_party(),
+            // Change this party's signing threshold.
+            KeyCode::Char('T') => self.open_change_threshold(),
             // View the on-chain governance audit trail.
             KeyCode::Char('c') => self.open_chain_audit(),
             // Open the governance approvals list (confirm / execute / revoke).
@@ -2329,7 +2634,23 @@ impl App {
                 cursor: 0,
             }
         };
+        // Gather the distinct picker sources this form needs and kick off their
+        // background fetch; options stream in via `Update::PickerOptions`.
+        let party_id = composer.party_id.clone();
+        let mut sources: Vec<PickerSource> = Vec::new();
+        for field in &composer.fields {
+            if let FieldKind::Picker { source, .. } = field.kind
+                && !sources.contains(&source)
+            {
+                sources.push(source);
+            }
+        }
         self.overlay = Overlay::Composer(Box::new(composer));
+        if !sources.is_empty() {
+            let _ = self
+                .requests
+                .send(Request::PickerOptions { party_id, sources });
+        }
     }
 
     /// Validate the composer form and submit it (confirm or propose).
@@ -2404,6 +2725,12 @@ impl App {
     fn open_network_edit(&mut self) {
         let _ = self.requests.send(Request::NetworkPeers);
         self.overlay = Overlay::Busy("Loading network configuration…".to_owned());
+    }
+
+    /// Fetch and show this node's key status and DSO network identity.
+    fn open_node_info(&mut self) {
+        let _ = self.requests.send(Request::NodeInfo);
+        self.overlay = Overlay::Busy("Loading node info…".to_owned());
     }
 
     /// Save the edited peer list back to the node.
@@ -2856,6 +3183,120 @@ impl App {
         self.overlay = Overlay::Busy(format!("Kicking {label}…"));
     }
 
+    /// Open the add-party form for the party in the detail view, listing the
+    /// configured peers not already members (self excluded).
+    fn open_add_party(&mut self) {
+        let Some(party) = self.detail.as_ref() else {
+            return;
+        };
+        // Require this node's identity to be resolved so self is excluded.
+        let Some(self_id) = self
+            .peers
+            .iter()
+            .find(|peer| peer.is_self)
+            .map(|peer| peer.participant_id.clone())
+        else {
+            self.overlay = Overlay::Message(
+                "Still resolving this node's identity — try again in a moment.".to_owned(),
+            );
+            return;
+        };
+        let members: HashSet<String> = party
+            .participants
+            .iter()
+            .map(|participant| participant.participant_uid.to_string())
+            .collect();
+        let candidates: Vec<KickCandidate> = self
+            .peers
+            .iter()
+            .filter(|peer| !peer.is_self && peer.participant_id != self_id)
+            .filter(|peer| !members.contains(&peer.participant_id))
+            .map(|peer| KickCandidate {
+                participant_id: peer.participant_id.clone(),
+                label: peer.name.clone(),
+            })
+            .collect();
+        if candidates.is_empty() {
+            self.overlay = Overlay::Message(
+                "No peers left to add — every configured peer is already a member.".to_owned(),
+            );
+            return;
+        }
+        // Bound the threshold by the post-add member count (current + new one).
+        let member_count = i32::try_from(party.participants.len()).unwrap_or(i32::MAX);
+        let max_threshold = member_count.saturating_add(1);
+        self.overlay = Overlay::AddParty(AddPartyForm {
+            party_id: party.party_id.to_string(),
+            party_name: party_name(party).to_owned(),
+            previous_threshold: party.threshold,
+            candidates,
+            selected: 0,
+            new_threshold: party.threshold.clamp(1, max_threshold),
+            max_threshold,
+        });
+    }
+
+    /// Send the add-party request for the selected candidate.
+    fn confirm_add_party(&mut self) {
+        let Overlay::AddParty(form) = &self.overlay else {
+            return;
+        };
+        let Some(candidate) = form.candidates.get(form.selected) else {
+            return;
+        };
+        let request = Request::AddParty {
+            party_id: form.party_id.clone(),
+            participant_id: candidate.participant_id.clone(),
+            new_threshold: form.new_threshold,
+            previous_threshold: form.previous_threshold,
+        };
+        let label = candidate.label.clone();
+        let _ = self.requests.send(request);
+        self.overlay = Overlay::Busy(format!("Adding {label}…"));
+    }
+
+    /// Open the change-threshold form for the party in the detail view.
+    fn open_change_threshold(&mut self) {
+        let Some(party) = self.detail.as_ref() else {
+            return;
+        };
+        // A solo-owner party has a fixed threshold of 1 and nothing to change
+        // (mirrors the server's rejection).
+        let member_count = i32::try_from(party.participants.len()).unwrap_or(i32::MAX);
+        if member_count < 2 {
+            self.overlay = Overlay::Message(
+                "Cannot change threshold: the party has only one member.".to_owned(),
+            );
+            return;
+        }
+        self.overlay = Overlay::ChangeThreshold(ChangeThresholdForm {
+            party_id: party.party_id.to_string(),
+            party_name: party_name(party).to_owned(),
+            previous_threshold: party.threshold,
+            new_threshold: party.threshold.clamp(1, member_count),
+            max_threshold: member_count,
+        });
+    }
+
+    /// Send the change-threshold request from the form.
+    fn confirm_change_threshold(&mut self) {
+        let Overlay::ChangeThreshold(form) = &self.overlay else {
+            return;
+        };
+        if form.new_threshold == form.previous_threshold {
+            self.overlay =
+                Overlay::Message(format!("Threshold is already {}.", form.previous_threshold));
+            return;
+        }
+        let request = Request::ChangeThreshold {
+            party_id: form.party_id.clone(),
+            new_threshold: form.new_threshold,
+            previous_threshold: form.previous_threshold,
+        };
+        let _ = self.requests.send(request);
+        self.overlay = Overlay::Busy("Changing threshold…".to_owned());
+    }
+
     /// Kick off the package checker.
     fn start_compare(&mut self) {
         let _ = self.requests.send(Request::Compare);
@@ -3236,6 +3677,74 @@ mod tests {
         assert_eq!(body["auth0_domain"], "tenant.auth0.com");
         assert_eq!(body["auth0_client_id"], "a0client");
         assert!(body.get("keycloak_client_secret").is_none());
+    }
+
+    #[test]
+    fn next_picker_value_cycles_and_starts_at_first() {
+        let options = vec![
+            PickerOption {
+                value: "a".to_owned(),
+                label: "A".to_owned(),
+            },
+            PickerOption {
+                value: "b".to_owned(),
+                label: "B".to_owned(),
+            },
+            PickerOption {
+                value: "c".to_owned(),
+                label: "C".to_owned(),
+            },
+        ];
+        // Nothing (or a typed cid) selected → first press lands on the first.
+        assert_eq!(next_picker_value(&options, "", true), "a");
+        assert_eq!(next_picker_value(&options, "", false), "a");
+        assert_eq!(next_picker_value(&options, "typed", true), "a");
+        // Forward and backward wrap around the ends.
+        assert_eq!(next_picker_value(&options, "c", true), "a");
+        assert_eq!(next_picker_value(&options, "a", false), "c");
+        assert_eq!(next_picker_value(&options, "a", true), "b");
+        // No options → the current value is kept.
+        assert_eq!(next_picker_value(&[], "x", true), "x");
+    }
+
+    #[test]
+    fn tab_at_maps_border_columns_to_tabs() {
+        // Title bar: "‹space›Parties │ Peers │ Dars │ Workflows", starting one
+        // column in from the top-left border corner.
+        let body = Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 20,
+        };
+        // The corner and the leading space are not a tab.
+        assert_eq!(tab_at(body, 0), None);
+        assert_eq!(tab_at(body, 1), None);
+        // "Parties" spans columns 2..9.
+        assert_eq!(tab_at(body, 2), Some(Tab::Parties));
+        assert_eq!(tab_at(body, 8), Some(Tab::Parties));
+        // The " │ " divider is dead space.
+        assert_eq!(tab_at(body, 9), None);
+        // The remaining tabs, past each divider.
+        assert_eq!(tab_at(body, 12), Some(Tab::Peers));
+        assert_eq!(tab_at(body, 20), Some(Tab::Dars));
+        assert_eq!(tab_at(body, 27), Some(Tab::Workflows));
+        assert_eq!(tab_at(body, 35), Some(Tab::Workflows));
+        // Past the last title.
+        assert_eq!(tab_at(body, 60), None);
+    }
+
+    #[test]
+    fn tab_at_respects_panel_offset() {
+        // A non-zero panel origin shifts every tab range by the same amount.
+        let body = Rect {
+            x: 10,
+            y: 4,
+            width: 80,
+            height: 20,
+        };
+        assert_eq!(tab_at(body, 12), Some(Tab::Parties));
+        assert_eq!(tab_at(body, 22), Some(Tab::Peers));
     }
 
     #[test]

--- a/crates/decman-cli/src/composer.rs
+++ b/crates/decman-cli/src/composer.rs
@@ -25,6 +25,42 @@ pub enum FieldKind {
     /// Newline-separated rows, each split on commas into `columns` → a JSON
     /// array of `{ column: value }` objects.
     Rows(Vec<&'static str>),
+    /// A contract id chosen from a live-fetched list (← / → cycles once the
+    /// options load). Falls back to free-text entry while loading or when the
+    /// list is empty, so a cid can still be pasted. `options` / `loaded` are
+    /// filled in asynchronously after the form opens; serializes as a string,
+    /// exactly like [`FieldKind::Text`].
+    Picker {
+        source: PickerSource,
+        options: Vec<PickerOption>,
+        loaded: bool,
+    },
+}
+
+/// Which read endpoint populates a [`FieldKind::Picker`]'s options — the same
+/// lists the web frontend's proposal forms fetch to offer contract dropdowns.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PickerSource {
+    Instruments,
+    Vaults,
+    ProviderServices,
+    UserServices,
+    RegistrarServices,
+    CredentialOffers,
+    MintRequests,
+    BurnRequests,
+    TransferInstructions,
+    TransferFactories,
+}
+
+/// One fetched contract offered in a [`FieldKind::Picker`]. Owned, unlike the
+/// `&'static` [`SelectOption`], because the values come from the ledger.
+#[derive(Clone, Debug)]
+pub struct PickerOption {
+    /// The contract id stored in the field's value on selection.
+    pub value: String,
+    /// A human-readable one-line summary shown instead of the raw cid.
+    pub label: String,
 }
 
 /// One option in a [`FieldKind::Select`].
@@ -215,6 +251,24 @@ fn select(
     )
 }
 
+/// A required contract-id field backed by a live-fetched picker. The list is
+/// populated asynchronously; until then (and if it comes back empty) the field
+/// accepts a pasted cid.
+fn picker(key: &'static str, label: &'static str, source: PickerSource) -> ComposerField {
+    field(
+        key,
+        label,
+        FieldKind::Picker {
+            source,
+            options: Vec::new(),
+            loaded: false,
+        },
+        String::new(),
+        false,
+        "←/→ to pick",
+    )
+}
+
 fn rows(key: &'static str, label: &'static str, columns: Vec<&'static str>) -> ComposerField {
     field(
         key,
@@ -328,19 +382,25 @@ pub fn fields_for_action(action_type: &str, ctx: &ComposerContext) -> Vec<Compos
             3_600_000_000,
             "1 hour = 3,600,000,000 µs",
         )],
-        "vault_pause" | "vault_unpause" => vec![text("vault_id", "Vault contract id")],
+        "vault_pause" | "vault_unpause" => {
+            vec![picker(
+                "vault_id",
+                "Vault contract id",
+                PickerSource::Vaults,
+            )]
+        }
         "vault_update_limits" => vec![
-            text("vault_id", "Vault contract id"),
+            picker("vault_id", "Vault contract id", PickerSource::Vaults),
             text_opt("new_limits.max_total_deposit", "Max total deposit"),
             text_opt("new_limits.min_deposit_amount", "Min deposit amount"),
             text_opt("new_limits.min_withdrawal_amount", "Min withdrawal amount"),
         ],
         "vault_update_backend" => vec![
-            text("vault_id", "Vault contract id"),
+            picker("vault_id", "Vault contract id", PickerSource::Vaults),
             text("new_backend_signatory", "New backend signatory"),
         ],
         "vault_update_far_beneficiaries" => vec![
-            text("vault_id", "Vault contract id"),
+            picker("vault_id", "Vault contract id", PickerSource::Vaults),
             rows_required(
                 "new_beneficiaries",
                 "Beneficiaries (party,weight)",
@@ -359,15 +419,23 @@ pub fn fields_for_action(action_type: &str, ctx: &ComposerContext) -> Vec<Compos
                 text_opt("limits.min_deposit_amount", "Min deposit amount"),
                 text_opt("limits.min_withdrawal_amount", "Min withdrawal amount"),
                 text("vault_backend_signatory", "Backend signatory"),
-                text("allocation_factory_cid", "Allocation factory cid"),
-                text("registrar_service_cid", "Registrar service cid"),
+                picker(
+                    "allocation_factory_cid",
+                    "Allocation factory cid",
+                    PickerSource::TransferFactories,
+                ),
+                picker(
+                    "registrar_service_cid",
+                    "Registrar service cid",
+                    PickerSource::RegistrarServices,
+                ),
             ]);
             fields
         }
         "yield_epoch_deployment" => {
             let mut fields = vec![
                 text("vault_rules_cid", "Vault rules cid"),
-                text("vault_cid", "Vault contract id"),
+                picker("vault_cid", "Vault contract id", PickerSource::Vaults),
             ];
             fields.extend(instrument_id("asset_instrument_id", String::new()));
             fields.push(text("vault_backend_signatory", "Backend signatory"));
@@ -376,7 +444,11 @@ pub fn fields_for_action(action_type: &str, ctx: &ComposerContext) -> Vec<Compos
         "processor_deployment_request" => vec![
             text("vault_processor_rules_cid", "Processor rules cid"),
             text("vault_backend_signatory", "Backend signatory"),
-            text("allocation_factory_cid", "Burn/mint factory cid"),
+            picker(
+                "allocation_factory_cid",
+                "Burn/mint factory cid",
+                PickerSource::TransferFactories,
+            ),
             list_required("initial_supported_vaults", "Initial supported vault cids"),
         ],
         "utility_create_provider_request" | "utility_create_user_request" => {
@@ -388,18 +460,34 @@ pub fn fields_for_action(action_type: &str, ctx: &ComposerContext) -> Vec<Compos
         }
         "utility_setup" => vec![
             text_value("operator", "Operator party", ctx.operator_party.clone()),
-            text("provider_service_cid", "Provider service cid"),
-            text("user_service_cid", "User service cid"),
+            picker(
+                "provider_service_cid",
+                "Provider service cid",
+                PickerSource::ProviderServices,
+            ),
+            picker(
+                "user_service_cid",
+                "User service cid",
+                PickerSource::UserServices,
+            ),
         ],
         "utility_accept_holder_service_request" => vec![
             text_value("operator", "Operator party", ctx.operator_party.clone()),
-            text("provider_service_cid", "Provider service cid"),
+            picker(
+                "provider_service_cid",
+                "Provider service cid",
+                PickerSource::ProviderServices,
+            ),
             text("holder_service_request_cid", "Holder service request cid"),
             text("holder", "Holder party"),
         ],
         "credential_offer_free" => vec![
             text_value("operator", "Operator party", ctx.operator_party.clone()),
-            text("user_service_cid", "User service cid"),
+            picker(
+                "user_service_cid",
+                "User service cid",
+                PickerSource::UserServices,
+            ),
             text("holder", "Holder party"),
             text("id", "Credential id"),
             text("description", "Description"),
@@ -411,8 +499,16 @@ pub fn fields_for_action(action_type: &str, ctx: &ComposerContext) -> Vec<Compos
         ],
         "credential_accept_free" => vec![
             text_value("operator", "Operator party", ctx.operator_party.clone()),
-            text("user_service_cid", "User service cid"),
-            text("credential_offer_cid", "Credential offer cid"),
+            picker(
+                "user_service_cid",
+                "User service cid",
+                PickerSource::UserServices,
+            ),
+            picker(
+                "credential_offer_cid",
+                "Credential offer cid",
+                PickerSource::CredentialOffers,
+            ),
         ],
         "dev_net_feature_app" => vec![text("amulet_rules_cid", "Amulet rules cid")],
         _ => Vec::new(),
@@ -436,7 +532,11 @@ pub fn fields_for_proposal(proposal_type: &str, ctx: &ComposerContext) -> Vec<Co
         ],
         "transfer" => {
             let mut fields = vec![
-                text("transfer_factory_cid", "Transfer factory cid"),
+                picker(
+                    "transfer_factory_cid",
+                    "Transfer factory cid",
+                    PickerSource::TransferFactories,
+                ),
                 text("expected_admin", "Expected admin"),
                 text("receiver", "Receiver party"),
                 text("amount", "Amount"),
@@ -450,13 +550,21 @@ pub fn fields_for_proposal(proposal_type: &str, ctx: &ComposerContext) -> Vec<Co
             ));
             fields
         }
-        "accept_transfer" => vec![text("transfer_instruction_cid", "Transfer instruction cid")],
+        "accept_transfer" => vec![picker(
+            "transfer_instruction_cid",
+            "Transfer instruction cid",
+            PickerSource::TransferInstructions,
+        )],
         "create_user_service_request" => vec![operator(), text_value("user", "User party", party)],
         "create_provider_service_request" => {
             vec![operator(), text_value("provider", "Provider party", party)]
         }
         "setup_utility" => vec![
-            text("provider_service_cid", "Provider service cid"),
+            picker(
+                "provider_service_cid",
+                "Provider service cid",
+                PickerSource::ProviderServices,
+            ),
             operator(),
             text("instrument_id_text", "Instrument id"),
             boolean("create_transfer_rule", "Create transfer rule", true),
@@ -467,7 +575,11 @@ pub fn fields_for_proposal(proposal_type: &str, ctx: &ComposerContext) -> Vec<Co
             ),
         ],
         "set_provider_app_reward_beneficiaries" => vec![
-            text("instrument_configuration_cid", "Instrument config cid"),
+            picker(
+                "instrument_configuration_cid",
+                "Instrument config cid",
+                PickerSource::Instruments,
+            ),
             rows(
                 "provider_app_reward_beneficiaries",
                 "Beneficiaries (party,weight) — empty clears",
@@ -475,7 +587,11 @@ pub fn fields_for_proposal(proposal_type: &str, ctx: &ComposerContext) -> Vec<Co
             ),
         ],
         "set_enable_result_contracts" => vec![
-            text("registrar_service_cid", "Registrar service cid"),
+            picker(
+                "registrar_service_cid",
+                "Registrar service cid",
+                PickerSource::RegistrarServices,
+            ),
             select(
                 "enable_result_contracts",
                 "Enable result contracts",
@@ -489,10 +605,18 @@ pub fn fields_for_proposal(proposal_type: &str, ctx: &ComposerContext) -> Vec<Co
         ],
         "create_delegated_batched_markers_proxy" => vec![operator()],
         "mint" => {
-            let mut fields = vec![text("allocation_factory_cid", "Allocation factory cid")];
+            let mut fields = vec![picker(
+                "allocation_factory_cid",
+                "Allocation factory cid",
+                PickerSource::TransferFactories,
+            )];
             fields.extend(instrument_id("instrument_id", party));
             fields.extend([
-                text("instrument_configuration_cid", "Instrument config cid"),
+                picker(
+                    "instrument_configuration_cid",
+                    "Instrument config cid",
+                    PickerSource::Instruments,
+                ),
                 text("recipient", "Recipient party"),
                 text("amount", "Amount"),
                 text("description", "Description"),
@@ -500,10 +624,18 @@ pub fn fields_for_proposal(proposal_type: &str, ctx: &ComposerContext) -> Vec<Co
             fields
         }
         "burn" => {
-            let mut fields = vec![text("allocation_factory_cid", "Allocation factory cid")];
+            let mut fields = vec![picker(
+                "allocation_factory_cid",
+                "Allocation factory cid",
+                PickerSource::TransferFactories,
+            )];
             fields.extend(instrument_id("instrument_id", party));
             fields.extend([
-                text("instrument_configuration_cid", "Instrument config cid"),
+                picker(
+                    "instrument_configuration_cid",
+                    "Instrument config cid",
+                    PickerSource::Instruments,
+                ),
                 text("holder", "Holder party"),
                 text("amount", "Amount"),
                 text("description", "Description"),
@@ -511,17 +643,37 @@ pub fn fields_for_proposal(proposal_type: &str, ctx: &ComposerContext) -> Vec<Co
             fields
         }
         "accept_mint_request" => vec![
-            text("mint_request_cid", "Mint request cid"),
-            text("instrument_configuration_cid", "Instrument config cid"),
+            picker(
+                "mint_request_cid",
+                "Mint request cid",
+                PickerSource::MintRequests,
+            ),
+            picker(
+                "instrument_configuration_cid",
+                "Instrument config cid",
+                PickerSource::Instruments,
+            ),
             text("description", "Description"),
         ],
         "accept_burn_request" => vec![
-            text("burn_request_cid", "Burn request cid"),
-            text("instrument_configuration_cid", "Instrument config cid"),
+            picker(
+                "burn_request_cid",
+                "Burn request cid",
+                PickerSource::BurnRequests,
+            ),
+            picker(
+                "instrument_configuration_cid",
+                "Instrument config cid",
+                PickerSource::Instruments,
+            ),
             text("description", "Description"),
         ],
         "offer_free_credential" => vec![
-            text("user_service_cid", "User service cid"),
+            picker(
+                "user_service_cid",
+                "User service cid",
+                PickerSource::UserServices,
+            ),
             text("holder", "Holder party"),
             text("id", "Credential id"),
             text("description", "Description"),
@@ -532,8 +684,16 @@ pub fn fields_for_proposal(proposal_type: &str, ctx: &ComposerContext) -> Vec<Co
             ),
         ],
         "accept_free_credential" => vec![
-            text("user_service_cid", "User service cid"),
-            text("credential_offer_cid", "Credential offer cid"),
+            picker(
+                "user_service_cid",
+                "User service cid",
+                PickerSource::UserServices,
+            ),
+            picker(
+                "credential_offer_cid",
+                "Credential offer cid",
+                PickerSource::CredentialOffers,
+            ),
         ],
         _ => Vec::new(),
     }
@@ -575,7 +735,7 @@ fn field_value(field: &ComposerField) -> Result<Option<Value>, String> {
         }
     };
     match &field.kind {
-        FieldKind::Text => {
+        FieldKind::Text | FieldKind::Picker { .. } => {
             require()?;
             Ok((!trimmed.is_empty()).then(|| Value::String(trimmed.to_owned())))
         }
@@ -828,5 +988,61 @@ mod tests {
         assert_eq!(field_value(&field), Ok(Some(Value::Null)));
         field.value = "true".to_owned();
         assert_eq!(field_value(&field), Ok(Some(Value::Bool(true))));
+    }
+
+    #[test]
+    fn accept_mint_request_uses_pickers_and_serializes_cids() {
+        let ctx = ComposerContext {
+            party_id: "dec::1".to_owned(),
+            operator_party: String::new(),
+            default_threshold: 1,
+        };
+        let fields = fields_for_proposal("accept_mint_request", &ctx);
+
+        // Both contract-id fields are pickers backed by the right sources.
+        let mint = fields
+            .iter()
+            .find(|field| field.key == "mint_request_cid")
+            .expect("mint_request_cid field");
+        assert!(matches!(
+            mint.kind,
+            FieldKind::Picker {
+                source: PickerSource::MintRequests,
+                ..
+            }
+        ));
+        let instrument = fields
+            .iter()
+            .find(|field| field.key == "instrument_configuration_cid")
+            .expect("instrument_configuration_cid field");
+        assert!(matches!(
+            instrument.kind,
+            FieldKind::Picker {
+                source: PickerSource::Instruments,
+                ..
+            }
+        ));
+
+        // A picker with a chosen value serializes as a plain string, like text.
+        let mut composer = composer("accept_mint_request", fields);
+        for field in &mut composer.fields {
+            field.value = match field.key {
+                "mint_request_cid" => "00mint".to_owned(),
+                "instrument_configuration_cid" => "00inst".to_owned(),
+                _ => "d".to_owned(),
+            };
+        }
+        let payload = match build_payload(&composer) {
+            Ok(payload) => payload,
+            Err(error) => panic!("build_payload failed: {error}"),
+        };
+        assert_eq!(payload["mint_request_cid"], "00mint");
+        assert_eq!(payload["instrument_configuration_cid"], "00inst");
+    }
+
+    #[test]
+    fn empty_required_picker_is_rejected() {
+        let field = picker("vault_id", "Vault", PickerSource::Vaults);
+        assert!(field_value(&field).is_err());
     }
 }

--- a/crates/decman-cli/src/main.rs
+++ b/crates/decman-cli/src/main.rs
@@ -6,9 +6,13 @@ mod config;
 mod logo;
 mod ui;
 
+use std::io::stdout;
+
 use anyhow::Result;
 use clap::Parser;
 use ratatui::DefaultTerminal;
+use ratatui::crossterm::event::{DisableMouseCapture, EnableMouseCapture};
+use ratatui::crossterm::execute;
 use tracing_subscriber::{EnvFilter, fmt};
 
 use crate::api::AuthSettings;
@@ -43,14 +47,36 @@ fn main() -> Result<()> {
     };
 
     let mut terminal = ratatui::init();
+    enable_mouse();
+    // `ratatui::init` installs a panic hook that restores the terminal; chain it
+    // so a panic also turns mouse capture back off (else the terminal is left
+    // emitting mouse escape codes).
+    let previous_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        disable_mouse();
+        previous_hook(info);
+    }));
+
     let result = match env_session {
         Some((api_url, auth)) => run_env(&mut terminal, api_url, auth),
         None => run_profiles(&mut terminal, profiles),
     };
+    disable_mouse();
     ratatui::restore();
 
     tracing::info!("decman-cli terminal UI exited");
     result
+}
+
+/// Turn on mouse capture so the TUI receives scroll / click events. Best-effort:
+/// a terminal that rejects it just leaves the keyboard-only experience intact.
+fn enable_mouse() {
+    let _ = execute!(stdout(), EnableMouseCapture);
+}
+
+/// Turn mouse capture back off, restoring the terminal's native text selection.
+fn disable_mouse() {
+    let _ = execute!(stdout(), DisableMouseCapture);
 }
 
 /// Run the app against the single profile configured in `.env`.

--- a/crates/decman-cli/src/ui.rs
+++ b/crates/decman-cli/src/ui.rs
@@ -9,8 +9,8 @@ use ratatui::widgets::{
 };
 
 use common::types::{
-    ConnectionStatus, DecentralizedParty, PeerErrorKind, PeerPackageComparison, PendingInvitation,
-    Permission, VettedPackageInfo, WorkflowProgress, WorkflowRun,
+    ConnectionStatus, DecentralizedParty, PackageInfo, PeerErrorKind, PeerPackageComparison,
+    PendingInvitation, Permission, VettedPackageInfo, WorkflowProgress, WorkflowRun,
 };
 
 use crate::api::{
@@ -18,9 +18,9 @@ use crate::api::{
     invitation_name, party_name, run_name,
 };
 use crate::app::{
-    App, ComposerKind, ComposerPick, DeployForm, DetailData, GovItem, GovView, GrantForm, IdpMode,
-    KickForm, NetworkEditState, OnboardForm, Overlay, PartyConfigForm, PcRow, PeerChoice, PeerForm,
-    Status, Tab, TabView,
+    AddPartyForm, App, ChangeThresholdForm, ComposerKind, ComposerPick, DeployForm, DetailData,
+    GovItem, GovView, GrantForm, IdpMode, KickForm, NetworkEditState, NodeInfoData, OnboardForm,
+    Overlay, PartyConfigForm, PcRow, PeerChoice, PeerForm, Status, Tab, TabView,
 };
 use crate::composer::{Composer, FieldKind};
 use crate::config::Profile;
@@ -41,7 +41,10 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     ])
     .areas(frame.area());
 
-    draw_header(frame, header);
+    // Record the panel rect so mouse clicks can be mapped back to a tab / row.
+    app.set_body_area(body);
+
+    draw_header(frame, header, app.node_version());
 
     let spinner = SPINNER[app.tick() % SPINNER.len()];
 
@@ -53,6 +56,8 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         let hint = match app.overlay() {
             Overlay::Json { .. } | Overlay::ChainAudit { .. } => " ↑/↓ scroll · esc close",
             Overlay::Kick(_) => " ↑/↓ pick · ←/→ threshold · enter kick · esc cancel",
+            Overlay::AddParty(_) => " ↑/↓ pick · ←/→ threshold · enter add · esc cancel",
+            Overlay::ChangeThreshold(_) => " ←/→ threshold · enter apply · esc cancel",
             Overlay::Governance(_) => {
                 " ↑/↓ · c confirm · e exec · r revoke · x expire · n new · p propose · esc"
             }
@@ -66,7 +71,8 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
             }
             Overlay::Message(_) | Overlay::Busy(_) => " enter / esc to close",
             _ => {
-                " ↑/↓ audit · enter json · a login · g gov · D deploy · c chain · K kick · esc back"
+                " ↑/↓ audit · enter json · a login · g gov · D deploy · c chain · K kick · \
+                 P add · T thresh · esc back"
             }
         };
         frame.render_widget(
@@ -135,8 +141,10 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     draw_overlay(frame, frame.area(), app.overlay(), spinner);
 }
 
-/// Draw the centered BitSafe wordmark and subtitle.
-fn draw_header(frame: &mut Frame, area: Rect) {
+/// Draw the centered BitSafe wordmark, subtitle, and — once connected — the
+/// version of the node this session is managing (the login screen has no node
+/// yet, so `version` is `None` there).
+fn draw_header(frame: &mut Frame, area: Rect, version: Option<&str>) {
     let mut lines = logo::lines();
     lines.push(Line::styled(
         SUBTITLE,
@@ -144,6 +152,12 @@ fn draw_header(frame: &mut Frame, area: Rect) {
             .fg(Color::Gray)
             .add_modifier(Modifier::BOLD),
     ));
+    if let Some(version) = version {
+        lines.push(Line::styled(
+            format!("v{version}"),
+            Style::default().fg(Color::DarkGray),
+        ));
+    }
     frame.render_widget(Paragraph::new(lines).alignment(Alignment::Center), area);
 }
 
@@ -156,7 +170,8 @@ pub fn draw_login(frame: &mut Frame, profiles: &[Profile], state: &mut TableStat
     ])
     .areas(frame.area());
 
-    draw_header(frame, header);
+    // No node is connected on the profile picker, so no version to show.
+    draw_header(frame, header, None);
 
     let header_row = Row::new(["PROFILE", "NETWORK", "USER", "API URL"]).style(header_style());
     let rows: Vec<Row> = profiles
@@ -172,8 +187,8 @@ pub fn draw_login(frame: &mut Frame, profiles: &[Profile], state: &mut TableStat
         .collect();
     let widths = [
         Constraint::Length(20),
-        Constraint::Length(12),
-        Constraint::Length(16),
+        Constraint::Length(10),
+        Constraint::Length(30),
         Constraint::Fill(1),
     ];
     let table = Table::new(rows, widths)
@@ -909,11 +924,13 @@ fn peers_table<'a>(peers: &'a [PeerView], block: Block<'a>) -> Table<'a> {
         ])
     });
 
+    // ADDRESS flexes to fill the width (host:port strings are long); the peer
+    // name column is fixed and comfortably fits a name plus its workflow note.
     let widths = [
         Constraint::Length(14),
+        Constraint::Length(30),
         Constraint::Fill(1),
-        Constraint::Length(18),
-        Constraint::Length(8),
+        Constraint::Length(9),
         Constraint::Length(9),
     ];
 
@@ -977,11 +994,19 @@ fn feed_table<'a>(feed: &[FeedItem], block: Block<'a>) -> Table<'a> {
             ]),
             FeedItem::Run(run) => {
                 let (color, label) = workflow_status_display(run.status);
+                // Only an in-progress run has a meaningful position; show it
+                // 1-based ("step 3 of 8"), matching the web frontend. A finished
+                // run's status column already says Completed / Failed.
+                let progress = if run.status == WorkflowProgress::InProgress && run.step_total > 0 {
+                    format!("{}/{}", run.step_index + 1, run.step_total)
+                } else {
+                    "—".to_owned()
+                };
                 Row::new(vec![
                     Cell::from(dash_if_empty(run.kind.as_str())),
                     Cell::from(dash_if_empty(run_name(run))),
                     Cell::from(dash_if_empty(&run.current_step)),
-                    Cell::from(format!("{}/{}", run.step_index, run.step_total)),
+                    Cell::from(progress),
                     Cell::from(Line::from(Span::styled(label, Style::default().fg(color)))),
                 ])
             }
@@ -1085,6 +1110,8 @@ fn footer_hint(active: Tab, overlay: &Overlay, can_logout: bool) -> String {
             " ↑/↓ field · space toggle peer · enter start · esc cancel".to_owned()
         }
         Overlay::Kick(_) => " ↑/↓ pick · ←/→ threshold · enter kick · esc cancel".to_owned(),
+        Overlay::AddParty(_) => " ↑/↓ pick · ←/→ threshold · enter add · esc cancel".to_owned(),
+        Overlay::ChangeThreshold(_) => " ←/→ threshold · enter apply · esc cancel".to_owned(),
         Overlay::Auth { .. } => " ↑/↓ select · t test · g grant · e config · esc close".to_owned(),
         Overlay::GrantRights(_) => " ↑/↓ field · type · enter next/grant · esc cancel".to_owned(),
         Overlay::PartyConfig(_) => {
@@ -1106,12 +1133,13 @@ fn footer_hint(active: Tab, overlay: &Overlay, can_logout: bool) -> String {
             " ↑/↓ select · a add · d remove · s save · esc cancel"
         }
         .to_owned(),
+        Overlay::NodeInfo(_) => " esc close".to_owned(),
         Overlay::Message(_) => " enter / esc to close".to_owned(),
         Overlay::Busy(_) => " working… · enter/esc to dismiss".to_owned(),
         Overlay::None => {
             let base = match active {
                 Tab::Parties => " ↑↓ nav · enter view · n onboard · r refresh",
-                Tab::Peers => " ↑↓ nav · e edit · tab switch",
+                Tab::Peers => " ↑↓ nav · e edit · i info · tab switch",
                 Tab::Dars => " c check · u upload · d distribute",
                 Tab::Workflows => {
                     " a accept · x deny · c cancel · t retry · enter detail · d dismiss"
@@ -1207,6 +1235,8 @@ fn draw_overlay(frame: &mut Frame, area: Rect, overlay: &Overlay, spinner: &str)
         Overlay::Json { value, scroll } => json_popup(frame, area, value, *scroll),
         Overlay::Onboard(form) => onboard_popup(frame, area, form),
         Overlay::Kick(form) => kick_popup(frame, area, form),
+        Overlay::AddParty(form) => add_party_popup(frame, area, form),
+        Overlay::ChangeThreshold(form) => change_threshold_popup(frame, area, form),
         Overlay::FeedDetail { item, scroll } => feed_detail_popup(frame, area, item, *scroll),
         Overlay::ChainAudit { entries, scroll } => chain_audit_popup(frame, area, entries, *scroll),
         Overlay::Auth { parties, selected } => auth_popup(frame, area, parties, *selected),
@@ -1217,6 +1247,7 @@ fn draw_overlay(frame: &mut Frame, area: Rect, overlay: &Overlay, spinner: &str)
         Overlay::Deploy(form) => deploy_popup(frame, area, form),
         Overlay::NetworkEdit(state) => network_edit_popup(frame, area, state),
         Overlay::PartyConfig(form) => party_config_popup(frame, area, form),
+        Overlay::NodeInfo(data) => node_info_popup(frame, area, data),
     }
 }
 
@@ -1572,6 +1603,34 @@ fn composer_field_display(field: &crate::composer::ComposerField, focused: bool)
                 "(empty)".to_owned()
             } else {
                 field.value.clone()
+            }
+        }
+        FieldKind::Picker {
+            options, loaded, ..
+        } => {
+            if let Some(option) = options.iter().find(|option| option.value == field.value) {
+                // A selected option: show its human label, not the raw cid.
+                format!("‹ {} ›", option.label)
+            } else if !field.value.is_empty() {
+                // A pasted / typed cid with no matching option.
+                if focused {
+                    format!("{}▏", field.value)
+                } else {
+                    field.value.clone()
+                }
+            } else if !loaded {
+                "loading…".to_owned()
+            } else if options.is_empty() {
+                // Nothing on the ledger to pick — fall back to text entry.
+                if focused {
+                    "▏".to_owned()
+                } else {
+                    "(none — type a cid)".to_owned()
+                }
+            } else if focused {
+                format!("‹ pick 1 of {} ›", options.len())
+            } else {
+                "(none selected)".to_owned()
             }
         }
     }
@@ -1979,59 +2038,111 @@ fn message_popup(frame: &mut Frame, area: Rect, title: &str, message: &str, colo
 
 /// The package-checker popup: local count and each peer's sync state.
 fn compare_popup(frame: &mut Frame, area: Rect, comparison: &PeerPackageComparison, scroll: u16) {
-    let local_ids: HashSet<&str> = comparison
-        .local_packages
-        .iter()
-        .map(|package| package.package_id.as_str())
-        .collect();
-
-    let mut lines = vec![
-        Line::from(Span::styled(
-            format!("Local packages: {}", comparison.local_packages.len()),
-            Style::default().add_modifier(Modifier::BOLD),
-        )),
-        Line::default(),
-    ];
-    for peer in &comparison.peers {
-        let line = if peer.reachable {
-            let peer_ids: HashSet<&str> = peer
-                .packages
-                .iter()
-                .map(|p| p.package_id.as_str())
-                .collect();
-            let missing = local_ids
-                .iter()
-                .filter(|id| !peer_ids.contains(*id))
-                .count();
-            let (color, note) = if missing == 0 {
-                (Color::Green, "in sync".to_owned())
-            } else {
-                (Color::Yellow, format!("{missing} missing"))
-            };
-            Line::from(vec![
-                Span::styled("● ", Style::default().fg(color)),
-                Span::raw(format!("{}  ", peer.name)),
-                Span::styled(note, Style::default().fg(color)),
-                Span::styled(
-                    format!("  ({} pkgs)", peer.packages.len()),
-                    Style::default().fg(Color::DarkGray),
-                ),
-            ])
-        } else {
-            let error = peer.error_kind.map_or("unreachable", peer_error_label);
-            Line::from(vec![
-                Span::styled("● ", Style::default().fg(Color::Red)),
-                Span::raw(format!("{}  ", peer.name)),
-                Span::styled(
-                    format!("unreachable ({error})"),
-                    Style::default().fg(Color::Red),
-                ),
-            ])
-        };
-        lines.push(line);
+    /// A peer rendered as a matrix column: its label, the set of
+    /// `(name, version)` it vets, and how many local packages it is missing.
+    struct PeerCol {
+        label: String,
+        width: usize,
+        reachable: bool,
+        error: &'static str,
+        keys: HashSet<(String, String)>,
+        missing: usize,
     }
 
-    let width = 70.min(area.width.saturating_sub(4));
+    let key_of = |pkg: &PackageInfo| (pkg.name.clone(), pkg.version.clone());
+    let peer_cols: Vec<PeerCol> = comparison
+        .peers
+        .iter()
+        .map(|peer| {
+            let keys: HashSet<(String, String)> = peer.packages.iter().map(key_of).collect();
+            let missing = comparison
+                .local_packages
+                .iter()
+                .filter(|pkg| !keys.contains(&key_of(pkg)))
+                .count();
+            let label = truncate(&peer.name, 12);
+            let width = label.chars().count().max(3);
+            PeerCol {
+                label,
+                width,
+                reachable: peer.reachable,
+                error: peer.error_kind.map_or("unreachable", peer_error_label),
+                keys,
+                missing,
+            }
+        })
+        .collect();
+
+    let name_w = 32usize;
+    let ver_w = 9usize;
+
+    // Header: total, then one status chip per peer.
+    let mut lines = vec![Line::from(Span::styled(
+        format!("Local packages: {}", comparison.local_packages.len()),
+        Style::default().add_modifier(Modifier::BOLD),
+    ))];
+    let mut summary: Vec<Span> = Vec::new();
+    for (index, (peer, col)) in comparison.peers.iter().zip(&peer_cols).enumerate() {
+        if index > 0 {
+            summary.push(Span::raw("   "));
+        }
+        let (color, note) = if !col.reachable {
+            (Color::Red, format!("unreachable ({})", col.error))
+        } else if col.missing == 0 {
+            (Color::Green, "in sync".to_owned())
+        } else {
+            (Color::Yellow, format!("{} missing", col.missing))
+        };
+        summary.push(Span::styled("● ", Style::default().fg(color)));
+        summary.push(Span::raw(format!("{} ", peer.name)));
+        summary.push(Span::styled(note, Style::default().fg(color)));
+    }
+    lines.push(Line::from(summary));
+    lines.push(Line::default());
+
+    // Matrix header row: PACKAGE · VERSION · one column per peer.
+    let mut header = vec![
+        Span::styled(format!("{:<name_w$}", "PACKAGE"), header_style()),
+        Span::styled(format!("{:<ver_w$}", "VERSION"), header_style()),
+    ];
+    for col in &peer_cols {
+        header.push(Span::styled(
+            format!(" {:^width$}", col.label, width = col.width),
+            header_style(),
+        ));
+    }
+    lines.push(Line::from(header));
+
+    // One row per local package (sorted like the Dars tab), with a ✓ / ✗ / –
+    // per peer: vetted (green) / missing-or-mismatch (yellow) / unreachable.
+    let mut locals: Vec<&PackageInfo> = comparison.local_packages.iter().collect();
+    locals.sort_by(|a, b| a.name.cmp(&b.name).then_with(|| a.version.cmp(&b.version)));
+    for pkg in locals {
+        let key = key_of(pkg);
+        let mut spans = vec![
+            Span::raw(format!("{:<name_w$}", truncate(&pkg.name, name_w - 1))),
+            Span::styled(
+                format!("{:<ver_w$}", truncate(&pkg.version, ver_w - 1)),
+                Style::default().fg(Color::DarkGray),
+            ),
+        ];
+        for col in &peer_cols {
+            let (symbol, color) = if !col.reachable {
+                ("–", Color::DarkGray)
+            } else if col.keys.contains(&key) {
+                ("✓", Color::Green)
+            } else {
+                ("✗", Color::Yellow)
+            };
+            spans.push(Span::styled(
+                format!(" {:^width$}", symbol, width = col.width),
+                Style::default().fg(color),
+            ));
+        }
+        lines.push(Line::from(spans));
+    }
+
+    let width = 92.min(area.width.saturating_sub(4));
     let height = ((lines.len() as u16) + 2)
         .min(area.height.saturating_sub(4))
         .max(6);
@@ -2177,6 +2288,141 @@ fn kick_popup(frame: &mut Frame, area: Rect, form: &KickForm) {
     let height = ((lines.len() as u16) + 2).clamp(8, area.height.saturating_sub(4));
     let rect = centered_rect(width, height, area);
     let paragraph = Paragraph::new(lines).block(popup_block("Kick participant"));
+    draw_shadow(frame, rect, area);
+    frame.render_widget(Clear, rect);
+    frame.render_widget(paragraph, rect);
+}
+
+/// A `new threshold` editor line shared by the add-party and change-threshold
+/// popups: the current value in orange, then a dim hint with the old value,
+/// the ceiling, and the adjust keys.
+fn threshold_line(new_threshold: i32, previous: i32, max: i32) -> Line<'static> {
+    Line::from(vec![
+        Span::styled("New threshold  ", Style::default().fg(Color::DarkGray)),
+        Span::styled(
+            format!("{new_threshold} "),
+            Style::default()
+                .fg(logo::ORANGE)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            format!("(was {previous}, max {max}) ←/→ adjust"),
+            Style::default().fg(Color::DarkGray),
+        ),
+    ])
+}
+
+/// The add-party form popup: pick a peer to add and set the new threshold.
+fn add_party_popup(frame: &mut Frame, area: Rect, form: &AddPartyForm) {
+    let mut lines = vec![
+        Line::from(vec![
+            Span::styled("Party  ", Style::default().fg(Color::DarkGray)),
+            Span::raw(form.party_name.clone()),
+        ]),
+        Line::default(),
+        dim_line("Add participant:"),
+    ];
+    for (i, candidate) in form.candidates.iter().enumerate() {
+        let focused = i == form.selected;
+        let marker = if focused { "▶ " } else { "  " };
+        let style = if focused {
+            Style::default()
+                .fg(logo::ORANGE)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default()
+        };
+        lines.push(Line::from(Span::styled(
+            format!("{marker}{}", candidate.label),
+            style,
+        )));
+    }
+    lines.push(Line::default());
+    lines.push(threshold_line(
+        form.new_threshold,
+        form.previous_threshold,
+        form.max_threshold,
+    ));
+
+    let width = 64.min(area.width.saturating_sub(4));
+    let height = ((lines.len() as u16) + 2).clamp(8, area.height.saturating_sub(4));
+    let rect = centered_rect(width, height, area);
+    let paragraph = Paragraph::new(lines).block(popup_block("Add party member"));
+    draw_shadow(frame, rect, area);
+    frame.render_widget(Clear, rect);
+    frame.render_widget(paragraph, rect);
+}
+
+/// The change-threshold form popup: adjust a party's signing threshold.
+fn change_threshold_popup(frame: &mut Frame, area: Rect, form: &ChangeThresholdForm) {
+    let lines = vec![
+        Line::from(vec![
+            Span::styled("Party  ", Style::default().fg(Color::DarkGray)),
+            Span::raw(form.party_name.clone()),
+        ]),
+        Line::default(),
+        dim_line("Membership is unchanged; only the signing threshold changes."),
+        Line::default(),
+        threshold_line(
+            form.new_threshold,
+            form.previous_threshold,
+            form.max_threshold,
+        ),
+    ];
+
+    let width = 64.min(area.width.saturating_sub(4));
+    let height = ((lines.len() as u16) + 2).clamp(7, area.height.saturating_sub(4));
+    let rect = centered_rect(width, height, area);
+    let paragraph = Paragraph::new(lines).block(popup_block("Change threshold"));
+    draw_shadow(frame, rect, area);
+    frame.render_widget(Clear, rect);
+    frame.render_widget(paragraph, rect);
+}
+
+/// This node's Noise key status and DSO network identity. Both sections render
+/// independently, so an unreachable DSO API still shows the local key status.
+fn node_info_popup(frame: &mut Frame, area: Rect, data: &NodeInfoData) {
+    let error_line =
+        |error: &str| Line::styled(format!("Error: {error}"), Style::default().fg(Color::Red));
+
+    let mut lines = vec![dim_line("Node keys")];
+    match &data.key {
+        Ok(status) => {
+            lines.push(detail_kv(
+                "Noise keys",
+                if status.has_keys {
+                    "present".to_owned()
+                } else {
+                    "not generated".to_owned()
+                },
+            ));
+            if let Some(key) = status.public_key.as_deref().filter(|key| !key.is_empty()) {
+                lines.push(detail_kv("Public key", key.to_owned()));
+            }
+        }
+        Err(error) => lines.push(error_line(error)),
+    }
+    lines.push(Line::default());
+    lines.push(dim_line("DSO network"));
+    match &data.network {
+        Ok(info) => {
+            lines.push(detail_kv("DSO party", info.dso_party_id.clone()));
+            if !info.amulet_rules_cid.is_empty() {
+                lines.push(detail_kv(
+                    "Amulet rules",
+                    truncate(&info.amulet_rules_cid, 44),
+                ));
+            }
+        }
+        Err(error) => lines.push(error_line(error)),
+    }
+
+    let width = 80.min(area.width.saturating_sub(4));
+    let height = ((lines.len() as u16) + 2).clamp(7, area.height.saturating_sub(4));
+    let rect = centered_rect(width, height, area);
+    let paragraph = Paragraph::new(lines)
+        .wrap(Wrap { trim: false })
+        .block(popup_block("Node info"));
     draw_shadow(frame, rect, area);
     frame.render_widget(Clear, rect);
     frame.render_widget(paragraph, rect);
@@ -2346,8 +2592,8 @@ fn invitation_detail_lines(invitation: &PendingInvitation) -> Vec<Line<'static>>
 mod tests {
     use common::canton_id::CantonId;
     use common::types::{
-        AuditLogEntry, ContractInfo, InvitationType, ParticipantInfo, PendingInvitation,
-        WorkflowKind, WorkflowRole, WorkflowRun,
+        AuditLogEntry, ContractInfo, InvitationType, ParticipantInfo, PeerPackageResult,
+        PendingInvitation, WorkflowKind, WorkflowRole, WorkflowRun,
     };
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
@@ -2537,6 +2783,34 @@ mod tests {
                 created_at: 0,
                 updated_at: 0,
             }),
+            FeedItem::Run(WorkflowRun {
+                instance_name: "onboarding-done-abc".to_owned(),
+                kind: WorkflowKind::Onboarding,
+                role: WorkflowRole::Coordinator,
+                status: WorkflowProgress::Completed,
+                current_step: "Complete".to_owned(),
+                step_index: 5,
+                step_total: 6,
+                config_json: String::new(),
+                coordinator_pubkey: None,
+                coordinator_instance: None,
+                coordinator_name: None,
+                expected_peers: Vec::new(),
+                completed_peers: Vec::new(),
+                dec_party_id: None,
+                prefix: None,
+                participants: Vec::new(),
+                previous_threshold: None,
+                new_threshold: None,
+                kicked_participant: None,
+                added_participant: None,
+                package_names: Vec::new(),
+                dar_filenames: Vec::new(),
+                error: None,
+                dismissed: false,
+                created_at: 0,
+                updated_at: 0,
+            }),
             FeedItem::Invitation(PendingInvitation {
                 id: "inv-1".to_owned(),
                 invitation_type: InvitationType::Onboarding,
@@ -2570,11 +2844,76 @@ mod tests {
         assert!(rendered.contains("Contracts"));
         // The full instance name is shown (not clipped to two characters).
         assert!(rendered.contains("contracts-pending-xyz"));
-        assert!(rendered.contains("2/3"));
+        // Progress is 1-based: step index 2 of 3 renders as "3/3" (final step).
+        assert!(rendered.contains("3/3"));
         assert!(rendered.contains("In progress"));
+        // A finished run hides its step fraction (no "5/6" or "6/6"); the
+        // status column carries the outcome instead.
+        assert!(rendered.contains("Completed"));
+        assert!(!rendered.contains("5/6"));
+        assert!(!rendered.contains("6/6"));
         // The invitation row is present and actionable.
         assert!(rendered.contains("Onboarding"));
         assert!(rendered.contains("vault-rc5"));
+    }
+
+    #[test]
+    fn header_shows_node_version_only_when_connected() {
+        let with = render(|frame, area| draw_header(frame, area, Some("1.2.1")));
+        assert!(with.contains("Decentralization Manager"));
+        assert!(with.contains("v1.2.1"));
+
+        // The login screen passes None — no version line.
+        let without = render(|frame, area| draw_header(frame, area, None));
+        assert!(without.contains("Decentralization Manager"));
+        assert!(!without.contains("v1.2.1"));
+    }
+
+    fn pkg(name: &str, version: &str) -> PackageInfo {
+        PackageInfo {
+            package_id: format!("00{name}"),
+            name: name.to_owned(),
+            version: version.to_owned(),
+        }
+    }
+
+    #[test]
+    fn compare_popup_renders_matrix_of_marks() {
+        let comparison = PeerPackageComparison {
+            local_packages: vec![pkg("cbtc", "1.0.0"), pkg("vault", "0.0.1")],
+            peers: vec![
+                PeerPackageResult {
+                    participant_id: "p1::1220".to_owned(),
+                    name: "devnet 1".to_owned(),
+                    reachable: true,
+                    error_kind: None,
+                    // Has cbtc but is missing vault.
+                    packages: vec![pkg("cbtc", "1.0.0")],
+                },
+                PeerPackageResult {
+                    participant_id: "p2::1220".to_owned(),
+                    name: "devnet 4".to_owned(),
+                    reachable: false,
+                    error_kind: None,
+                    packages: Vec::new(),
+                },
+            ],
+        };
+        let overlay = Overlay::Compare {
+            comparison,
+            scroll: 0,
+        };
+        let rendered = render(|frame, area| draw_overlay(frame, area, &overlay, "⠋"));
+
+        assert!(rendered.contains("Local packages: 2"));
+        assert!(rendered.contains("PACKAGE"));
+        assert!(rendered.contains("cbtc"));
+        // devnet 1: cbtc ✓, vault ✗; devnet 4: unreachable → – in every cell.
+        assert!(rendered.contains('✓'));
+        assert!(rendered.contains('✗'));
+        assert!(rendered.contains('–'));
+        assert!(rendered.contains("1 missing"));
+        assert!(rendered.contains("unreachable"));
         assert!(rendered.contains("Invitation"));
     }
 
@@ -2781,6 +3120,134 @@ mod tests {
         assert!(rendered.contains("cbtc-network"));
         assert!(rendered.contains("peerA"));
         assert!(rendered.contains("New threshold"));
+    }
+
+    #[test]
+    fn add_party_popup_renders_candidates_and_threshold() {
+        use crate::app::KickCandidate;
+
+        let overlay = Overlay::AddParty(AddPartyForm {
+            party_id: "dec::1220".to_owned(),
+            party_name: "cbtc-network".to_owned(),
+            previous_threshold: 2,
+            candidates: vec![KickCandidate {
+                participant_id: "p::1220".to_owned(),
+                label: "peerNew".to_owned(),
+            }],
+            selected: 0,
+            new_threshold: 3,
+            max_threshold: 3,
+        });
+        let rendered = render(|frame, area| draw_overlay(frame, area, &overlay, "⠋"));
+        assert!(rendered.contains("Add party member"));
+        assert!(rendered.contains("cbtc-network"));
+        assert!(rendered.contains("peerNew"));
+        assert!(rendered.contains("New threshold"));
+    }
+
+    #[test]
+    fn change_threshold_popup_renders_threshold_bounds() {
+        let overlay = Overlay::ChangeThreshold(ChangeThresholdForm {
+            party_id: "dec::1220".to_owned(),
+            party_name: "cbtc-network".to_owned(),
+            previous_threshold: 2,
+            new_threshold: 3,
+            max_threshold: 4,
+        });
+        let rendered = render(|frame, area| draw_overlay(frame, area, &overlay, "⠋"));
+        assert!(rendered.contains("Change threshold"));
+        assert!(rendered.contains("cbtc-network"));
+        assert!(rendered.contains("(was 2, max 4)"));
+    }
+
+    #[test]
+    fn node_info_popup_renders_keys_and_network() {
+        use crate::api::{KeyStatus, NetworkInfo};
+
+        let overlay = Overlay::NodeInfo(Box::new(NodeInfoData {
+            key: Ok(KeyStatus {
+                has_keys: true,
+                public_key: Some("deadbeefcafe".to_owned()),
+            }),
+            network: Ok(NetworkInfo {
+                dso_party_id: "DSO::1220".to_owned(),
+                amulet_rules_cid: "00rules".to_owned(),
+            }),
+        }));
+        let rendered = render(|frame, area| draw_overlay(frame, area, &overlay, "⠋"));
+        assert!(rendered.contains("Node info"));
+        assert!(rendered.contains("present"));
+        assert!(rendered.contains("deadbeefcafe"));
+        assert!(rendered.contains("DSO"));
+    }
+
+    #[test]
+    fn node_info_popup_shows_network_error_but_keeps_keys() {
+        use crate::api::KeyStatus;
+
+        let overlay = Overlay::NodeInfo(Box::new(NodeInfoData {
+            key: Ok(KeyStatus {
+                has_keys: false,
+                public_key: None,
+            }),
+            network: Err("DSO API unreachable".to_owned()),
+        }));
+        let rendered = render(|frame, area| draw_overlay(frame, area, &overlay, "⠋"));
+        assert!(rendered.contains("not generated"));
+        assert!(rendered.contains("Error"));
+    }
+
+    #[test]
+    fn composer_field_display_picker_states() {
+        use crate::composer::{ComposerField, PickerOption, PickerSource};
+
+        let make = |kind, value: &str| ComposerField {
+            key: "mint_request_cid",
+            label: "Mint request",
+            kind,
+            value: value.to_owned(),
+            optional: false,
+            help: "",
+        };
+
+        // Still loading.
+        let loading = make(
+            FieldKind::Picker {
+                source: PickerSource::MintRequests,
+                options: Vec::new(),
+                loaded: false,
+            },
+            "",
+        );
+        assert_eq!(composer_field_display(&loading, false), "loading…");
+
+        // Loaded but empty → text-entry fallback.
+        let empty = make(
+            FieldKind::Picker {
+                source: PickerSource::MintRequests,
+                options: Vec::new(),
+                loaded: true,
+            },
+            "",
+        );
+        assert_eq!(composer_field_display(&empty, false), "(none — type a cid)");
+
+        // A selected option shows its human label, not the raw cid.
+        let selected = make(
+            FieldKind::Picker {
+                source: PickerSource::MintRequests,
+                options: vec![PickerOption {
+                    value: "00abc".to_owned(),
+                    label: "100 CBTC → alice".to_owned(),
+                }],
+                loaded: true,
+            },
+            "00abc",
+        );
+        assert_eq!(
+            composer_field_display(&selected, false),
+            "‹ 100 CBTC → alice ›"
+        );
     }
 
     #[test]

--- a/crates/decman-cli/src/ui.rs
+++ b/crates/decman-cli/src/ui.rs
@@ -2855,6 +2855,7 @@ mod tests {
         // The invitation row is present and actionable.
         assert!(rendered.contains("Onboarding"));
         assert!(rendered.contains("vault-rc5"));
+        assert!(rendered.contains("Invitation"));
     }
 
     #[test]
@@ -2914,7 +2915,6 @@ mod tests {
         assert!(rendered.contains('–'));
         assert!(rendered.contains("1 missing"));
         assert!(rendered.contains("unreachable"));
-        assert!(rendered.contains("Invitation"));
     }
 
     #[test]


### PR DESCRIPTION
Closes the gaps between decman-cli and the web frontend, fixes display bugs I hit while reviewing the running TUI, and adds mouse support. No server changes; every endpoint already existed.

Feature parity:
- Start add-party and change-threshold workflows. The CLI could cancel them but not start them.
- Governance composer picks contract ids from live lists (mint/burn requests, vaults, instruments, provider/user/registrar services, credential offers, transfer factories/instructions) instead of pasting a cid. Falls back to free text when the list is empty.
- Node key status and DSO network info, via `i` on the Peers tab.

Display fixes:
- Workflow progress is 1-based and only shown while in progress. A completed run no longer shows a misleading 5/6.
- Package check is a per-peer matrix (vetted / missing / unreachable) like the frontend, not a one-line summary.
- Peers address column stopped truncating. The self row now shows its own API round-trip latency.
- Profile-picker USER column stopped truncating.
- Header shows the connected node version.

Mouse:
- Scroll wheel navigates everywhere. Click a tab to switch, click a row to select (clicking a party opens it). Overlays stay keyboard-driven for now.

fmt + clippy --all-targets clean; unit and render tests added.
