### PR TITLE
chore(canton): bump localnet to 0.6.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: .localnet/
-          key: localnet-0.6.11
+          key: localnet-0.6.12
       # Generate the frontend TS bindings before the integration build (which
       # builds the decman binary → build.rs → frontend, needing this file).
       - name: Generate frontend TypeScript bindings

--- a/integration-tests/env.sh
+++ b/integration-tests/env.sh
@@ -16,7 +16,7 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/common.sh"
 SCRIPT_DIR="${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 
 # Localnet
-LOCALNET_VERSION="0.6.11"
+LOCALNET_VERSION="0.6.12"
 LOCALNET_BUNDLE_URL="https://github.com/digital-asset/decentralized-canton-sync/releases/download/v${LOCALNET_VERSION}/${LOCALNET_VERSION}_splice-node.tar.gz"
 LOCALNET_CACHE_DIR="$SCRIPT_DIR/.localnet"
 LOCALNET_COMPOSE_DIR="$LOCALNET_CACHE_DIR/splice-node/docker-compose/localnet"


### PR DESCRIPTION
Bumps the integration-test localnet bundle from 0.6.11 (Canton 3.5.7) to 0.6.12 (Canton 3.5.8), matching what devnet runs.

Motivation: the add-party ACS sync failed on devnet while IT was green, because IT ran a Canton one patch behind devnet. Aligning the versions so the e2e harness exercises the same Canton as devnet.

- `integration-tests/env.sh`: LOCALNET_VERSION 0.6.11 -> 0.6.12
- `.github/workflows/ci.yml`: cache key localnet-0.6.11 -> 0.6.12 (forces a fresh bundle download)

No protocol-version change (both are PV35).