### PR TITLE
feat(decman): show CI build version in UI (alt to #266)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,5 +58,7 @@ jobs:
         run: |
           cp Dockerfile ctx/Dockerfile
           docker buildx build ctx \
+            --build-arg DECPM_BUILD_VERSION=$SHORT_SHA \
+            --build-arg DECPM_BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
             -t $ECR_REGISTRY/decentralization-manager:$SHORT_SHA \
             --push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,27 @@ jobs:
     uses: ./.github/workflows/ci.yml
     secrets: inherit
 
+  # Guard the peer-compatibility semver: the version peers gate on
+  # (MIN_PEER_VERSION) is decman's Cargo.toml version, so a release tag must
+  # match it. Runs in parallel with `ci` and gates `binary`, so a mismatched
+  # tag fails fast before the expensive compile.
+  verify-tag:
+    name: Verify tag matches crate version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Check crates/decman/Cargo.toml version == tag
+        run: |
+          crate_version=$(grep -m1 '^version = ' crates/decman/Cargo.toml \
+            | sed -E 's/^version = "(.*)"/\1/')
+          if [ "v$crate_version" != "$GITHUB_REF_NAME" ]; then
+            echo "::error::Release tag $GITHUB_REF_NAME does not match crates/decman/Cargo.toml version v$crate_version"
+            exit 1
+          fi
+          echo "Tag $GITHUB_REF_NAME matches crate version v$crate_version"
+
   binary:
-    needs: ci
+    needs: [ci, verify-tag]
     uses: ./.github/workflows/build-binary.yml
     with:
       profile: release
@@ -61,5 +80,7 @@ jobs:
         run: |
           cp Dockerfile ctx/Dockerfile
           docker buildx build ctx \
+            --build-arg DECPM_BUILD_VERSION=$VERSION_TAG \
+            --build-arg DECPM_BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
             -t public.ecr.aws/dlc-link/decentralization-manager:$VERSION_TAG \
             --push

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,18 @@ COPY --chmod=0755 dec-party-manager /usr/local/bin/dec-party-manager
 
 EXPOSE 8080 9000
 
+# Build identity, stamped by CI (build.yml / release.yml). DECPM_BUILD_VERSION
+# is the pushed image tag (releases) or short commit SHA (per-commit images);
+# it's what the UI shows as the build version. Left blank on a plain
+# `docker build`, in which case the app falls back to `<cargo-semver>-dev`.
+ARG DECPM_BUILD_VERSION=
+ARG DECPM_BUILD_TIME=
+
 # Image defaults; override via env at run time.
 ENV DECPM_DIR=/ \
     DECPM_HOST=0.0.0.0 \
-    DECPM_PORT=8080
+    DECPM_PORT=8080 \
+    DECPM_BUILD_VERSION=$DECPM_BUILD_VERSION \
+    DECPM_BUILD_TIME=$DECPM_BUILD_TIME
 
 ENTRYPOINT ["dec-party-manager", "serve"]

--- a/crates/common/src/types.rs
+++ b/crates/common/src/types.rs
@@ -201,11 +201,16 @@ pub struct ParticipantStatus {
     /// reported one (peers on older code report `None`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workflow: Option<WorkflowInfo>,
-    /// dec-party-manager version: this node's own version for the current
+    /// dec-party-manager semver: this node's own version for the current
     /// node, or the version a peer reported in its health response. `None` for
     /// unreachable peers and peers on older code that don't report one.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
+    /// Display build identity (image tag / short SHA / `<semver>-dev`) for this
+    /// node or the one a peer reported. `None` for unreachable peers and peers
+    /// on code that predates the field. This is what the peers table shows.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub build_version: Option<String>,
 }
 
 /// Response for the participants status endpoint

--- a/crates/decman-cli/src/api.rs
+++ b/crates/decman-cli/src/api.rs
@@ -1790,6 +1790,7 @@ mod tests {
             status: ConnectionStatus::Connected,
             latency_ms: Some(12),
             version: Some("1.2.3".to_owned()),
+            build_version: Some("v1.2.3".to_owned()),
             workflow,
         }
     }

--- a/crates/decman/frontend/src/App.tsx
+++ b/crates/decman/frontend/src/App.tsx
@@ -577,6 +577,14 @@ const App = () => {
     ) +
     workflowRuns.length;
 
