### PR TITLE
chore(decman): bump version to 1.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1319,7 +1319,7 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "decman"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "actix-cors",
  "actix-web",

--- a/crates/decman/Cargo.toml
+++ b/crates/decman/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "decman"
-version = "1.4.1"
+version = "1.4.2"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
Bumps the `decman` crate version `1.4.1` → `1.4.2` (`crates/decman/Cargo.toml`), with the matching `Cargo.lock` update so `--locked` builds stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)