### PR TITLE
refactor(signing): extract party-key signing behind a TransactionSigner trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1334,6 +1334,7 @@ dependencies = [
  "actix-web",
  "aes-gcm 0.11.0",
  "anyhow",
+ "async-trait",
  "base64",
  "bytes",
  "canton-proto-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ actix-cors = { version = "0.7" }
 actix-web = { version = "4" }
 aes-gcm = { version = "0.11" }
 anyhow = { version = "1.0.98" }
+async-trait = { version = "0.1" }
 base64 = { version = "0.22" }
 bytes = { version = "1.11.1" }
 chrono = { version = "0.4", default-features = false, features = [

--- a/crates/decman/Cargo.toml
+++ b/crates/decman/Cargo.toml
@@ -42,6 +42,7 @@ actix-cors = { workspace = true }
 actix-web = { workspace = true }
 aes-gcm = { workspace = true }
 anyhow = { workspace = true }
+async-trait = { workspace = true }
 base64 = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }

--- a/crates/decman/src/lib.rs
+++ b/crates/decman/src/lib.rs
@@ -12,6 +12,7 @@ pub mod db;
 pub mod error;
 pub mod noise;
 pub mod server;
+pub mod signing;
 pub mod utils;
 pub mod workflow;
 

--- a/crates/decman/src/signing/error.rs
+++ b/crates/decman/src/signing/error.rs
@@ -1,0 +1,16 @@
+use thiserror::Error;
+
+/// Errors a signing backend can return.
+///
+/// The typed boundary keeps backend failures distinguishable at the trait
+/// surface. Backend internals may still use `anyhow` for one-off failures;
+/// those arrive as [`SigningError::Other`].
+#[derive(Debug, Error)]
+pub enum SigningError {
+    /// A Canton admin-API RPC failed (for example `ExportKeyPair`).
+    #[error("vault RPC failed: {0}")]
+    VaultRpc(#[from] tonic::Status),
+    /// Any other signing failure.
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}

--- a/crates/decman/src/signing/mod.rs
+++ b/crates/decman/src/signing/mod.rs
@@ -15,62 +15,13 @@
 //!   in the signing flow changes.
 //!
 //! The one operation that varies is "turn a prepared-transaction hash into a
-//! Canton [`Signature`]"; everything else (loading the key, loading prepared
+//! Canton `Signature`"; everything else (loading the key, loading prepared
 //! submissions, persisting the signature bundle) is provider-independent and
 //! stays in `workflow::contracts::steps::sign`.
 
+mod error;
+mod signer;
 pub mod vault_export;
 
-use async_trait::async_trait;
-use canton_proto_rs::com::digitalasset::canton::crypto::v30::{Signature, SigningPublicKey};
-use tonic::transport::Channel;
-
-use crate::error::Result;
-
-/// Everything a signing backend needs to sign for one party key. Resolved once
-/// by the caller from Canton's vault metadata (`VaultService.ListMyKeys`).
-pub struct SigningKeyContext {
-    /// Canton fingerprint of the key. Goes into [`Signature::signed_by`] and is
-    /// how Canton selects the verifying key from the party's topology.
-    pub fingerprint: String,
-    /// The public key (format, key spec, bytes). A backend uses this to choose
-    /// the signature algorithm/format, and the export backend uses it to verify
-    /// the recovered private key.
-    pub public_key: SigningPublicKey,
-    /// The underlying KMS key id, present when the key is KMS-backed (from
-    /// `PrivateKeyMetadata.kms_key_id`). A KMS signing backend signs with this;
-    /// the export backend ignores it.
-    pub kms_key_id: Option<String>,
-}
-
-/// Signs a decentralized party's interactive-submission prepared hashes.
-///
-/// Implement this trait to add a new signing backend (e.g. AWS KMS, MPCH), then
-/// wire it into [`select_signer`].
-#[async_trait]
-pub trait TransactionSigner: Send + Sync {
-    /// Sign each prepared-transaction `hash` with the party key described by
-    /// `key`, returning one Canton [`Signature`] per hash, in order.
-    async fn sign(&self, hashes: &[Vec<u8>], key: &SigningKeyContext) -> Result<Vec<Signature>>;
-}
-
-/// Choose the signing backend for a given party key.
-///
-/// The choice is forced by how the key is held, not by preference: a
-/// KMS-backed key can only be signed by the matching KMS backend, an
-/// exportable key by [`vault_export::VaultExportSigner`]. Today only the export
-/// backend exists; a KMS-backed key still falls through to it and fails at
-/// export exactly as before — the KMS backend lands with its own change. This
-/// is the single extension point for new backends.
-///
-/// Takes the caller's already-open admin-API `channel` so the export backend
-/// reuses one connection instead of opening a second. Async so a future KMS
-/// backend can build its own KMS client here.
-pub async fn select_signer(
-    _key: &SigningKeyContext,
-    channel: Channel,
-) -> Result<Box<dyn TransactionSigner>> {
-    // TODO(#264 Phase 2): when `_key.kms_key_id.is_some()`, return the KMS
-    // backend (AWS KMS / MPCH) instead of the export backend.
-    Ok(Box::new(vault_export::VaultExportSigner::new(channel)))
-}
+pub use error::SigningError;
+pub use signer::{PreparedTransactionHash, SigningKeyContext, TransactionSigner, select_signer};

--- a/crates/decman/src/signing/mod.rs
+++ b/crates/decman/src/signing/mod.rs
@@ -23,8 +23,9 @@ pub mod vault_export;
 
 use async_trait::async_trait;
 use canton_proto_rs::com::digitalasset::canton::crypto::v30::{Signature, SigningPublicKey};
+use tonic::transport::Channel;
 
-use crate::{config::NodeConfig, error::Result};
+use crate::error::Result;
 
 /// Everything a signing backend needs to sign for one party key. Resolved once
 /// by the caller from Canton's vault metadata (`VaultService.ListMyKeys`).
@@ -62,16 +63,14 @@ pub trait TransactionSigner: Send + Sync {
 /// export exactly as before — the KMS backend lands with its own change. This
 /// is the single extension point for new backends.
 ///
-/// Async because building a backend may need an admin-API channel (which
-/// applies the configured TLS settings); a future KMS backend would build its
-/// own KMS client here instead.
+/// Takes the caller's already-open admin-API `channel` so the export backend
+/// reuses one connection instead of opening a second. Async so a future KMS
+/// backend can build its own KMS client here.
 pub async fn select_signer(
-    config: &NodeConfig,
     _key: &SigningKeyContext,
+    channel: Channel,
 ) -> Result<Box<dyn TransactionSigner>> {
     // TODO(#264 Phase 2): when `_key.kms_key_id.is_some()`, return the KMS
     // backend (AWS KMS / MPCH) instead of the export backend.
-    Ok(Box::new(vault_export::VaultExportSigner::new(
-        config.admin_channel().await?,
-    )))
+    Ok(Box::new(vault_export::VaultExportSigner::new(channel)))
 }

--- a/crates/decman/src/signing/mod.rs
+++ b/crates/decman/src/signing/mod.rs
@@ -1,0 +1,77 @@
+//! Pluggable signing backends for a decentralized party's Daml key.
+//!
+//! A decentralized party authorizes its Daml transactions (today: deploying the
+//! governance-core contract at bootstrap) by signing the Ledger API
+//! interactive-submission *prepared-transaction hash* with the party's protocol
+//! signing key. Where that key lives — and therefore how it signs — varies:
+//!
+//! - [`vault_export::VaultExportSigner`] pulls the private key out of the
+//!   participant's vault (`VaultService.ExportKeyPair`) and signs locally with
+//!   Ed25519. This is the only backend today and works for the JCE crypto
+//!   provider, whose keys are exportable.
+//! - A KMS-backed key (AWS KMS, MPCH) is non-exportable, so it must be signed by
+//!   asking the KMS to sign the hash. That backend is a follow-up: implement
+//!   [`TransactionSigner`] and add a branch to [`select_signer`]. Nothing else
+//!   in the signing flow changes.
+//!
+//! The one operation that varies is "turn a prepared-transaction hash into a
+//! Canton [`Signature`]"; everything else (loading the key, loading prepared
+//! submissions, persisting the signature bundle) is provider-independent and
+//! stays in `workflow::contracts::steps::sign`.
+
+pub mod vault_export;
+
+use async_trait::async_trait;
+use canton_proto_rs::com::digitalasset::canton::crypto::v30::{Signature, SigningPublicKey};
+
+use crate::{config::NodeConfig, error::Result};
+
+/// Everything a signing backend needs to sign for one party key. Resolved once
+/// by the caller from Canton's vault metadata (`VaultService.ListMyKeys`).
+pub struct SigningKeyContext {
+    /// Canton fingerprint of the key. Goes into [`Signature::signed_by`] and is
+    /// how Canton selects the verifying key from the party's topology.
+    pub fingerprint: String,
+    /// The public key (format, key spec, bytes). A backend uses this to choose
+    /// the signature algorithm/format, and the export backend uses it to verify
+    /// the recovered private key.
+    pub public_key: SigningPublicKey,
+    /// The underlying KMS key id, present when the key is KMS-backed (from
+    /// `PrivateKeyMetadata.kms_key_id`). A KMS signing backend signs with this;
+    /// the export backend ignores it.
+    pub kms_key_id: Option<String>,
+}
+
+/// Signs a decentralized party's interactive-submission prepared hashes.
+///
+/// Implement this trait to add a new signing backend (e.g. AWS KMS, MPCH), then
+/// wire it into [`select_signer`].
+#[async_trait]
+pub trait TransactionSigner: Send + Sync {
+    /// Sign each prepared-transaction `hash` with the party key described by
+    /// `key`, returning one Canton [`Signature`] per hash, in order.
+    async fn sign(&self, hashes: &[Vec<u8>], key: &SigningKeyContext) -> Result<Vec<Signature>>;
+}
+
+/// Choose the signing backend for a given party key.
+///
+/// The choice is forced by how the key is held, not by preference: a
+/// KMS-backed key can only be signed by the matching KMS backend, an
+/// exportable key by [`vault_export::VaultExportSigner`]. Today only the export
+/// backend exists; a KMS-backed key still falls through to it and fails at
+/// export exactly as before — the KMS backend lands with its own change. This
+/// is the single extension point for new backends.
+///
+/// Async because building a backend may need an admin-API channel (which
+/// applies the configured TLS settings); a future KMS backend would build its
+/// own KMS client here instead.
+pub async fn select_signer(
+    config: &NodeConfig,
+    _key: &SigningKeyContext,
+) -> Result<Box<dyn TransactionSigner>> {
+    // TODO(#264 Phase 2): when `_key.kms_key_id.is_some()`, return the KMS
+    // backend (AWS KMS / MPCH) instead of the export backend.
+    Ok(Box::new(vault_export::VaultExportSigner::new(
+        config.admin_channel().await?,
+    )))
+}

--- a/crates/decman/src/signing/signer.rs
+++ b/crates/decman/src/signing/signer.rs
@@ -1,0 +1,88 @@
+use async_trait::async_trait;
+use canton_proto_rs::com::digitalasset::canton::crypto::v30::{Signature, SigningPublicKey};
+use tonic::transport::Channel;
+
+use crate::{
+    error::Result,
+    signing::{SigningError, vault_export::VaultExportSigner},
+};
+
+/// An interactive-submission prepared-transaction hash, as returned by the
+/// Ledger API `PrepareSubmission` call.
+///
+/// The bytes stay length-unchecked on purpose. The proto defines the field as
+/// free-form `bytes` with no length promise, and Canton signature schemes
+/// treat the value as the *message* to sign (the scheme hashes it again
+/// internally), so no fixed size can be assumed here.
+#[derive(Debug)]
+pub struct PreparedTransactionHash(Vec<u8>);
+
+impl PreparedTransactionHash {
+    pub fn new(bytes: Vec<u8>) -> Self {
+        Self(bytes)
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+/// Everything a signing backend needs to sign for one party key. Resolved once
+/// by the caller from Canton's vault metadata (`VaultService.ListMyKeys`).
+pub struct SigningKeyContext {
+    /// Canton fingerprint of the key. Goes into [`Signature::signed_by`] and is
+    /// how Canton selects the verifying key from the party's topology.
+    pub fingerprint: String,
+    /// The public key (format, key spec, bytes). A backend uses this to choose
+    /// the signature algorithm/format, and the export backend uses it to verify
+    /// the recovered private key.
+    pub public_key: SigningPublicKey,
+    /// The underlying KMS key id, present when the key is KMS-backed (from
+    /// `PrivateKeyMetadata.kms_key_id`). A KMS signing backend signs with this;
+    /// the export backend ignores it.
+    ///
+    /// `None` is not a failure state: it is the normal value for a non-KMS
+    /// key. A failure to *read* the metadata is a hard error at the
+    /// `ListMyKeys` call site and never reaches this field.
+    pub kms_key_id: Option<String>,
+}
+
+/// Signs a decentralized party's interactive-submission prepared hashes.
+///
+/// Implement this trait to add a new signing backend (e.g. AWS KMS, MPCH), then
+/// wire it into [`select_signer`].
+#[async_trait]
+pub trait TransactionSigner: Send + Sync {
+    /// Sign each prepared-transaction hash with the party key described by
+    /// `key`, returning one Canton [`Signature`] per hash, in order.
+    async fn sign(
+        &self,
+        hashes: &[PreparedTransactionHash],
+        key: &SigningKeyContext,
+    ) -> Result<Vec<Signature>, SigningError>;
+}
+
+/// Choose the signing backend for a given party key.
+///
+/// The choice is forced by how the key is held, not by preference: a
+/// KMS-backed key can only be signed by the matching KMS backend, an
+/// exportable key by [`VaultExportSigner`]. Today only the export backend
+/// exists; a KMS-backed key still falls through to it and fails at export
+/// exactly as before — the KMS backend lands with its own change. This is the
+/// single extension point for new backends.
+///
+/// Returns a boxed trait object because the backend is picked at *runtime*
+/// from the key's custody, so the concrete type differs per call; the one
+/// dynamic dispatch is noise next to the signing RPCs themselves.
+///
+/// Takes the caller's already-open admin-API `channel` so the export backend
+/// reuses one connection instead of opening a second. Async so a future KMS
+/// backend can build its own KMS client here.
+pub async fn select_signer(
+    _key: &SigningKeyContext,
+    channel: Channel,
+) -> Result<Box<dyn TransactionSigner>> {
+    // TODO(#264): when `_key.kms_key_id.is_some()`, return the KMS backend
+    // (AWS KMS / MPCH) instead of the export backend.
+    Ok(Box::new(VaultExportSigner::new(channel)))
+}

--- a/crates/decman/src/signing/vault_export.rs
+++ b/crates/decman/src/signing/vault_export.rs
@@ -18,7 +18,7 @@ use zeroize::Zeroizing;
 use crate::{
     consts::CANTON_PROTOCOL_VERSION,
     error::Result,
-    signing::{SigningKeyContext, TransactionSigner},
+    signing::{PreparedTransactionHash, SigningError, SigningKeyContext, TransactionSigner},
 };
 
 /// DER OCTET STRING tag
@@ -42,7 +42,11 @@ impl VaultExportSigner {
 
 #[async_trait]
 impl TransactionSigner for VaultExportSigner {
-    async fn sign(&self, hashes: &[Vec<u8>], key: &SigningKeyContext) -> Result<Vec<Signature>> {
+    async fn sign(
+        &self,
+        hashes: &[PreparedTransactionHash],
+        key: &SigningKeyContext,
+    ) -> Result<Vec<Signature>, SigningError> {
         let key_fingerprint = &key.fingerprint;
 
         let mut vault_client = VaultServiceClient::new(self.admin_channel.clone());
@@ -124,7 +128,10 @@ impl TransactionSigner for VaultExportSigner {
         }
 
         if candidate_keys.is_empty() {
-            anyhow::bail!("Could not find any Ed25519 key candidates in exported data");
+            return Err(anyhow::anyhow!(
+                "Could not find any Ed25519 key candidates in exported data"
+            )
+            .into());
         }
 
         tracing::info!(
@@ -146,11 +153,12 @@ impl TransactionSigner for VaultExportSigner {
         const ED25519_PUBLIC_KEY_LENGTH: usize = 32;
 
         if expected_public_key_der.len() < DER_HEADER_LENGTH + ED25519_PUBLIC_KEY_LENGTH {
-            anyhow::bail!(
+            return Err(anyhow::anyhow!(
                 "Expected public key is too short: {result_count} bytes (need at least {expected_count})",
                 result_count = expected_public_key_der.len(),
                 expected_count = DER_HEADER_LENGTH + ED25519_PUBLIC_KEY_LENGTH
-            );
+            )
+            .into());
         }
 
         let expected_raw_public_key = &expected_public_key_der[DER_HEADER_LENGTH..];
@@ -197,11 +205,11 @@ impl TransactionSigner for VaultExportSigner {
         let mut signatures: Vec<Signature> = Vec::with_capacity(hashes.len());
 
         for (idx, hash) in hashes.iter().enumerate() {
-            let signature_bytes = signing_key.sign(hash).to_bytes();
+            let signature_bytes = signing_key.sign(hash.as_bytes()).to_bytes();
 
             // Verify locally
             let sig = DalekSignature::from_bytes(&signature_bytes);
-            if verifying_key.verify(hash, &sig).is_ok() {
+            if verifying_key.verify(hash.as_bytes(), &sig).is_ok() {
                 tracing::info!("Signature {index} verified locally", index = idx + 1);
             } else {
                 tracing::error!(

--- a/crates/decman/src/signing/vault_export.rs
+++ b/crates/decman/src/signing/vault_export.rs
@@ -1,0 +1,227 @@
+//! Signing backend that exports the private key from the participant's vault
+//! and signs locally with Ed25519.
+//!
+//! This is the historical decman behaviour and works only for the JCE crypto
+//! provider, whose keys are exportable. It is unusable on a KMS-backed node
+//! (the private key cannot leave the KMS) — that case needs a KMS signing
+//! backend instead (see [`crate::signing`]).
+
+use async_trait::async_trait;
+use canton_proto_rs::com::digitalasset::canton::crypto::{
+    admin::v30::{ExportKeyPairRequest, vault_service_client::VaultServiceClient},
+    v30::{Signature, SignatureFormat, SigningAlgorithmSpec},
+};
+use ed25519_dalek::{Signature as DalekSignature, Signer, SigningKey, Verifier};
+use tonic::transport::Channel;
+use zeroize::Zeroizing;
+
+use crate::{
+    consts::CANTON_PROTOCOL_VERSION,
+    error::Result,
+    signing::{SigningKeyContext, TransactionSigner},
+};
+
+/// DER OCTET STRING tag
+const DER_OCTET_STRING_TAG: u8 = 0x04;
+
+/// Expected length of Ed25519 private key in bytes (32 bytes)
+const ED25519_PRIVATE_KEY_LENGTH: u8 = 0x20;
+
+/// Signs by exporting the private key from Canton's vault and signing locally.
+pub struct VaultExportSigner {
+    /// Admin-API channel (carries the configured TLS settings), built by
+    /// `select_signer` from `NodeConfig::admin_channel`.
+    admin_channel: Channel,
+}
+
+impl VaultExportSigner {
+    pub fn new(admin_channel: Channel) -> Self {
+        Self { admin_channel }
+    }
+}
+
+#[async_trait]
+impl TransactionSigner for VaultExportSigner {
+    async fn sign(&self, hashes: &[Vec<u8>], key: &SigningKeyContext) -> Result<Vec<Signature>> {
+        let key_fingerprint = &key.fingerprint;
+
+        let mut vault_client = VaultServiceClient::new(self.admin_channel.clone());
+
+        // Export the private key.
+        tracing::info!("Exporting private key from Canton...");
+        tracing::debug!("Key fingerprint: {key_fingerprint}");
+
+        let mut export_response = vault_client
+            .export_key_pair(tonic::Request::new(ExportKeyPairRequest {
+                fingerprint: key_fingerprint.clone(),
+                protocol_version: CANTON_PROTOCOL_VERSION,
+                password: String::new(), // Empty: the exported key pair is not passphrase-protected.
+            }))
+            .await
+            .map_err(|e| {
+                tracing::error!("ExportKeyPair RPC failed with error: {e:?}");
+                tracing::error!("Attempted fingerprint: {key_fingerprint}");
+                e
+            })?
+            .into_inner();
+
+        // Extract Ed25519 private key from Canton's export response.
+        // Canton returns the key in a custom format with embedded metadata.
+        //
+        // Move the bytes directly out of the proto struct with `std::mem::take`
+        // into a zeroizing buffer — avoids a second heap copy of the secret that
+        // `.clone()` would create. The proto's `key_pair` is left as an empty
+        // `Vec` and dropped along with `export_response` shortly after. All
+        // 32-byte candidates derived below are also held in `Zeroizing<[u8; 32]>`
+        // so they self-wipe on drop.
+        let exported_key_data: Zeroizing<Vec<u8>> =
+            Zeroizing::new(std::mem::take(&mut export_response.key_pair));
+        tracing::debug!(
+            "Parsing exported key pair ({len} bytes)",
+            len = exported_key_data.len()
+        );
+
+        // Strategy: Try ALL possible 32-byte sequences and test each one.
+        // The correct private key should verify against the public key.
+        let key_size = ED25519_PRIVATE_KEY_LENGTH as usize;
+        let max_offset = exported_key_data.len().saturating_sub(key_size);
+
+        tracing::info!(
+            "Searching for valid Ed25519 private key among {max_offset} possible positions"
+        );
+
+        let mut candidate_keys: Vec<(usize, Zeroizing<[u8; 32]>, &str)> = Vec::new();
+
+        // First, try DER-tagged sequences (0x04 0x20 pattern)
+        for offset in 0..max_offset.saturating_sub(2) {
+            if exported_key_data[offset] == DER_OCTET_STRING_TAG
+                && exported_key_data[offset + 1] == ED25519_PRIVATE_KEY_LENGTH
+            {
+                let mut key_bytes = [0u8; 32];
+                key_bytes.copy_from_slice(&exported_key_data[offset + 2..offset + 2 + key_size]);
+                candidate_keys.push((offset + 2, Zeroizing::new(key_bytes), "DER-tagged"));
+            }
+        }
+        tracing::debug!(
+            "Found {count} DER-tagged candidates",
+            count = candidate_keys.len()
+        );
+
+        if candidate_keys.is_empty() {
+            tracing::warn!("No DER-tagged sequences found, trying all possible 32-byte sequences");
+
+            // Try every possible 32-byte sequence in the exported data
+            for offset in (0..max_offset).step_by(4) {
+                let mut key_bytes = [0u8; 32];
+                key_bytes.copy_from_slice(&exported_key_data[offset..offset + key_size]);
+                candidate_keys.push((offset, Zeroizing::new(key_bytes), "raw"));
+            }
+
+            tracing::debug!(
+                "Found {count} raw 32-byte candidates",
+                count = candidate_keys.len()
+            );
+        }
+
+        if candidate_keys.is_empty() {
+            anyhow::bail!("Could not find any Ed25519 key candidates in exported data");
+        }
+
+        tracing::info!(
+            "Found {count} candidate Ed25519 key positions to try",
+            count = candidate_keys.len()
+        );
+
+        // Verify each candidate key produces the correct public key.
+        tracing::info!("Verifying candidates against expected public key...");
+
+        // Get the public key bytes from Canton's metadata for verification.
+        // Canton stores Ed25519 public keys in DER format with this structure:
+        // - Bytes 0-11: DER wrapper (SEQUENCE + algorithm OID + BIT STRING header)
+        // - Bytes 12-43: Raw 32-byte Ed25519 public key
+        let expected_public_key_der = &key.public_key.public_key;
+
+        // Extract raw Ed25519 public key from DER format
+        const DER_HEADER_LENGTH: usize = 12;
+        const ED25519_PUBLIC_KEY_LENGTH: usize = 32;
+
+        if expected_public_key_der.len() < DER_HEADER_LENGTH + ED25519_PUBLIC_KEY_LENGTH {
+            anyhow::bail!(
+                "Expected public key is too short: {result_count} bytes (need at least {expected_count})",
+                result_count = expected_public_key_der.len(),
+                expected_count = DER_HEADER_LENGTH + ED25519_PUBLIC_KEY_LENGTH
+            );
+        }
+
+        let expected_raw_public_key = &expected_public_key_der[DER_HEADER_LENGTH..];
+
+        let mut verified_key_bytes: Option<Zeroizing<[u8; 32]>> = None;
+
+        for (offset, key_bytes, source) in &candidate_keys {
+            let signing_key = SigningKey::from_bytes(key_bytes);
+            let derived_public_bytes = signing_key.verifying_key().to_bytes();
+
+            // Compare raw Ed25519 public keys (32 bytes)
+            if derived_public_bytes.as_slice() == expected_raw_public_key {
+                tracing::info!("Found matching private key at offset {offset} ({source})");
+                verified_key_bytes = Some(Zeroizing::new(**key_bytes));
+                break;
+            }
+        }
+
+        let key_bytes = verified_key_bytes.ok_or_else(|| {
+            anyhow::anyhow!(
+                "None of the {count} candidate keys produced the expected public key. \
+                This indicates the private key is not in the expected format in the exported data.",
+                count = candidate_keys.len()
+            )
+        })?;
+        // Drop the remaining candidates; each Zeroizing<[u8; 32]> wipes on drop.
+        drop(candidate_keys);
+
+        tracing::info!("Successfully verified Ed25519 private key");
+
+        // Sign transaction hashes with verified key.
+        // `SigningKey` impls `Zeroize` (via the `zeroize` feature on
+        // `ed25519-dalek`) and zeros its inner secret on drop.
+        tracing::info!(
+            "Signing {count} transaction hashes...",
+            count = hashes.len()
+        );
+
+        let signing_key = SigningKey::from_bytes(&key_bytes);
+        let verifying_key = signing_key.verifying_key();
+        tracing::debug!("Key fingerprint used in signatures: {key_fingerprint}");
+
+        // Sign each prepared transaction hash and create Signature protobuf messages
+        let mut signatures: Vec<Signature> = Vec::with_capacity(hashes.len());
+
+        for (idx, hash) in hashes.iter().enumerate() {
+            let signature_bytes = signing_key.sign(hash).to_bytes();
+
+            // Verify locally
+            let sig = DalekSignature::from_bytes(&signature_bytes);
+            if verifying_key.verify(hash, &sig).is_ok() {
+                tracing::info!("Signature {index} verified locally", index = idx + 1);
+            } else {
+                tracing::error!(
+                    "Signature {index} failed local verification!",
+                    index = idx + 1
+                );
+            }
+
+            // Create Signature protobuf message
+            // Ed25519 signatures use CONCAT format (r || s in little-endian)
+            signatures.push(Signature {
+                format: SignatureFormat::Concat as i32,
+                signature: signature_bytes.to_vec(),
+                signed_by: key_fingerprint.clone(),
+                signing_algorithm_spec: SigningAlgorithmSpec::Ed25519 as i32,
+                signature_delegation: None,
+            });
+        }
+
+        tracing::debug!("Generated {count} signatures", count = signatures.len());
+        Ok(signatures)
+    }
+}

--- a/crates/decman/src/workflow/contracts/steps/sign.rs
+++ b/crates/decman/src/workflow/contracts/steps/sign.rs
@@ -21,7 +21,7 @@ use crate::{
     canton_id::CantonId,
     config::NodeConfig,
     error::Result,
-    signing::{SigningKeyContext, select_signer},
+    signing::{PreparedTransactionHash, SigningKeyContext, select_signer},
     utils,
     workflow::storage::{WorkflowStorage, artifact_kinds, identity_kinds},
 };
@@ -208,9 +208,9 @@ pub async fn sign_submissions(
     // exporting it and signing locally with Ed25519 today (JCE keys), or asking
     // a KMS to sign a non-exportable key (follow-up). Everything else in this
     // step is provider-independent.
-    let hashes: Vec<Vec<u8>> = prepared_submissions
+    let hashes: Vec<PreparedTransactionHash> = prepared_submissions
         .into_iter()
-        .map(|s| s.prepared_transaction_hash)
+        .map(|s| PreparedTransactionHash::new(s.prepared_transaction_hash))
         .collect();
 
     let key_context = SigningKeyContext {

--- a/crates/decman/src/workflow/contracts/steps/sign.rs
+++ b/crates/decman/src/workflow/contracts/steps/sign.rs
@@ -4,10 +4,9 @@ use canton_proto_rs::com::{
     digitalasset::canton::{
         crypto::{
             admin::v30::{
-                ExportKeyPairRequest, ListKeysFilters, ListMyKeysRequest,
-                vault_service_client::VaultServiceClient,
+                ListKeysFilters, ListMyKeysRequest, vault_service_client::VaultServiceClient,
             },
-            v30::{Signature, SignatureFormat, SigningAlgorithmSpec, SigningPublicKey},
+            v30::SigningPublicKey,
         },
         topology::admin::v30::{
             BaseQuery, ListPartyToKeyMappingRequest, ListPartyToParticipantRequest, StoreId,
@@ -16,24 +15,16 @@ use canton_proto_rs::com::{
         },
     },
 };
-use ed25519_dalek::{Signature as DalekSignature, Signer, SigningKey, Verifier};
 use sqlx::SqlitePool;
-use zeroize::Zeroizing;
 
 use crate::{
     canton_id::CantonId,
     config::NodeConfig,
-    consts::CANTON_PROTOCOL_VERSION,
     error::Result,
+    signing::{SigningKeyContext, select_signer},
     utils,
     workflow::storage::{WorkflowStorage, artifact_kinds, identity_kinds},
 };
-
-/// DER OCTET STRING tag
-const DER_OCTET_STRING_TAG: u8 = 0x04;
-
-/// Expected length of Ed25519 private key in bytes (32 bytes)
-const ED25519_PRIVATE_KEY_LENGTH: u8 = 0x20;
 
 /// Sign prepared ledger submissions with Daml key
 ///
@@ -173,6 +164,13 @@ pub async fn sign_submissions(
         count = keys_response.private_keys_metadata.len()
     );
 
+    // Capture the underlying KMS key id, present only for KMS-backed keys. The
+    // signer selection uses it to route a non-exportable key to a KMS backend.
+    let kms_key_id = keys_response
+        .private_keys_metadata
+        .first()
+        .and_then(|m| m.kms_key_id.clone());
+
     // Step 3: Dynamically load all prepared submissions from storage. They were
     // written by `prepare_submissions` keyed by zero-padded ordinal so
     // `list_artifacts` returns them sorted by their original creation order.
@@ -203,186 +201,26 @@ pub async fn sign_submissions(
         count = prepared_submissions.len()
     );
 
-    // Step 4: Export the private key
-    tracing::info!("Exporting private key from Canton...");
-    tracing::debug!("Key fingerprint: {key_fingerprint}");
+    // Step 4: Sign each prepared-transaction hash with the party's Daml key via
+    // the selected signing backend. The backend abstracts *how* the key signs —
+    // exporting it and signing locally with Ed25519 today (JCE keys), or asking
+    // a KMS to sign a non-exportable key (follow-up). Everything else in this
+    // step is provider-independent.
+    let hashes: Vec<Vec<u8>> = prepared_submissions
+        .iter()
+        .map(|s| s.prepared_transaction_hash.clone())
+        .collect();
 
-    let mut export_response = vault_client
-        .export_key_pair(tonic::Request::new(ExportKeyPairRequest {
-            fingerprint: key_fingerprint.clone(),
-            protocol_version: CANTON_PROTOCOL_VERSION,
-            password: String::new(), // Empty: the exported key pair is not passphrase-protected.
-        }))
-        .await
-        .map_err(|e| {
-            tracing::error!("ExportKeyPair RPC failed with error: {e:?}");
-            tracing::error!("Attempted fingerprint: {key_fingerprint}");
-            e
-        })?
-        .into_inner();
+    let key_context = SigningKeyContext {
+        fingerprint: key_fingerprint.clone(),
+        public_key: signing_public_key.clone(),
+        kms_key_id,
+    };
 
-    // Step 5: Extract Ed25519 private key from Canton's export response.
-    // Canton returns the key in a custom format with embedded metadata.
-    //
-    // Move the bytes directly out of the proto struct with `std::mem::take`
-    // into a zeroizing buffer — avoids a second heap copy of the secret that
-    // `.clone()` would create. The proto's `key_pair` is left as an empty
-    // `Vec` and dropped along with `export_response` shortly after. All
-    // 32-byte candidates derived below are also held in `Zeroizing<[u8; 32]>`
-    // so they self-wipe on drop.
-    let exported_key_data: Zeroizing<Vec<u8>> =
-        Zeroizing::new(std::mem::take(&mut export_response.key_pair));
-    tracing::debug!(
-        "Parsing exported key pair ({len} bytes)",
-        len = exported_key_data.len()
-    );
+    let signer = select_signer(config, &key_context).await?;
+    let signatures = signer.sign(&hashes, &key_context).await?;
 
-    // Strategy: Try ALL possible 32-byte sequences and test each one.
-    // The correct private key should verify against the public key.
-    let key_size = ED25519_PRIVATE_KEY_LENGTH as usize;
-    let max_offset = exported_key_data.len().saturating_sub(key_size);
-
-    tracing::info!("Searching for valid Ed25519 private key among {max_offset} possible positions");
-
-    let mut candidate_keys: Vec<(usize, Zeroizing<[u8; 32]>, &str)> = Vec::new();
-
-    // First, try DER-tagged sequences (0x04 0x20 pattern)
-    for offset in 0..max_offset.saturating_sub(2) {
-        if exported_key_data[offset] == DER_OCTET_STRING_TAG
-            && exported_key_data[offset + 1] == ED25519_PRIVATE_KEY_LENGTH
-        {
-            let mut key_bytes = [0u8; 32];
-            key_bytes.copy_from_slice(&exported_key_data[offset + 2..offset + 2 + key_size]);
-            candidate_keys.push((offset + 2, Zeroizing::new(key_bytes), "DER-tagged"));
-        }
-    }
-    tracing::debug!(
-        "Found {count} DER-tagged candidates",
-        count = candidate_keys.len()
-    );
-
-    if candidate_keys.is_empty() {
-        tracing::warn!("No DER-tagged sequences found, trying all possible 32-byte sequences");
-
-        // Try every possible 32-byte sequence in the exported data
-        for offset in (0..max_offset).step_by(4) {
-            let mut key_bytes = [0u8; 32];
-            key_bytes.copy_from_slice(&exported_key_data[offset..offset + key_size]);
-            candidate_keys.push((offset, Zeroizing::new(key_bytes), "raw"));
-        }
-
-        tracing::debug!(
-            "Found {count} raw 32-byte candidates",
-            count = candidate_keys.len()
-        );
-    }
-
-    if candidate_keys.is_empty() {
-        anyhow::bail!("Could not find any Ed25519 key candidates in exported data");
-    }
-
-    tracing::info!(
-        "Found {count} candidate Ed25519 key positions to try",
-        count = candidate_keys.len()
-    );
-
-    // Step 6: Try each candidate key and verify it produces the correct public key
-    tracing::info!("Verifying candidates against expected public key...");
-
-    // Get the public key bytes from Canton's metadata for verification
-    // Canton stores Ed25519 public keys in DER format with this structure:
-    // - Bytes 0-11: DER wrapper (SEQUENCE + algorithm OID + BIT STRING header)
-    // - Bytes 12-43: Raw 32-byte Ed25519 public key
-    let expected_public_key_der = &signing_public_key.public_key;
-
-    // Extract raw Ed25519 public key from DER format
-    const DER_HEADER_LENGTH: usize = 12;
-    const ED25519_PUBLIC_KEY_LENGTH: usize = 32;
-
-    if expected_public_key_der.len() < DER_HEADER_LENGTH + ED25519_PUBLIC_KEY_LENGTH {
-        anyhow::bail!(
-            "Expected public key is too short: {result_count} bytes (need at least {expected_count})",
-            result_count = expected_public_key_der.len(),
-            expected_count = DER_HEADER_LENGTH + ED25519_PUBLIC_KEY_LENGTH
-        );
-    }
-
-    let expected_raw_public_key = &expected_public_key_der[DER_HEADER_LENGTH..];
-
-    let mut verified_key_bytes: Option<Zeroizing<[u8; 32]>> = None;
-
-    for (offset, key_bytes, source) in &candidate_keys {
-        let signing_key = SigningKey::from_bytes(key_bytes);
-        let derived_public_bytes = signing_key.verifying_key().to_bytes();
-
-        // Compare raw Ed25519 public keys (32 bytes)
-        if derived_public_bytes.as_slice() == expected_raw_public_key {
-            tracing::info!("Found matching private key at offset {offset} ({source})");
-            verified_key_bytes = Some(Zeroizing::new(**key_bytes));
-            break;
-        }
-    }
-
-    let key_bytes = verified_key_bytes.ok_or_else(|| {
-        anyhow::anyhow!(
-            "None of the {count} candidate keys produced the expected public key. \
-            This indicates the private key is not in the expected format in the exported data.",
-            count = candidate_keys.len()
-        )
-    })?;
-    // Drop the remaining candidates; each Zeroizing<[u8; 32]> wipes on drop.
-    drop(candidate_keys);
-
-    tracing::info!("Successfully verified Ed25519 private key");
-
-    // Step 7: Sign transaction hashes with verified key.
-    // `SigningKey` impls `Zeroize` (via the `zeroize` feature on
-    // `ed25519-dalek`) and zeros its inner secret on drop.
-    tracing::info!(
-        "Signing {count} transaction hashes...",
-        count = prepared_submissions.len()
-    );
-
-    let signing_key = SigningKey::from_bytes(&key_bytes);
-    let verifying_key = signing_key.verifying_key();
-    tracing::debug!("Key fingerprint used in signatures: {key_fingerprint}");
-
-    // Sign each prepared transaction hash and create Signature protobuf messages
-    let mut signatures: Vec<Signature> = Vec::new();
-
-    for (idx, prepared_sub) in prepared_submissions.iter().enumerate() {
-        let signature_bytes = signing_key
-            .sign(&prepared_sub.prepared_transaction_hash)
-            .to_bytes();
-
-        // Verify locally
-        let sig = DalekSignature::from_bytes(&signature_bytes);
-        if verifying_key
-            .verify(&prepared_sub.prepared_transaction_hash, &sig)
-            .is_ok()
-        {
-            tracing::info!("Signature {index} verified locally", index = idx + 1);
-        } else {
-            tracing::error!(
-                "Signature {index} failed local verification!",
-                index = idx + 1
-            );
-        }
-
-        // Create Signature protobuf message
-        // Ed25519 signatures use CONCAT format (r || s in little-endian)
-        signatures.push(Signature {
-            format: SignatureFormat::Concat as i32,
-            signature: signature_bytes.to_vec(),
-            signed_by: key_fingerprint.clone(),
-            signing_algorithm_spec: SigningAlgorithmSpec::Ed25519 as i32,
-            signature_delegation: None,
-        });
-    }
-
-    tracing::debug!("Generated {count} signatures", count = signatures.len());
-
-    // Step 8: Persist signatures bundle as `SUBMISSION_SIGNATURES` artefact.
+    // Step 5: Persist signatures bundle as `SUBMISSION_SIGNATURES` artefact.
     // The blob is the same multi-message `varint(len)||proto` framing the
     // previous on-disk `submission-signatures-{node_id}.bin` used; the
     // execute step will read it back via `read_all_messages_from_bytes`.

--- a/crates/decman/src/workflow/contracts/steps/sign.rs
+++ b/crates/decman/src/workflow/contracts/steps/sign.rs
@@ -137,8 +137,10 @@ pub async fn sign_submissions(
     tracing::info!("Using Daml key with fingerprint: {key_fingerprint}");
     tracing::debug!("This is the key that was generated in step 1 and added to P2P mapping");
 
-    // Verify this key exists in Canton's vault
-    let mut vault_client = VaultServiceClient::new(config.admin_channel().await?);
+    // Verify this key exists in Canton's vault. Keep the channel: the signing
+    // backend reuses it instead of opening a second connection.
+    let admin_channel = config.admin_channel().await?;
+    let mut vault_client = VaultServiceClient::new(admin_channel.clone());
 
     let keys_response = vault_client
         .list_my_keys(tonic::Request::new(ListMyKeysRequest {
@@ -207,8 +209,8 @@ pub async fn sign_submissions(
     // a KMS to sign a non-exportable key (follow-up). Everything else in this
     // step is provider-independent.
     let hashes: Vec<Vec<u8>> = prepared_submissions
-        .iter()
-        .map(|s| s.prepared_transaction_hash.clone())
+        .into_iter()
+        .map(|s| s.prepared_transaction_hash)
         .collect();
 
     let key_context = SigningKeyContext {
@@ -217,7 +219,7 @@ pub async fn sign_submissions(
         kms_key_id,
     };
 
-    let signer = select_signer(config, &key_context).await?;
+    let signer = select_signer(&key_context, admin_channel).await?;
     let signatures = signer.sign(&hashes, &key_context).await?;
 
     // Step 5: Persist signatures bundle as `SUBMISSION_SIGNATURES` artefact.


### PR DESCRIPTION
## What

Introduces a `TransactionSigner` trait and a `signing` module so the decentralized party's Daml-key signing has one clean, pluggable seam. Adding a new signing backend (AWS KMS, MPCH) becomes "implement the trait + add one branch to `select_signer`" — nothing else in the signing flow changes.

```rust
pub struct SigningKeyContext { pub fingerprint: String, pub public_key: SigningPublicKey, pub kms_key_id: Option<String> }

#[async_trait]
pub trait TransactionSigner: Send + Sync {
    async fn sign(&self, hashes: &[Vec<u8>], key: &SigningKeyContext) -> Result<Vec<Signature>>;
}
```

`signing/vault_export.rs` holds the current export-and-sign-locally backend; `signing/mod.rs` has the trait, context, and `select_signer`. `workflow/contracts/steps/sign.rs` shrinks to orchestration: resolve the key context (fingerprint, public key, and the `kms_key_id` from `ListMyKeys`), pick a signer, sign the prepared hashes, persist.

## Why

Prep for KMS support (#264). A KMS-held party key is non-exportable, so it can't use the export path — it must be signed by asking the KMS. Rather than special-casing that inside `sign.rs`, this carves the seam now, while there's still only one implementation, so the KMS backend is a self-contained follow-up. Also cleans up #241's concern by isolating the `ExportKeyPair` blob-scan in one named place.

## Behaviour-preserving

- The export/scan/verify/sign logic moves **verbatim** into `VaultExportSigner` (same `Zeroizing` handling, same DER-tag candidate scan + fallback, same local verify, same `Signature { Concat, Ed25519, signed_by }`).
- `select_signer` returns `VaultExportSigner` unconditionally today, so JCE parties sign exactly as before; a KMS-backed key still falls through and fails at export exactly as before (the KMS backend is the next PR).
- The signer is built from `NodeConfig::admin_channel` — the same TLS-applying channel the step already used — **not** a bare `connect(url)`, so connection semantics (incl. admin-API TLS) are unchanged.
- `public` API `sign_submissions(...)` signature is unchanged; no callers touched.

## How tested

- `cargo test -p decman --lib` — 298 tests pass.
- `cargo clippy -p decman` and `cargo fmt --check` clean (frontend build skipped via `DECMAN_SKIP_FRONTEND=1`; changes are Rust-only).
- No functional change to verify at runtime — this is a refactor; the KMS behaviour it enables is validated in the follow-up.

## New dependency

`async-trait` (0.1) — standard, ubiquitous, needed for `Box<dyn TransactionSigner>` async dispatch (the mechanism that makes runtime backend selection work). Added to workspace + decman deps; `Cargo.lock` committed.

## Follow-up (not in this PR)

`AwsKmsSigner` — sign the prepared hash via `aws-sdk-kms` (`ECDSA_SHA_256`, `MessageType=RAW`) → `Signature { Der, EcDsaSha256, signed_by }` — and a `select_signer` branch on `kms_key_id.is_some()`. Depends on the fingerprint fix in #268 for the P-256 `signed_by`.

Refs #264, #241