+  const buildInfo = nodeConfig
+    ? {
+        version: nodeConfig.version,
+        buildVersion: nodeConfig.build_version,
+        buildTime: nodeConfig.build_time,
+      }
+    : undefined;
+
   return (
     <Box
       sx={{
@@ -591,9 +599,10 @@ const App = () => {
           partyCount={parties.length}
           packageCount={packageCount}
           notificationCount={notificationCount}
+          buildInfo={buildInfo}
         />
       ) : (
-        <Header />
+        <Header buildInfo={buildInfo} />
       )}
 
       {isLargeScreen && activeTab === 0 && !selectedPartyId && !error && (

--- a/crates/decman/frontend/src/components/Header.tsx
+++ b/crates/decman/frontend/src/components/Header.tsx
@@ -2,10 +2,15 @@ import { Box, Container, IconButton, Tooltip } from "@mui/material";
 import LogoutIcon from "@mui/icons-material/Logout";
 
 import { useAuth } from "../contexts";
-import { Logo } from "./Logo";
+import { Logo, type BuildInfo } from "./Logo";
 import { ThemeSwitcher } from "./ThemeSwitcher";
 
-export const Header = () => {
+interface HeaderProps {
+  /** Build identity for the header's hidden build-info reveal. */
+  buildInfo?: BuildInfo;
+}
+
+export const Header = ({ buildInfo }: HeaderProps) => {
   const { token, logout } = useAuth();
 
   return (
@@ -35,7 +40,10 @@ export const Header = () => {
           justifyContent: "space-between",
         }}
       >
-        <Logo subtitle="Monitor and manage your decentralized parties" />
+        <Logo
+          subtitle="Monitor and manage your decentralized parties"
+          buildInfo={buildInfo}
+        />
         <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
           <ThemeSwitcher />
           {token && (

--- a/crates/decman/frontend/src/components/Logo.tsx
+++ b/crates/decman/frontend/src/components/Logo.tsx
@@ -9,27 +9,61 @@ import { BITSAFE_BRANDING } from "../constants";
 
 declare const __BUILD_DATE__: string;
 
-interface LogoProps {
-  subtitle?: string;
+export interface BuildInfo {
+  /** Cargo semver (compatibility version). */
+  version?: string;
+  /** Display build identity: image tag / short SHA / `<semver>-dev`. */
+  buildVersion?: string;
+  /** Image build time (RFC 3339), if CI stamped it. */
+  buildTime?: string;
 }
 
-export const Logo = ({ subtitle = "Decentralization Manager" }: LogoProps) => {
+interface LogoProps {
+  subtitle?: string;
+  /** Build identity for the hidden build-info reveal. Absent before login. */
+  buildInfo?: BuildInfo;
+}
+
+const formatTimestamp = (iso: string) =>
+  new Date(iso).toLocaleString("hu-HU", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+
+export const Logo = ({
+  subtitle = "Decentralization Manager",
+  buildInfo,
+}: LogoProps) => {
   const theme = useTheme();
   const wordmark =
     theme.palette.mode === "light" ? BitSafeLogoDark : BitSafeLogoLight;
-  const [showBuildDate, setShowBuildDate] = useState(false);
+  const [showBuildInfo, setShowBuildInfo] = useState(false);
   const clickCount = useRef(0);
 
   const handleSubtitleClick = () => {
     clickCount.current += 1;
     if (clickCount.current >= 10) {
       clickCount.current = 0;
-      setShowBuildDate(false);
+      setShowBuildInfo(false);
       window.location.href = "/swagger-ui/";
     } else if (clickCount.current >= 5) {
-      setShowBuildDate(true);
+      setShowBuildInfo(true);
     }
   };
+
+  // Prefer the CI-stamped image build time (matches the running image); fall
+  // back to the frontend bundle's build date when the backend didn't stamp one
+  // (e.g. before login, or a local build).
+  const builtAt = buildInfo?.buildTime ?? __BUILD_DATE__;
+  const buildLabel = buildInfo?.buildVersion
+    ? `Build ${buildInfo.buildVersion}${
+        buildInfo.version ? ` · v${buildInfo.version}` : ""
+      } · ${formatTimestamp(builtAt)}`
+    : `Build: ${formatTimestamp(builtAt)}`;
 
   if (!BITSAFE_BRANDING) {
     // Co-brand mode: replace the "itsafe" wordmark with "Decentralization
@@ -52,9 +86,7 @@ export const Logo = ({ subtitle = "Decentralization Manager" }: LogoProps) => {
             userSelect: "none",
           }}
         >
-          {showBuildDate
-            ? `Build: ${new Date(__BUILD_DATE__).toLocaleString("hu-HU", { year: "numeric", month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit", hour12: false })}`
-            : "Decentralization Manager"}
+          {showBuildInfo ? buildLabel : "Decentralization Manager"}
         </Typography>
       </Box>
     );
@@ -74,9 +106,7 @@ export const Logo = ({ subtitle = "Decentralization Manager" }: LogoProps) => {
         onClick={handleSubtitleClick}
         sx={{ mt: 0.5, cursor: "default", userSelect: "none" }}
       >
-        {showBuildDate
-          ? `Build: ${new Date(__BUILD_DATE__).toLocaleString("hu-HU", { year: "numeric", month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit", hour12: false })}`
-          : subtitle}
+        {showBuildInfo ? buildLabel : subtitle}
       </Typography>
     </Box>
   );

--- a/crates/decman/frontend/src/components/NetworkConfigAccordion.tsx
+++ b/crates/decman/frontend/src/components/NetworkConfigAccordion.tsx
@@ -444,8 +444,8 @@ export const NetworkConfigAccordion = ({
                   <TableCell
                     sx={{ fontFamily: "monospace", fontSize: "0.75rem", py: 1, whiteSpace: "nowrap" }}
                   >
-                    {getStat(selfEntry.participant_id)?.version ??
-                      nodeConfig?.version ??
+                    {getStat(selfEntry.participant_id)?.build_version ??
+                      nodeConfig?.build_version ??
                       "—"}
                   </TableCell>
                 </TableRow>
@@ -499,7 +499,7 @@ export const NetworkConfigAccordion = ({
                     <TableCell
                       sx={{ fontFamily: "monospace", fontSize: "0.75rem", py: 1, whiteSpace: "nowrap" }}
                     >
-                      {st?.version ?? "—"}
+                      {st?.build_version ?? "—"}
                     </TableCell>
                   </TableRow>
                 );

--- a/crates/decman/frontend/src/components/Sidebar.tsx
+++ b/crates/decman/frontend/src/components/Sidebar.tsx
@@ -21,7 +21,7 @@ import BitSafeLogoLight from "../assets/bitsafe-logo-light.svg";
 
 import { useAuth } from "../contexts";
 import { BITSAFE_BRANDING } from "../constants";
-import { Logo } from "./Logo";
+import { Logo, type BuildInfo } from "./Logo";
 import { ThemeSwitcher } from "./ThemeSwitcher";
 
 export const SIDEBAR_WIDTH = 260;
@@ -32,6 +32,8 @@ interface SidebarProps {
   partyCount: number;
   packageCount: number;
   notificationCount: number;
+  /** Build identity for the logo's hidden build-info reveal. */
+  buildInfo?: BuildInfo;
 }
 
 const navItems = [
@@ -47,6 +49,7 @@ export const Sidebar = ({
   partyCount,
   packageCount,
   notificationCount,
+  buildInfo,
 }: SidebarProps) => {
   const theme = useTheme();
   const { token, logout } = useAuth();
@@ -70,7 +73,7 @@ export const Sidebar = ({
     >
       {/* Logo */}
       <Box sx={{ px: 3, pt: 3, pb: 1 }}>
-        <Logo />
+        <Logo buildInfo={buildInfo} />
       </Box>
 
       {/* Navigation */}

--- a/crates/decman/src/build_info.rs
+++ b/crates/decman/src/build_info.rs
@@ -1,0 +1,46 @@
+//! Build identity for this binary.
+//!
+//! There are two distinct notions of "version" here, and they must not be
+//! conflated:
+//!
+//! * [`SEMVER`] is the Cargo package version. It is the *compatibility*
+//!   version peers exchange over Noise and gate on (`MIN_PEER_VERSION`), so it
+//!   must stay a parseable semver and is compiled in via `CARGO_PKG_VERSION`.
+//! * [`build_version`] and [`build_time`] are *display only*. CI passes the
+//!   pushed image tag (releases) or short commit SHA (per-commit dev images)
+//!   plus a build timestamp as Docker `--build-arg`s, which the runtime
+//!   Dockerfile turns into the `DECPM_BUILD_VERSION` / `DECPM_BUILD_TIME` env
+//!   vars. Because the same value that tags the image fills `build_version`,
+//!   what the UI shows equals the image tag by construction.
+//!
+//! Outside CI (a plain `cargo run`, local `docker build`) the env vars are
+//! unset, so `build_version` falls back to `<semver>-dev` and `build_time` is
+//! `None`.
+
+use std::sync::LazyLock;
+
+/// Cargo package semver — the wire/compatibility version peers gate on.
+pub const SEMVER: &str = env!("CARGO_PKG_VERSION");
+
+static BUILD_VERSION: LazyLock<String> =
+    LazyLock::new(|| read_env("DECPM_BUILD_VERSION").unwrap_or_else(|| format!("{SEMVER}-dev")));
+
+static BUILD_TIME: LazyLock<Option<String>> = LazyLock::new(|| read_env("DECPM_BUILD_TIME"));
+
+/// Display build identifier: the git tag on release images, the short SHA on
+/// per-commit images, or `<semver>-dev` when built/run outside CI.
+pub fn build_version() -> &'static str {
+    &BUILD_VERSION
+}
+
+/// When the image was built (RFC 3339), if CI stamped it. `None` outside CI.
+pub fn build_time() -> Option<&'static str> {
+    BUILD_TIME.as_deref()
+}
+
+/// Read an env var, treating unset or blank (`""`, whitespace) as absent — a
+/// build-arg that isn't passed still materializes as an empty `ENV`, which we
+/// want to behave the same as unset.
+fn read_env(key: &str) -> Option<String> {
+    std::env::var(key).ok().filter(|v| !v.trim().is_empty())
+}

--- a/crates/decman/src/lib.rs
+++ b/crates/decman/src/lib.rs
@@ -5,6 +5,7 @@
 //! an embedded React UI.
 
 pub mod auth;
+pub mod build_info;
 pub mod config;
 pub mod consts;
 pub mod db;

--- a/crates/decman/src/server/handlers/config.rs
+++ b/crates/decman/src/server/handlers/config.rs
@@ -78,7 +78,7 @@ pub async fn save_network_config(
 /// `config` is owned (not borrowed) so the type can derive `ts_rs::TS` for the
 /// frontend type generator — `TS` needs an owned, `'static` type. The handler
 /// clones the node config once per request, which is cheap relative to the I/O.
-#[derive(Serialize)]
+#[derive(Serialize, utoipa::ToSchema)]
 #[cfg_attr(feature = "typegen", derive(ts_rs::TS), ts(optional_fields))]
 pub struct NodeConfigResponse {
     #[serde(flatten)]
@@ -101,7 +101,7 @@ pub struct NodeConfigResponse {
 #[utoipa::path(
     tag = "Configuration",
     responses(
-        (status = 200, description = "Node configuration", body = NodeConfig)
+        (status = 200, description = "Node configuration", body = NodeConfigResponse)
     )
 )]
 #[get("/node-config")]
@@ -146,4 +146,26 @@ async fn save_peers_to_db(db: &SqlitePool, peers: &[Peer]) -> Result {
         tx.insert_peer(peer).await?;
     }
     Commitable::commit(tx).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use utoipa::PartialSchema;
+
+    // The `/node-config` OpenAPI response is documented as `NodeConfigResponse`,
+    // not the flattened `NodeConfig`. Guard that its schema builds (flatten can
+    // fail at spec-assembly, not compile time) and actually documents the build
+    // identity fields, so the generated Swagger stays honest.
+    #[test]
+    fn node_config_response_schema_documents_build_fields() {
+        let schema = NodeConfigResponse::schema();
+        let json = serde_json::to_string(&schema).expect("schema should serialize");
+        for field in ["version", "build_version", "build_time"] {
+            assert!(
+                json.contains(field),
+                "OpenAPI schema missing `{field}`: {json}"
+            );
+        }
+    }
 }

--- a/crates/decman/src/server/handlers/config.rs
+++ b/crates/decman/src/server/handlers/config.rs
@@ -79,14 +79,22 @@ pub async fn save_network_config(
 /// frontend type generator — `TS` needs an owned, `'static` type. The handler
 /// clones the node config once per request, which is cheap relative to the I/O.
 #[derive(Serialize)]
-#[cfg_attr(feature = "typegen", derive(ts_rs::TS))]
+#[cfg_attr(feature = "typegen", derive(ts_rs::TS), ts(optional_fields))]
 pub struct NodeConfigResponse {
     #[serde(flatten)]
     config: NodeConfig,
     test_mode: bool,
-    /// dec-party-manager binary version, so the Config tab can show which
-    /// build this node is running.
+    /// Cargo package semver. This is the *compatibility* version peers gate on
+    /// (`MIN_PEER_VERSION`), not necessarily the release identity — see
+    /// `build_version`.
     version: &'static str,
+    /// Display build identity: the git tag on release images, the short commit
+    /// SHA on per-commit images, or `<semver>-dev` outside CI. This is what the
+    /// Config tab's Version column and the header build-info easter egg show.
+    build_version: &'static str,
+    /// When this image was built (RFC 3339), if CI stamped it; `None` outside CI.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    build_time: Option<&'static str>,
 }
 
 /// Get the node configuration
@@ -101,7 +109,9 @@ pub async fn get_node_config(data: web::Data<AppState>) -> impl Responder {
     HttpResponse::Ok().json(NodeConfigResponse {
         config: data.config.clone(),
         test_mode: data.test_mode,
-        version: env!("CARGO_PKG_VERSION"),
+        version: crate::build_info::SEMVER,
+        build_version: crate::build_info::build_version(),
+        build_time: crate::build_info::build_time(),
     })
 }
 

--- a/crates/decman/src/server/handlers/parties.rs
+++ b/crates/decman/src/server/handlers/parties.rs
@@ -935,7 +935,8 @@ async fn check_participants_status(
                     status: ConnectionStatus::CurrentNode,
                     latency_ms: None,
                     workflow: None,
-                    version: Some(env!("CARGO_PKG_VERSION").to_string()),
+                    version: Some(crate::build_info::SEMVER.to_string()),
+                    build_version: Some(crate::build_info::build_version().to_string()),
                 }
             }));
             continue;
@@ -957,6 +958,7 @@ async fn check_participants_status(
                     latency_ms: None,
                     workflow: None,
                     version: None,
+                    build_version: None,
                 };
             };
 
@@ -976,13 +978,14 @@ async fn check_participants_status(
                     // classify_health_reply extracts its workflow state (or None
                     // if the peer is on older code that doesn't answer Health).
                     let latency_ms = u64::try_from(started.elapsed().as_millis()).ok();
-                    let (status, workflow, version) = classify_health_reply(&response);
+                    let reply = classify_health_reply(&response);
                     ParticipantStatus {
                         id: peer_id,
-                        status,
+                        status: reply.status,
                         latency_ms,
-                        workflow,
-                        version,
+                        workflow: reply.workflow,
+                        version: reply.version,
+                        build_version: reply.build_version,
                     }
                 }
                 Err(e) => {
@@ -1003,6 +1006,7 @@ async fn check_participants_status(
                         latency_ms: None,
                         workflow: None,
                         version: None,
+                        build_version: None,
                     }
                 }
             }

--- a/crates/decman/src/server/handlers/workflows.rs
+++ b/crates/decman/src/server/handlers/workflows.rs
@@ -3345,7 +3345,7 @@ async fn preflight_incompatible_peers(
             )
             .await
             {
-                Ok(response) => match classify_health_reply(&response).2 {
+                Ok(response) => match classify_health_reply(&response).version {
                     Some(v) if utils::version_at_least(&v, MIN_PEER_VERSION) => None,
                     Some(v) => Some((id, format!("running version {v}"))),
                     None => Some((

--- a/crates/decman/src/server/health.rs
+++ b/crates/decman/src/server/health.rs
@@ -28,7 +28,14 @@ pub struct HealthResponse {
     /// so payloads from nodes that predate this field still parse.
     #[serde(default)]
     pub workflow_count: usize,
+    /// Cargo semver — the compatibility version peers gate on
+    /// (`MIN_PEER_VERSION`).
     pub version: String,
+    /// Display build identity (image tag / short SHA / `<semver>-dev`). Shown
+    /// in the peers table; not used for compatibility gating. `default` so
+    /// payloads from peers that predate this field still parse.
+    #[serde(default)]
+    pub build_version: String,
 }
 
 impl HealthResponse {
@@ -81,24 +88,49 @@ pub async fn build_health_response(db: &SqlitePool, participant_id: &str) -> Hea
         in_workflow: workflow.is_some(),
         workflow,
         workflow_count,
-        version: env!("CARGO_PKG_VERSION").to_string(),
+        version: crate::build_info::SEMVER.to_string(),
+        build_version: crate::build_info::build_version().to_string(),
     }
+}
+
+/// Outcome of classifying a peer's reply to a `Health` probe. A reachable peer
+/// on older code fills only `status` (the rest are `None`/`Connected`), since
+/// its reply isn't a parseable [`HealthResponse`].
+pub(crate) struct HealthReply {
+    pub status: ConnectionStatus,
+    pub workflow: Option<WorkflowInfo>,
+    /// Semver the peer reported — used for `MIN_PEER_VERSION` gating.
+    pub version: Option<String>,
+    /// Display build identity the peer reported. `None` for peers on code that
+    /// predates the field (they send an empty string, normalized to `None`).
+    pub build_version: Option<String>,
 }
 
 /// Classify a successful Noise reply to a `Health` probe. Any reply that isn't a
 /// parseable `HealthResponse` (a peer on older code, a `Pong`, an empty body)
 /// still means the peer is reachable — we just don't learn its workflow state or
-/// version. Returns `(status, workflow, version)`.
-pub(crate) fn classify_health_reply(
-    reply: &[u8],
-) -> (ConnectionStatus, Option<WorkflowInfo>, Option<String>) {
+/// version.
+pub(crate) fn classify_health_reply(reply: &[u8]) -> HealthReply {
     if let Ok(msg) = Message::from_bytes(reply)
         && msg.msg_type == MessageType::HealthResponse
         && let Some(h) = HealthResponse::from_payload(&msg.payload)
     {
-        return (ConnectionStatus::Connected, h.workflow, Some(h.version));
+        // A blank build_version means the peer predates the field; normalize to
+        // None so the UI shows "—" rather than an empty cell.
+        let build_version = Some(h.build_version).filter(|v| !v.is_empty());
+        return HealthReply {
+            status: ConnectionStatus::Connected,
+            workflow: h.workflow,
+            version: Some(h.version),
+            build_version,
+        };
     }
-    (ConnectionStatus::Connected, None, None)
+    HealthReply {
+        status: ConnectionStatus::Connected,
+        workflow: None,
+        version: None,
+        build_version: None,
+    }
 }
 
 #[cfg(test)]
@@ -127,10 +159,12 @@ mod tests {
             }),
             workflow_count: 1,
             version: "0.1.0".into(),
+            build_version: "v0.1.0".into(),
         };
         let back =
             HealthResponse::from_payload(&h.to_payload()).context("payload should round-trip")?;
         assert!(back.in_workflow);
+        assert_eq!(back.build_version, "v0.1.0");
         let workflow = back.workflow.context("workflow should be present")?;
         assert_eq!(workflow.step, "SignDns");
         Ok(())
@@ -151,29 +185,47 @@ mod tests {
             }),
             workflow_count: 1,
             version: "0.1.0".into(),
+            build_version: "v0.1.0".into(),
         };
         let reply = Message::new(MessageType::HealthResponse, hr.to_payload()).to_bytes();
-        let (status, workflow, version) = classify_health_reply(&reply);
-        assert_eq!(status, ConnectionStatus::Connected);
+        let r = classify_health_reply(&reply);
+        assert_eq!(r.status, ConnectionStatus::Connected);
         assert_eq!(
-            workflow.context("workflow should be parsed")?.kind,
+            r.workflow.context("workflow should be parsed")?.kind,
             WorkflowKind::Onboarding
         );
-        assert_eq!(version.as_deref(), Some("0.1.0"));
+        assert_eq!(r.version.as_deref(), Some("0.1.0"));
+        assert_eq!(r.build_version.as_deref(), Some("v0.1.0"));
+
+        // Peer that predates build_version: sends an empty string → normalized
+        // to None, while version still parses.
+        let hr_old = HealthResponse {
+            participant_id: "p3::1220".into(),
+            in_workflow: false,
+            workflow: None,
+            workflow_count: 0,
+            version: "0.1.9".into(),
+            build_version: String::new(),
+        };
+        let reply = Message::new(MessageType::HealthResponse, hr_old.to_payload()).to_bytes();
+        let r = classify_health_reply(&reply);
+        assert_eq!(r.version.as_deref(), Some("0.1.9"));
+        assert!(r.build_version.is_none());
 
         // Old peer: replies Pong (not HealthResponse) → reachable, no workflow,
         // no version.
         let pong = Message::new_empty(MessageType::Pong).to_bytes();
-        let (status, workflow, version) = classify_health_reply(&pong);
-        assert_eq!(status, ConnectionStatus::Connected);
-        assert!(workflow.is_none());
-        assert!(version.is_none());
+        let r = classify_health_reply(&pong);
+        assert_eq!(r.status, ConnectionStatus::Connected);
+        assert!(r.workflow.is_none());
+        assert!(r.version.is_none());
+        assert!(r.build_version.is_none());
 
         // Empty body (e.g. an old listener's fall-through) → still reachable.
-        let (status, workflow, version) = classify_health_reply(&[]);
-        assert_eq!(status, ConnectionStatus::Connected);
-        assert!(workflow.is_none());
-        assert!(version.is_none());
+        let r = classify_health_reply(&[]);
+        assert_eq!(r.status, ConnectionStatus::Connected);
+        assert!(r.workflow.is_none());
+        assert!(r.version.is_none());
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Adds a display build identity to the UI so operators can tell **which image a node is running** — including the header build-info easter egg showing everything and **commit-unique** identification for dev builds.

> **Alternative to #266.** #266 solves the base problem CI-only, by rewriting `crates/decman/Cargo.toml`'s version at build time so the existing `CARGO_PKG_VERSION` becomes meaningful. This PR takes a different approach (a separate, display-only `build_version`) and additionally delivers two things #266 does not: the **easter egg showing everything** and **per-commit (short-SHA) identity** for dev images. Opened for comparison — the two overlap on `build.yml`/`release.yml` and should not both merge as-is.

## What changed

- **New `build_info` module** separates two notions of version that must not be conflated:
  - `version` — the Cargo semver. **Unchanged.** Still the compatibility version peers gate on (`MIN_PEER_VERSION`).
  - `build_version` / `build_time` — display-only, from `DECPM_BUILD_VERSION` / `DECPM_BUILD_TIME`, falling back to `<semver>-dev` outside CI.
- **CI stamps it via a Docker build-arg** → runtime `Dockerfile` env vars: `release.yml` passes the git tag, `build.yml` the short SHA. Same value tags the image, so **displayed build version == image tag by construction**.
- **Peers report `build_version`** over the Noise health handshake — additive `#[serde(default)]`, so older peers still parse. `classify_health_reply` now returns a named `HealthReply` struct.
- **UI**: Config peers-table "Version" column shows `build_version` for every node; the logo easter egg (5 clicks) shows build version + semver + build time.
- **`verify-tag` CI job** fails a release if the git tag ≠ `crates/decman/Cargo.toml` version. (Note: #266 forces this by overwriting instead — if #266 wins, this job is redundant.)

## Type of change

- [x] New feature
- [x] Build / CI / chore

## How tested

- Backend: `cargo fmt --check` + `cargo clippy` clean; **279 lib tests pass** (incl. new `build_version` round-trip + old-peer fallback in `health`).
- Frontend: `tsc -b && vite build` passes. Generated TS types carry the new fields and stay gitignored (regenerated in CI).

## Notes for reviewers

Please review alongside #266 and decide which approach to take. If #266 is preferred, the salvageable value here is the **easter-egg "show everything"** and **commit-level dev identity**, which can be layered on top of #266 as a much smaller follow-up.
