### PR TITLE
chore(canton): bump localnet to 0.6.11 and protocol version to 35

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: .localnet/
-          key: localnet-0.6.7
+          key: localnet-0.6.11
       # Generate the frontend TS bindings before the integration build (which
       # builds the decman binary → build.rs → frontend, needing this file).
       - name: Generate frontend TypeScript bindings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
 
   integration-test:
     name: Integration Tests
-    runs-on: ubuntu-latest # TEMP stopgap: ubuntu-8-core larger runners unavailable — revert once restored
+    runs-on: ubuntu-very-big
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7

--- a/crates/decman/src/consts.rs
+++ b/crates/decman/src/consts.rs
@@ -92,8 +92,10 @@ pub const DECLINE_NOTIFY_BACKOFF_SECS: u64 = 2;
 
 pub const MAX_CONSECUTIVE_NO_WORKFLOW_POLLS: usize = 4;
 
-/// Canton protocol version used for key export and topology operations
-pub const CANTON_PROTOCOL_VERSION: i32 = 34;
+/// Canton protocol version used for key export and topology operations.
+/// Bumped 34 -> 35 alongside the localnet 0.6.7 -> 0.6.11 test target; the
+/// network (testnet) has live-upgraded to protocol version 35.
+pub const CANTON_PROTOCOL_VERSION: i32 = 35;
 
 /// Additional wait time in seconds for Canton topology propagation
 /// After topology becomes effective, Canton needs time to propagate updates

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -659,7 +659,7 @@ FAR configuration is used in:
 
 - **Canton Admin API access required**: The application needs access to privileged Admin API endpoints (topology management, key vaults, package upload). This is not the public Ledger API -- it requires high node-level privileges.
 - **6 Admin API services used**: TopologyManagerRead, TopologyManagerWrite, VaultManager, IdentityInitialization, SynchronizerConnectivity, PackageService
-- **Canton protocol version**: 34 (hardcoded for key export and topology operations)
+- **Canton protocol version**: 35 (hardcoded for key export and topology operations)
 - **Network ports**: TCP 8080 (HTTP server) + TCP 9000 (Noise P2P)
 
 ### Timing Constraints

--- a/integration-tests/env.sh
+++ b/integration-tests/env.sh
@@ -16,7 +16,7 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/common.sh"
 SCRIPT_DIR="${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 
 # Localnet
-LOCALNET_VERSION="0.6.7"
+LOCALNET_VERSION="0.6.11"
 LOCALNET_BUNDLE_URL="https://github.com/digital-asset/decentralized-canton-sync/releases/download/v${LOCALNET_VERSION}/${LOCALNET_VERSION}_splice-node.tar.gz"
 LOCALNET_CACHE_DIR="$SCRIPT_DIR/.localnet"
 LOCALNET_COMPOSE_DIR="$LOCALNET_CACHE_DIR/splice-node/docker-compose/localnet"


### PR DESCRIPTION
Canton version watch flagged 0.6.7 -> 0.6.11.

Our gRPC layer (`canton-proto-rs`: Ledger API v2 + Admin API v30) isn't touched by the internal `Crypto.create` change that broke `bootstrap.sc`; we don't compile against Canton internals. Two things do track the network version though:

- `LOCALNET_VERSION` in the integration harness: 0.6.7 -> 0.6.11
- `CANTON_PROTOCOL_VERSION` in the key-export path (`ExportKeyPairRequest`): 34 -> 35 (testnet has live-upgraded to PV35)

Bumps both, plus the CI localnet cache key and the architecture doc note. Nothing else pinned to the Canton version.

The integration suite runs against the 0.6.11 splice-node bundle, so CI is the real validation here. If 0.6.11's localnet turns out to still be on PV34, the interactive-signing phase fails at `ExportKeyPair` and we drop the consts change back to 34.
