### PR TITLE
fix(onboarding): coordinator signs P2P with its namespace key after DNS activation

### DIFF
--- a/crates/decman/src/workflow/onboarding/steps/generate_keys.rs
+++ b/crates/decman/src/workflow/onboarding/steps/generate_keys.rs
@@ -12,7 +12,9 @@ use canton_proto_rs::com::digitalasset::canton::{
         topology_mapping,
     },
     topology::admin::v30::{
-        AuthorizeRequest, StoreId, authorize_request, store_id,
+        AuthorizeRequest, BaseQuery, ListNamespaceDelegationRequest, StoreId, authorize_request,
+        base_query, store_id,
+        topology_manager_read_service_client::TopologyManagerReadServiceClient,
         topology_manager_write_service_client::TopologyManagerWriteServiceClient,
     },
 };
@@ -68,15 +70,23 @@ pub async fn generate_keys(
     let namespace_fingerprint = compute_fingerprint(&namespace_key);
     tracing::debug!("Namespace key fingerprint: {namespace_fingerprint}");
 
-    // Only propose the namespace delegation when we just created the key — if
-    // the key already existed, its delegation was authorized by the prior run
-    // and re-proposing at the same serial would error.
-    if !namespace_was_existing {
+    // Propose the namespace delegation unless the topology already carries it.
+    // Re-proposing an authorized delegation errors, but keying the skip on
+    // "the vault has the key" is not the same question: a run interrupted
+    // between GenerateSigningKey and the authorize below leaves the key
+    // present and the delegation absent, and every retry would then skip it —
+    // silently dropping this node's namespace key out of Canton's signing-key
+    // auto-selection for the rest of the party's life (#261). Ask the topology
+    // instead. The check is skipped for a freshly-minted key, which cannot
+    // have a delegation yet.
+    if !namespace_was_existing
+        || !namespace_delegation_exists(config, &namespace_fingerprint).await?
+    {
         propose_namespace_delegation(config, &namespace_key, &namespace_fingerprint).await?;
     } else {
         tracing::info!(
             "Reusing existing namespace key {namespace_fingerprint}; \
-             skipping namespace delegation proposal (already authorized)"
+             its namespace delegation is already authorized"
         );
     }
 
@@ -183,6 +193,41 @@ pub(crate) fn encode_keys_payload(
         buffer.put_slice(&encoded);
     }
     buffer.to_vec()
+}
+
+/// Is a namespace delegation for `namespace_fingerprint` — targeting that same
+/// key, i.e. the root delegation [`propose_namespace_delegation`] issues —
+/// already authorized in this participant's Authorized store?
+///
+/// The Authorized store is queried rather than the synchronizer store because
+/// that is where the delegation is written; it answers "did we authorize it"
+/// without depending on synchronizer propagation having caught up.
+async fn namespace_delegation_exists(
+    config: &NodeConfig,
+    namespace_fingerprint: &str,
+) -> Result<bool> {
+    let mut topology_read_client =
+        TopologyManagerReadServiceClient::connect(config.admin_api_url()).await?;
+
+    let response = topology_read_client
+        .list_namespace_delegation(tonic::Request::new(ListNamespaceDelegationRequest {
+            base_query: Some(BaseQuery {
+                store: Some(StoreId {
+                    store: Some(store_id::Store::Authorized(store_id::Authorized {})),
+                }),
+                proposals: false,
+                operation: 0,
+                time_query: Some(base_query::TimeQuery::HeadState(())),
+                filter_signed_key: String::new(),
+                protocol_version: None,
+            }),
+            filter_namespace: namespace_fingerprint.to_string(),
+            filter_target_key_fingerprint: namespace_fingerprint.to_string(),
+        }))
+        .await?
+        .into_inner();
+
+    Ok(!response.results.is_empty())
 }
 
 /// Propose namespace delegation for the generated namespace key

--- a/crates/decman/src/workflow/onboarding/steps/proposals/submit.rs
+++ b/crates/decman/src/workflow/onboarding/steps/proposals/submit.rs
@@ -1,8 +1,11 @@
+use std::collections::HashSet;
+
 use canton_proto_rs::com::digitalasset::canton::{
     protocol::v30::{DecentralizedNamespaceDefinition, SignedTopologyTransaction},
     topology::admin::v30::{
         AddTransactionsRequest, BaseQuery, ListDecentralizedNamespaceDefinitionRequest,
-        ListPartyToParticipantRequest, StoreId, Synchronizer, base_query, store_id, synchronizer,
+        ListPartyToParticipantRequest, SignTransactionsRequest, StoreId, Synchronizer, base_query,
+        store_id, synchronizer,
         topology_manager_read_service_client::TopologyManagerReadServiceClient,
         topology_manager_write_service_client::TopologyManagerWriteServiceClient,
     },
@@ -21,6 +24,9 @@ use crate::{
     workflow::{
         onboarding::OnboardingConfig,
         storage::{WorkflowStorage, artifact_kinds},
+        topology::{
+            dedupe_signatures, sign_transactions_with_topology_retry, synchronizer_store_id,
+        },
     },
 };
 
@@ -225,6 +231,23 @@ pub async fn submit_final_proposals(
     let namespace_def: DecentralizedNamespaceDefinition =
         utils::read_first_message_from_bytes(&namespace_bytes)?;
 
+    // Only worth a round trip when an owner signature is genuinely absent —
+    // which, thanks to the Authorized-store gap described on
+    // `add_coordinator_signatures`, is the coordinator's own on every run that
+    // reaches this point.
+    let missing_owners = owners_missing_signatures(&namespace_def, &p2p_transaction);
+    let p2p_transaction = if missing_owners.is_empty() {
+        p2p_transaction
+    } else {
+        tracing::info!(
+            "P2P aggregate is missing {count} owner-namespace signature(s); \
+             re-signing against the synchronizer store",
+            count = missing_owners.len()
+        );
+        add_coordinator_signatures(config, &synchronizer_id, p2p_transaction).await?
+    };
+    ensure_owner_threshold_signed(&namespace_def, &p2p_transaction)?;
+
     let party_id_str = format!(
         "{party_id_prefix}::{namespace}",
         namespace = namespace_def.decentralized_namespace
@@ -275,6 +298,111 @@ pub async fn submit_final_proposals(
     time::sleep(propagation_delay).await;
     tracing::info!("Topology propagation wait complete");
 
+    Ok(())
+}
+
+/// Re-sign the aggregated P2P proposal with every key this node can still
+/// contribute, against the **synchronizer** store.
+///
+/// `create_proposals` builds the P2P in the coordinator's *Authorized* store,
+/// where the decentralized namespace is at that point nothing but a
+/// partially-signed proposal. Canton's key auto-selection cannot chain the
+/// party's namespace through a not-yet-authorized DNS, so the coordinator's
+/// signature set comes back as participant + party signing key only — its
+/// owner-namespace signature is missing. Peers don't hit this: they sign
+/// against the synchronizer store after `submit_dns_proposals` activated the
+/// DNS, so their namespace key resolves.
+///
+/// With the default majority threshold the peers' namespace signatures alone
+/// clear the bar and the gap is invisible. With a unanimous threshold
+/// (`threshold == owners`) every owner must sign, the aggregate stays one
+/// signature short, and the proposal sits pending on the synchronizer forever
+/// — retry re-submits the identical aggregate and can never recover (#261).
+///
+/// By this point the DNS *is* active, so making the same `SignTransactions`
+/// call the peers make picks up the namespace key. Keys already on the
+/// transaction re-sign to identical bytes (Ed25519 is deterministic), hence
+/// the dedupe — Canton rejects a transaction carrying the same signature
+/// twice.
+async fn add_coordinator_signatures(
+    config: &NodeConfig,
+    synchronizer_id: &str,
+    transaction: SignedTopologyTransaction,
+) -> Result<SignedTopologyTransaction> {
+    let before = transaction.signatures.len();
+
+    let request = SignTransactionsRequest {
+        transactions: vec![transaction],
+        signed_by: vec![],
+        store: Some(synchronizer_store_id(synchronizer_id)),
+        force_flags: vec![],
+    };
+    let response = sign_transactions_with_topology_retry(config, request, "P2P").await?;
+    let mut signed = response
+        .transactions
+        .into_iter()
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("No signed transaction returned for coordinator P2P"))?;
+
+    dedupe_signatures(&mut signed);
+    tracing::info!(
+        "Coordinator re-signed P2P against the synchronizer store: {before} -> {after} signature(s)",
+        after = signed.signatures.len()
+    );
+    Ok(signed)
+}
+
+/// The namespace owners that have not signed `transaction`.
+///
+/// Each owner of a decentralized namespace is the fingerprint of that node's
+/// namespace root key, and `generate_keys` delegates each namespace to that
+/// same key, so an owner's signature carries `signed_by == <owner>`.
+fn owners_missing_signatures<'a>(
+    namespace_def: &'a DecentralizedNamespaceDefinition,
+    transaction: &SignedTopologyTransaction,
+) -> Vec<&'a str> {
+    let signers: HashSet<&str> = transaction
+        .signatures
+        .iter()
+        .map(|sig| sig.signed_by.as_str())
+        .collect();
+
+    namespace_def
+        .owners
+        .iter()
+        .map(String::as_str)
+        .filter(|owner| !signers.contains(owner))
+        .collect()
+}
+
+/// Fail before submitting when fewer than `threshold` of the namespace owners
+/// have signed the P2P proposal.
+///
+/// Canton accepts such a proposal, stores it as pending, and never activates
+/// it; the only symptom is `wait_for_p2p_in_topology` timing out with no clue
+/// as to which node's signature is absent. Name the missing owners instead.
+fn ensure_owner_threshold_signed(
+    namespace_def: &DecentralizedNamespaceDefinition,
+    transaction: &SignedTopologyTransaction,
+) -> Result {
+    let missing = owners_missing_signatures(namespace_def, transaction);
+    let signed = namespace_def.owners.len() - missing.len();
+    if (signed as i32) < namespace_def.threshold {
+        anyhow::bail!(
+            "P2P proposal carries {signed} of the {threshold} required owner-namespace \
+             signature(s) ({total} owner(s) total); submitting it would leave the mapping \
+             pending on the synchronizer forever. Owners that have not signed: {missing}",
+            threshold = namespace_def.threshold,
+            total = namespace_def.owners.len(),
+            missing = missing.join(", "),
+        );
+    }
+
+    tracing::info!(
+        "P2P proposal has {signed} of {total} owner-namespace signature(s) (threshold {threshold})",
+        total = namespace_def.owners.len(),
+        threshold = namespace_def.threshold,
+    );
     Ok(())
 }
 
@@ -365,4 +493,99 @@ async fn wait_for_p2p_in_topology(
     }
 
     anyhow::bail!("P2P did not appear in topology after {max_attempts} attempts")
+}
+
+#[cfg(test)]
+mod tests {
+    use canton_proto_rs::com::digitalasset::canton::crypto::v30::Signature;
+
+    use super::*;
+
+    fn namespace_def(threshold: i32, owners: &[&str]) -> DecentralizedNamespaceDefinition {
+        DecentralizedNamespaceDefinition {
+            decentralized_namespace: "1220dec".to_string(),
+            threshold,
+            owners: owners.iter().map(|o| (*o).to_string()).collect(),
+        }
+    }
+
+    fn signed_by(fingerprints: &[&str]) -> SignedTopologyTransaction {
+        SignedTopologyTransaction {
+            signatures: fingerprints
+                .iter()
+                .map(|fp| Signature {
+                    signed_by: (*fp).to_string(),
+                    ..Default::default()
+                })
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    /// The predicate that decides whether the coordinator re-signs: after
+    /// `create_proposals` its own owner-namespace signature is the one absent.
+    #[test]
+    fn reports_the_owner_whose_namespace_signature_is_absent() {
+        let def = namespace_def(1, &["1220aaa", "1220bbb"]);
+        let tx = signed_by(&["1220bbb", "1220part1", "1220daml1"]);
+
+        assert_eq!(owners_missing_signatures(&def, &tx), ["1220aaa"]);
+    }
+
+    /// The one case that skips the extra `SignTransactions` round trip: every
+    /// owner has already signed, so there is nothing left to contribute.
+    #[test]
+    fn reports_nothing_missing_when_every_owner_signed() {
+        let def = namespace_def(1, &["1220aaa", "1220bbb"]);
+        let tx = signed_by(&["1220aaa", "1220bbb", "1220part1"]);
+
+        assert!(owners_missing_signatures(&def, &tx).is_empty());
+    }
+
+    /// The #261 shape: two owners, unanimous threshold, and the coordinator's
+    /// own namespace signature missing. Canton would park this as a pending
+    /// proposal; we reject it up-front and name the owner that didn't sign.
+    #[test]
+    fn rejects_p2p_short_of_a_unanimous_threshold() {
+        let def = namespace_def(2, &["1220aaa", "1220bbb"]);
+        // participant + party signing keys are present, only the coordinator's
+        // owner-namespace key (1220aaa) is absent.
+        let tx = signed_by(&["1220bbb", "1220part1", "1220daml1", "1220daml2"]);
+
+        let message = match ensure_owner_threshold_signed(&def, &tx) {
+            Ok(()) => panic!("expected the missing owner-namespace signature to be rejected"),
+            Err(e) => e.to_string(),
+        };
+        assert!(message.contains("1220aaa"), "unhelpful error: {message}");
+        assert!(message.contains("1 of the 2"), "unhelpful error: {message}");
+    }
+
+    /// Why the bug survived every integration test and testnet run: a majority
+    /// threshold is satisfied by the peers alone, so the coordinator's missing
+    /// signature is invisible. This must stay accepted.
+    #[test]
+    fn accepts_majority_threshold_without_every_owner() {
+        let def = namespace_def(2, &["1220aaa", "1220bbb", "1220ccc"]);
+        let tx = signed_by(&["1220bbb", "1220ccc", "1220part1"]);
+
+        assert!(ensure_owner_threshold_signed(&def, &tx).is_ok());
+    }
+
+    #[test]
+    fn accepts_p2p_signed_by_every_owner() {
+        let def = namespace_def(2, &["1220aaa", "1220bbb"]);
+        let tx = signed_by(&["1220aaa", "1220bbb", "1220part1", "1220part2"]);
+
+        assert!(ensure_owner_threshold_signed(&def, &tx).is_ok());
+    }
+
+    /// Signatures from keys outside the owner set (hosting participants, party
+    /// signing keys) must not be counted towards the owner threshold.
+    #[test]
+    fn does_not_count_non_owner_signatures() {
+        let def = namespace_def(2, &["1220aaa", "1220bbb"]);
+        let tx = signed_by(&["1220bbb", "1220part1", "1220part2", "1220daml1"]);
+
+        assert!(ensure_owner_threshold_signed(&def, &tx).is_err());
+    }
 }

--- a/crates/decman/tests/common/phases/mod.rs
+++ b/crates/decman/tests/common/phases/mod.rs
@@ -31,4 +31,5 @@ pub mod retry_with_offline_peer;
 pub mod start_handler_conflict_409;
 pub mod token_custody;
 pub mod two_member_party;
+pub mod unanimous_threshold_party;
 pub mod utility_onboarding;

--- a/crates/decman/tests/common/phases/unanimous_threshold_party.rs
+++ b/crates/decman/tests/common/phases/unanimous_threshold_party.rs
@@ -1,0 +1,137 @@
+//! Regression (#261): a decentralized party whose threshold equals its owner
+//! count — every owner must sign.
+//!
+//! A mainnet 2-node Create Party stalled at `P2P did not appear in topology
+//! after 30 attempts`. The `PartyToParticipant` sat on the synchronizer as a
+//! pending proposal, signed by both hosting participants, both party signing
+//! keys, but only **one** of the two owner-namespace keys — the coordinator's
+//! was missing. `CreateProposals` authorizes the P2P in the coordinator's
+//! Authorized store while the decentralized namespace is still an
+//! unauthorized proposal there, so Canton's key auto-selection cannot chain
+//! the party's namespace and leaves that signature off. Peers sign later,
+//! against the synchronizer store, after the DNS is active — so only the
+//! coordinator is short.
+//!
+//! Every other onboarding phase uses the default majority threshold
+//! (`ceil(owners / 2)`), where the peers' namespace signatures alone clear the
+//! bar and the missing coordinator signature is invisible. This phase pins the
+//! threshold to the owner count, which is what the mainnet operator chose, so
+//! the aggregate is one signature short and the proposal can never activate.
+//! Retry re-submits the identical bytes forever.
+//!
+//! Pre-fix this phase fails the onboarding run with the topology timeout;
+//! post-fix the coordinator re-signs against the synchronizer store once the
+//! DNS is active and the party is created.
+
+use std::time::Duration;
+
+use anyhow::Context;
+use serde_json::{Value, json};
+use tracing::info;
+
+use crate::common::{
+    Fixture,
+    chaos::fresh_prefix,
+    http::probe_workflow_status,
+    invitations::{InvitationIds, post_accept_invitation, probe_pending_invitation},
+    scenario::Scenario,
+    types::DecentralizedPartiesResponse,
+};
+
+pub async fn run(f: &mut Fixture) -> anyhow::Result<()> {
+    info!("Phase: unanimous_threshold_party");
+    let prefix = fresh_prefix("unanimous");
+    info!("Using prefix: {prefix}");
+
+    Scenario::with_ctx(
+        format!("create decentralized party {prefix} with a unanimous threshold"),
+        InvitationIds::default(),
+    )
+    .when("P1 posts /onboarding inviting P2 with threshold 2 of 2", {
+        let prefix = prefix.clone();
+        move |f, _| {
+            let prefix = prefix.clone();
+            Box::pin(async move {
+                // Two owners (P1 + P2) and an explicit threshold of 2: every
+                // owner namespace key must sign the P2P, including the
+                // coordinator's own.
+                let req = json!({
+                    "party_id_prefix": prefix,
+                    "peer_ids": [&f.p2.participant_id],
+                    "threshold": 2,
+                });
+                let _: Value = f.post_json(f.p1.http, "/onboarding", &req).await?;
+                Ok(())
+            })
+        }
+    })
+    .then(
+        "Onboarding invitation visible on P2",
+        Duration::from_secs(60),
+        |f, ctx| {
+            Box::pin(async move {
+                let id = probe_pending_invitation(f, f.p2.http, "Onboarding").await?;
+                ctx.p2 = Some(id);
+                Some(Ok(()))
+            })
+        },
+    )
+    .when("P2 accepts the Onboarding invitation", |f, ctx| {
+        Box::pin(async move {
+            let p2_id = ctx
+                .p2
+                .as_deref()
+                .context("P2 invitation id not set")?
+                .to_string();
+            post_accept_invitation(f, f.p2.http, &p2_id)
+                .await
+                .context("accept on P2")
+        })
+    })
+    .then(
+        "onboarding workflow reaches completed",
+        Duration::from_secs(240),
+        |f, _| {
+            Box::pin(async move {
+                probe_workflow_status(&*f, f.p1.http, "/onboarding/status", "onboarding").await
+            })
+        },
+    )
+    .then(
+        "party is visible with threshold 2 over 2 participants",
+        Duration::from_secs(30),
+        {
+            let prefix = prefix.clone();
+            move |f, _| {
+                let prefix = prefix.clone();
+                Box::pin(async move {
+                    let r: DecentralizedPartiesResponse =
+                        f.get_json(f.p1.http, "/decentralized-parties").await.ok()?;
+                    let party = r
+                        .parties
+                        .into_iter()
+                        .find(|p| p.party_id.starts_with(&prefix))?;
+                    // Guards the regression against a vacuous pass: if the
+                    // requested threshold were ever dropped on the way to the
+                    // topology, the party would come back as the 1-of-2
+                    // majority default and would never have exercised the bug.
+                    if party.threshold != 2 {
+                        return Some(Err(anyhow::anyhow!(
+                            "expected threshold 2, got {threshold}",
+                            threshold = party.threshold
+                        )));
+                    }
+                    if party.participants.len() != 2 {
+                        return Some(Err(anyhow::anyhow!(
+                            "expected 2 hosting participants, got {count}",
+                            count = party.participants.len()
+                        )));
+                    }
+                    Some(Ok(()))
+                })
+            }
+        },
+    )
+    .run(f)
+    .await
+}

--- a/crates/decman/tests/governance_workflows.rs
+++ b/crates/decman/tests/governance_workflows.rs
@@ -91,6 +91,11 @@ async fn governance_workflows_e2e() -> anyhow::Result<()> {
     // single invited peer (1 coordinator + 1 regular peer) before the
     // full-mesh happy path, which can't catch it because it invites everyone.
     phases::two_member_party::run(&mut f).await?;
+    // Regression guard for #261: a party whose threshold equals its owner
+    // count. The happy-path phases all use the majority default, where the
+    // peers' namespace signatures alone satisfy the P2P and the coordinator's
+    // missing one goes unnoticed.
+    phases::unanimous_threshold_party::run(&mut f).await?;
     phases::create_dec_party::run(&mut f).await?;
     phases::distribute_dars::run(&mut f).await?;
     phases::check_peer_dars::run(&mut f).await?;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -280,7 +280,7 @@ Creates a new decentralized party with multiple hosting participants.
 | 4 | SignDns | All | Each participant signs the DNS proposal with their namespace key |
 | 5 | SubmitDns | Coordinator | Submit signed DNS proposal to Canton, wait for topology propagation (30s) |
 | 6 | SignP2p | All | Each participant signs P2P proposals with their namespace key |
-| 7 | SubmitFinal | Coordinator | Submit signed P2P proposals, wait for propagation |
+| 7 | SubmitFinal | Coordinator | Re-sign the aggregate against the synchronizer store (the coordinator's namespace key only resolves once the DNS is active), verify the owner threshold is met, submit signed P2P proposals, wait for propagation |
 | 8 | Complete | All | Disconnect peers, workflow finished |
 
 **Canton API calls:**


### PR DESCRIPTION
Fixes #261.

## The bug

A Create Party run with a **unanimous threshold** (`threshold == owner count`) stalls at `P2P did not appear in topology after 30 attempts`, and no retry can ever recover it.

`CreateProposals` authorizes the `PartyToParticipant` in the coordinator's **Authorized** store, while the decentralized namespace there is still a partially-signed proposal. Canton's key auto-selection can't chain the party's namespace through a not-yet-authorized DNS, so the coordinator's signature set comes back as *participant + party signing key only* — its owner-namespace signature is missing. Peers are fine: they sign later, against the **Synchronizer** store, after `SubmitDns` activated the DNS.

With the default majority threshold the peers' namespace signatures alone clear the bar, so nothing looks wrong. At `threshold == owners` every owner must sign, the aggregate is permanently one signature short, and the proposal sits pending on the synchronizer. `SubmitFinal` re-reads the same artifacts and re-submits byte-identical signatures forever (Ed25519 is deterministic).

Every other topology workflow in the repo (kick, add-party, change-threshold) already builds its proposals against the synchronizer store — onboarding is the only one that doesn't, because at proposal time its namespace doesn't exist yet.

## The fix

1. **`submit.rs` — coordinator tops up its signatures after the DNS is active.** Before submitting, if any owner is missing from the aggregate's signature set, the coordinator makes the same `SignTransactions` call the peers make (synchronizer store, auto-selected keys) — which now resolves its namespace key — and dedupes. The re-sign is skipped when every owner has already signed, so the round trip only happens when there's something to add.

   This also makes the failure self-healing: a retry re-signs and re-submits, and Canton merges signatures onto the pending proposal by hash. That covers the "authorize-by-hash repair path" the issue asked for, without a new code path.

2. **`submit.rs` — pre-submit signature check.** Fewer than `threshold` owner signatures now fails fast, naming the owners that didn't sign, instead of polling 30× and timing out with no clue which node is missing.

3. **`generate_keys.rs` — delegation idempotency keyed on topology, not the vault** (the issue's secondary finding). A run interrupted between `GenerateSigningKey` and the `NamespaceDelegation` authorize left the key present and the delegation absent, and every retry then skipped it — silently dropping that node's namespace key from auto-selection. The skip now asks the Authorized store whether the delegation exists.

## Tests

New IT phase `unanimous_threshold_party` (2 owners, threshold 2), placed early in the suite next to `two_member_party`. It asserts the onboarding run completes and the party comes back with `threshold == 2` over 2 participants — the threshold assertion keeps the regression from passing vacuously if the requested threshold were ever dropped on the way to the topology.

The first commit on this branch is the phase alone, so CI shows it failing on the bug; the fix follows in the second commit.

**Before the fix** — [run 30248629254](https://github.com/DLC-link/decentralization-manager/actions/runs/30248629254) (phase only, `15307ed`):

```
Scenario "create decentralized party unanimous-... with a unanimous threshold" failed at THEN "onboarding workflow reaches completed"
  1: onboarding failed: Coordinator workflow failed: P2P did not appear in topology after 30 attempts
```

`two_member_party` — the same 2-node party at the default threshold 1 — passed 50s earlier in that same run, so the threshold is the only variable.

**After the fix** — [run 30252046956](https://github.com/DLC-link/decentralization-manager/actions/runs/30252046956) (`078604a`): the same phase completes in 50.0s and the full suite is green.

Unit tests cover the new signature-completeness helpers, including the majority case that must stay accepted.

## Alternative considered

Move the P2P proposal creation out of `CreateProposals` into the `SubmitDns` arm, so it is authorized against the synchronizer store with the DNS already active — exactly what kick / add-party / change-threshold do, one signing pass, no top-up. It is the tidier end state, but it moves an artifact write across a workflow step, which the resume and retry paths key off, and it does nothing for a party that is *already* stuck with a pending proposal. The top-up recovers those on the next retry. Worth doing as a follow-up cleanup if we want onboarding to match the other three workflows structurally.

## Reviewer notes

- `ensure_owner_threshold_signed` matches an owner's signature by `signed_by == <owner fingerprint>`. That holds because DecMan mints each owner's namespace key per party and delegates the namespace to that same key. An owner signing via a *different* delegated key would be rejected here — that key would have to be created by hand in the participant's vault for a party-scoped namespace DecMan just generated.
- No change to the DNS submission path; the DNS activates correctly today.
