### PR TITLE
fix: support KMS-backed nodes in party key generation (spec + fingerprint)

### DIFF
--- a/crates/decman/src/utils.rs
+++ b/crates/decman/src/utils.rs
@@ -230,49 +230,61 @@ where
     anyhow::bail!("Condition not met after {max_attempts} attempts")
 }
 
-/// Compute fingerprint (hash) of a Canton SigningPublicKey
+/// Compute the fingerprint (hash) of a Canton `SigningPublicKey`.
 ///
-/// Canton uses multihash format for fingerprints:
-/// - Prefix "1220" indicates SHA-256 hash (0x12) with 32 bytes length (0x20)
-/// - Followed by the hex-encoded SHA-256 hash of the protobuf-serialized key
+/// Canton uses multihash format: the `"1220"` prefix marks a SHA-256 hash
+/// (`0x12`) of 32 bytes (`0x20`), followed by the hex digest of
+/// `SHA-256( be32(HashPurpose.PublicKeyFingerprint=12) || data )`.
 ///
-/// The fingerprint serves as the namespace identifier and unique key identifier in Canton.
+/// `data` depends on `(format, key_spec)`, mirroring Canton's
+/// `SigningPublicKey.getDataForFingerprint` + `PublicKey.id`:
+///
+/// - **Ed25519 in X.509 SPKI form** hashes only the *extracted raw* public
+///   key. This is a backward-compat carve-out: Ed25519 keys were once stored
+///   raw, and the fingerprint had to stay stable when Canton moved them into
+///   SPKI. It applies to Ed25519 **and nothing else**.
+/// - **Every other key** — notably EC-P256/P-384, as generated on KMS-backed
+///   nodes — hashes the `public_key` bytes verbatim.
+///
+/// Extracting the SPKI bit-string for a P-256 key yields a fingerprint Canton
+/// never computes, which broke namespace delegation on KMS nodes with
+/// `TOPOLOGY_NO_APPROPRIATE_SIGNING_KEY_IN_STORE`. See #264.
+///
+/// The fingerprint serves as the namespace identifier and unique key
+/// identifier in Canton.
 pub fn compute_fingerprint(key: &SigningPublicKey) -> String {
+    use std::borrow::Cow;
+
+    use canton_proto_rs::com::digitalasset::canton::crypto::v30::{
+        CryptoKeyFormat, SigningKeySpec,
+    };
     use sha2::{Digest, Sha256};
     use x509_parser::prelude::*;
 
-    // Canton uses domain-separated hashing with a purpose ID prefix
     // HashPurpose.PublicKeyFingerprint = 12
-    // For Curve25519 keys in X.509 format, Canton extracts the raw key bytes first
     const PURPOSE_PUBLIC_KEY_FINGERPRINT: i32 = 12;
 
-    tracing::debug!(
-        "Computing fingerprint from {count} bytes of X.509 key material",
-        count = key.public_key.len()
-    );
+    let is_ed25519_spki = key.format == CryptoKeyFormat::DerX509SubjectPublicKeyInfo as i32
+        && key.key_spec == SigningKeySpec::EcCurve25519 as i32;
+
+    let data: Cow<[u8]> = if is_ed25519_spki {
+        // Ed25519 only: hash the raw key extracted from the X.509 SPKI.
+        match SubjectPublicKeyInfo::from_der(&key.public_key) {
+            Ok((_, spki)) => Cow::Owned(spki.subject_public_key.data.to_vec()),
+            Err(e) => {
+                tracing::warn!("Failed to parse Ed25519 X.509 SPKI: {e}; hashing full key bytes");
+                Cow::Borrowed(key.public_key.as_slice())
+            }
+        }
+    } else {
+        // P-256/P-384 and the general case: hash the public key bytes as-is.
+        Cow::Borrowed(key.public_key.as_slice())
+    };
 
     let mut hasher = Sha256::new();
-
-    // Add purpose ID as 4-byte big-endian integer (domain separation)
+    // Purpose ID as 4-byte big-endian integer (domain separation).
     hasher.update(PURPOSE_PUBLIC_KEY_FINGERPRINT.to_be_bytes());
-
-    // Extract raw key bytes from X.509 SubjectPublicKeyInfo and add to hash
-    match SubjectPublicKeyInfo::from_der(&key.public_key) {
-        Ok((_, spki)) => {
-            // Get the BIT STRING containing the raw public key
-            let raw_bytes = spki.subject_public_key.data;
-            tracing::debug!(
-                "Extracted {count} raw key bytes from X.509 structure",
-                count = raw_bytes.len()
-            );
-            hasher.update(raw_bytes.as_ref());
-        }
-        Err(e) => {
-            tracing::warn!("Failed to parse X.509 structure: {e}, falling back to full key bytes");
-            hasher.update(&key.public_key);
-        }
-    }
-
+    hasher.update(&data);
     let hash_result = hasher.finalize();
 
     let fingerprint = format!(
@@ -630,6 +642,63 @@ mod tests {
     use super::*;
 
     use prost_types::Timestamp;
+
+    use base64::Engine;
+    use canton_proto_rs::com::digitalasset::canton::crypto::v30::{
+        CryptoKeyFormat, SigningKeySpec,
+    };
+
+    /// Build a `SigningPublicKey` from a base64 DER-SPKI public key, as Canton's
+    /// VaultService returns it.
+    fn spki_key(der_b64: &str, key_spec: SigningKeySpec) -> SigningPublicKey {
+        SigningPublicKey {
+            format: CryptoKeyFormat::DerX509SubjectPublicKeyInfo as i32,
+            public_key: base64::engine::general_purpose::STANDARD
+                .decode(der_b64)
+                .unwrap(),
+            key_spec: key_spec as i32,
+            usage: vec![],
+            // deprecated scheme field
+            ..Default::default()
+        }
+    }
+
+    // Real key + fingerprint pairs captured from live Canton participant nodes.
+    // Each key is a node's *root* namespace key, so its Canton fingerprint is
+    // the node's own namespace (the part after "::" in the participant id) —
+    // ground truth we cannot get wrong.
+
+    #[test]
+    fn fingerprint_ed25519_matches_canton() {
+        // JCE devnet node (iBTC-validator-1). Ed25519 in X.509 SPKI form:
+        // Canton hashes the *extracted raw* key (backward-compat carve-out).
+        let key = spki_key(
+            "MCowBQYDK2VwAyEAdPyxaQ5QEYjsrWOMlkojsDVB7Hop7HkrP0DrJ3P2I38=",
+            SigningKeySpec::EcCurve25519,
+        );
+        assert_eq!(
+            compute_fingerprint(&key),
+            "1220fa8543db6c66fe3a55b1f180c8dfc7f876265c76684fbc1d35d89e02c8aafe8e"
+        );
+    }
+
+    #[test]
+    fn fingerprint_ec_p256_matches_canton() {
+        // AWS-KMS devnet node (bitsafe-validator-3). EC-P256 in X.509 SPKI form:
+        // Canton hashes the *full* SPKI bytes, not the extracted EC point.
+        // Regression for #264 — extracting the point here produced a fingerprint
+        // Canton never computes, breaking the namespace delegation with
+        // TOPOLOGY_NO_APPROPRIATE_SIGNING_KEY_IN_STORE.
+        let key = spki_key(
+            "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEqMC8MjPyOvneI165hTcATE6Log\
+             A1dsdqiY+qXlMFcGWQ2EZp7MMq/c2iSMJCb/IOlaGOw7guEzDK78qxAsB5KQ==",
+            SigningKeySpec::EcP256,
+        );
+        assert_eq!(
+            compute_fingerprint(&key),
+            "1220d326ba9000791574dcc0047fafa2147d077c4a6072cf640ba7b8ceb301a31129"
+        );
+    }
 
     #[tokio::test]
     async fn test_write_and_read_single_message() -> Result {

--- a/crates/decman/src/workflow/onboarding/steps/generate_keys.rs
+++ b/crates/decman/src/workflow/onboarding/steps/generate_keys.rs
@@ -153,9 +153,16 @@ pub(crate) async fn get_or_create_signing_key(
     }
 
     tracing::debug!("Generating new signing key with name '{name}'");
+    // Leave the key spec UNSPECIFIED so the node picks its own configured
+    // default: EC-Curve25519 (Ed25519) on the JCE provider, EC-P256 on a
+    // KMS-backed node. Hardcoding EcCurve25519 broke party creation on
+    // KMS nodes (AWS, MPCH), which treat Curve25519 as verification-only and
+    // reject generation with SIGNING_KEY_GENERATION_ERROR / UnsupportedKeySpec.
+    // Deferring to the node default also avoids decman requesting a spec that
+    // the node's `crypto.signing.keys.allowed` set forbids. See #264.
     let response = vault_client
         .generate_signing_key(tonic::Request::new(GenerateSigningKeyRequest {
-            key_spec: SigningKeySpec::EcCurve25519 as i32,
+            key_spec: SigningKeySpec::Unspecified as i32,
             name: name.to_string(),
             usage: vec![usage as i32],
         }))


### PR DESCRIPTION
## What

Two fixes that together let onboarding (and add-party, which shares the code path) create a decentralized party on a participant whose crypto provider is an external KMS (`crypto.provider = kms` — AWS KMS, MPCH):

1. **Key spec** (`generate_keys.rs`): stop hardcoding `EcCurve25519`; leave the `GenerateSigningKey` spec `UNSPECIFIED` so the node uses its own default (Ed25519 on JCE, EC-P256 on KMS).
2. **Fingerprint** (`utils.rs::compute_fingerprint`): compute P-256 key fingerprints the way Canton actually does.

## Why

**Key spec.** On a KMS node Canton treats Curve25519 as verification-only and rejects generation with `SIGNING_KEY_GENERATION_ERROR(8,0) / UnsupportedKeySpec`, so party creation failed at `GenerateKeys`. Leaving the spec unspecified makes each node self-adapt and avoids requesting a spec the node's `crypto.signing.keys.allowed` set forbids. (Reproduced on a fresh AWS-KMS devnet node.)

**Fingerprint.** With generation fixed, onboarding then failed at the namespace-delegation authorize step with `TOPOLOGY_NO_APPROPRIATE_SIGNING_KEY_IN_STORE`. Root cause: `compute_fingerprint` always extracted the raw public key from the X.509 SubjectPublicKeyInfo before hashing. Per Canton's `SigningPublicKey.getDataForFingerprint`, that raw-extraction is a **backward-compat carve-out for Ed25519 only** (Ed25519 keys were once stored raw); every other key — including EC-P256 on KMS nodes — hashes the `public_key` SPKI bytes verbatim. Extracting the EC point for P-256 produced a fingerprint Canton never computes, so the namespace it proposed matched no key. Fix mirrors Canton exactly: extract only for Ed25519-in-SPKI, hash verbatim otherwise.

## How tested

- New unit tests in `utils.rs` with two real key→fingerprint vectors captured from live devnet nodes, each a node's **root** namespace key (so the expected fingerprint is the node's own namespace — unimpeachable ground truth):
  - Ed25519 (JCE node) → extract-raw path.
  - EC-P256 (AWS-KMS node) → full-SPKI path (this is the regression that was failing).
- Full `decman` lib suite (281 tests), `cargo clippy`, `cargo fmt --check` all clean (frontend build skipped via `DECMAN_SKIP_FRONTEND=1`; changes are Rust-only).
- The P-256 algorithm was also independently confirmed against Canton source (`getDataForFingerprint` / `PublicKey.id`) and reproduced byte-for-byte against a live node's fingerprint.
- **Live end-to-end re-test on the AWS-KMS devnet node still pending** — needs an image built from this branch's HEAD; the currently deployed decman-6 image only has the key-spec commit.

## Scope / still out of scope

**Contract signing** (`contracts/steps/sign.rs`) still exports the private key via `VaultService.ExportKeyPair` and signs locally with Ed25519 — impossible with a non-exportable KMS key. That is the larger generalized-signing work in #264 (Phase 2) / #241 (Option A → B1). A party created on a KMS node is not yet operational for governance signing until that lands. This PR covers party **creation/onboarding** only.

Refs #264, #241