### PR TITLE
fix(workflow): rc peers could not form a decparty; parse versions with semver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1348,6 +1348,7 @@ dependencies = [
  "reqwest 0.13.3",
  "rust-embed",
  "secp256k1",
+ "semver",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ ratatui = { version = "0.30.2" }
 rfd = { version = "0.17.2", default-features = false, features = ["xdg-portal"] }
 rust-embed = { version = "8.5" }
 secp256k1 = { version = "0.29.1", features = ["rand-std"] }
+semver = { version = "1.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde-big-array = { version = "0.5.1" }
 serde_json = { version = "1.0" }

--- a/crates/decman/Cargo.toml
+++ b/crates/decman/Cargo.toml
@@ -60,6 +60,7 @@ prost-types = { workspace = true }
 reqwest = { version = "0.13", features = ["form", "json"] }
 rust-embed = { workspace = true }
 secp256k1 = { workspace = true }
+semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/decman/src/utils.rs
+++ b/crates/decman/src/utils.rs
@@ -585,26 +585,21 @@ pub fn decode_length_prefixed(data: &[u8], expected_count: usize) -> Result<Vec<
     Ok(items)
 }
 
-/// Whether dotted-numeric version `v` is at least `min` (component-wise
-/// numeric compare, missing components treated as 0). Returns `false` for
-/// anything that doesn't parse as dotted numerics — for version gating,
-/// "can't parse" must mean "can't verify", never "assume compatible".
+/// Whether version `v` is at least `min`, by semver precedence: a
+/// pre-release precedes its own release (`1.4.3-rc1` < `1.4.3`) but outranks
+/// any lower core (`1.4.3-rc1` > `0.1.9`), and build metadata is ignored.
+/// Both inputs must be full `x.y.z` semver — the only real input is a peer's
+/// `CARGO_PKG_VERSION`, which Cargo guarantees is. Returns `false` for
+/// anything that doesn't parse — for version gating, "can't parse" must mean
+/// "can't verify", never "assume compatible".
 pub fn version_at_least(v: &str, min: &str) -> bool {
-    fn parse(s: &str) -> Option<Vec<u64>> {
-        s.trim().split('.').map(|c| c.parse::<u64>().ok()).collect()
-    }
-    let (Some(v), Some(min)) = (parse(v), parse(min)) else {
+    let (Ok(v), Ok(min)) = (
+        semver::Version::parse(v.trim()),
+        semver::Version::parse(min.trim()),
+    ) else {
         return false;
     };
-    let len = v.len().max(min.len());
-    for i in 0..len {
-        let a = v.get(i).copied().unwrap_or(0);
-        let b = min.get(i).copied().unwrap_or(0);
-        if a != b {
-            return a > b;
-        }
-    }
-    true
+    v >= min
 }
 
 #[cfg(test)]
@@ -614,12 +609,21 @@ mod tests {
         assert!(version_at_least("0.1.9", "0.1.9"));
         assert!(version_at_least("0.1.10", "0.1.9"));
         assert!(version_at_least("0.2.0", "0.1.9"));
-        assert!(version_at_least("1.0", "0.1.9"));
+        assert!(version_at_least("1.0.0", "0.1.9"));
         assert!(!version_at_least("0.1.8", "0.1.9"));
-        assert!(!version_at_least("0.1", "0.1.9"));
-        // Unparseable must never pass the gate.
-        assert!(!version_at_least("", "0.1.9"));
+        // Semver precedence: a pre-release precedes its own release but
+        // outranks any lower core.
         assert!(!version_at_least("0.1.9-rc1", "0.1.9"));
+        assert!(version_at_least("0.1.10-rc1", "0.1.9"));
+        assert!(version_at_least("1.4.3-rc1", "0.1.9"));
+        // Build metadata is ignored for precedence.
+        assert!(version_at_least("1.4.3+build5", "0.1.9"));
+        assert!(version_at_least("1.0.0-rc1+build2", "0.1.9"));
+        // Unparseable — including partial versions, which a real
+        // CARGO_PKG_VERSION can never be — must never pass the gate.
+        assert!(!version_at_least("", "0.1.9"));
+        assert!(!version_at_least("1.0", "0.1.9"));
+        assert!(!version_at_least("-rc1", "0.1.9"));
         assert!(!version_at_least("abc", "0.1.9"));
     }
 


### PR DESCRIPTION
## Summary

Encountered an issue where rc version decman nodes could not form a decparty, due to a parsing issue in the `version_at_least` utility function. Switched the custom implementation for semver (was already in Cargo.lock as a secondary dep) to make it more robust.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build / CI / chore

## Checklist

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` is clean
- [x] `cargo test` passes
- [x] Added/updated tests where appropriate
- [x] Updated documentation where appropriate
- [x] Commits follow the `<type>(<scope>): <subject>` convention