### PR TITLE
Consistent cargo versioning

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -14,6 +14,10 @@ on:
         description: "Cargo profile to build: `fast` (dev images) or `release` (tags)."
         required: true
         type: string
+      version:
+        description: "Version string written into crates/decman/Cargo.toml before building."
+        required: true
+        type: string
 
 jobs:
   binary:
@@ -27,6 +31,14 @@ jobs:
       RUSTFLAGS: -C link-arg=-fuse-ld=mold
     steps:
       - uses: actions/checkout@v7
+
+      # Stamp the crate version (the binary reports it via CARGO_PKG_VERSION).
+      # Only crates/decman/Cargo.toml has a line-anchored `version = `; the
+      # dependency specs are `name = { version = ... }`, so they aren't matched.
+      - name: Set crate version
+        env:
+          VERSION: ${{ inputs.version }}
+        run: sed -i "s/^version = .*/version = \"$VERSION\"/" crates/decman/Cargo.toml
 
       - uses: ./.github/actions/setup-build-env
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,10 +10,30 @@ on:
       - "**"
 
 jobs:
+  # Dev version = latest tag with the patch number bumped by one (e.g. latest
+  # tag v1.4.3 -> 1.4.4). Any pre-release suffix on the tag is dropped first.
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - id: v
+        run: |
+          LATEST=$(git tag --sort=-v:refname | head -n1)
+          LATEST="${LATEST#v}"
+          if [ -z "$LATEST" ]; then LATEST="0.0.0"; fi
+          CORE="${LATEST%%-*}"
+          echo "version=${CORE%.*}.$(( ${CORE##*.} + 1 ))" >> "$GITHUB_OUTPUT"
+
   binary:
+    needs: version
     uses: ./.github/workflows/build-binary.yml
     with:
       profile: fast
+      version: ${{ needs.version.outputs.version }}
     secrets: inherit
 
   docker:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,11 +11,21 @@ jobs:
     uses: ./.github/workflows/ci.yml
     secrets: inherit
 
+  # Release version = the tag with its leading `v` stripped (v1.4.3 -> 1.4.3).
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+    steps:
+      - id: v
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
   binary:
-    needs: ci
+    needs: [ci, version]
     uses: ./.github/workflows/build-binary.yml
     with:
       profile: release
+      version: ${{ needs.version.outputs.version }}
     secrets: inherit
 
   docker:


### PR DESCRIPTION
**How versioning now works** written into [crates/decman/Cargo.toml at build time, so the binary reports it via CARGO_PKG_VERSION):

- Tag build (release.yml) → version = the tag minus its leading v (v1.4.3-rc2 → 1.4.3-rc2).
- Commit build (build.yml) → version = latest tag with the patch bumped, pre-release suffix dropped (v1.4.3 or v1.4.3-rc2 → 1.4.4; 1.10.9 → 1.10.10; no tags → 0.0.1).

Mechanics: each workflow has a small version job that computes the string and passes it to the reusable build-binary.yml, which seds it into the crate before gen-types and the binary build (so both agree). The commit-side version job uses fetch-depth: 0 to see tags.