### PR TITLE
feat(signing): sign with AWS KMS-held party keys

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -15,4 +15,10 @@ ignore = [
   # by ratatui (the decman-cli TUI). Trivial compile-time proc-macro, no
   # runtime/security surface. Mirrors the ignore in deny.toml.
   "RUSTSEC-2024-0436",
+  # rkyv 0.7 appears in the lockfile only through rust_decimal's disabled
+  # optional "rkyv" feature. It is never compiled into any artifact
+  # (`cargo tree -i rkyv` resolves to nothing), so the archive-validation
+  # out-of-bounds read is unreachable. cargo-deny agrees (graph-based, does
+  # not flag it).
+  "RUSTSEC-2026-0235",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,6 +401,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,6 +506,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-config"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b180a3c8b55960db3426d8964b8745e652466a1a49fe1a2eda828046d30b5e4"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 1.4.0",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e93964ffdaf57857f544be3666a5f57570bb699e934700f11b49708f61bb556e"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
 name = "aws-lc-rs"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -517,6 +564,320 @@ dependencies = [
  "cmake",
  "dunce",
  "fs_extra",
+]
+
+[[package]]
+name = "aws-runtime"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9007227e10b5fed2f3e0a2beff489211e2b5604c400b7a9d5d81ca9d64c24bb"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "bytes-utils",
+ "fastrand",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-kms"
+version = "1.114.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b7d906608ee41e7ddea9983577ba82200435644d567d63dc34e822e088b453"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.110.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd8b14781dfbff48984017d57167b6ea0b6471c6920ec52b44a2677c7feb3c13"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "723c2234ad7511ceef63eab016b7ba6ff7c55590fefb96fa8467af014a07309f"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac 0.13.0",
+ "http 0.2.12",
+ "http 1.4.0",
+ "percent-encoding",
+ "sha2 0.11.0",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02e407fb3b54891734224b9ffac8a71fdd35f542500fa1af95754a6b2beb316"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.64.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37843d9add67c3aff5856f409c6dc315d3cdff60f9c0cb5b670dab1e9920306d"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "635d23afda0a6ab48d666c4d447c4873e8d1e83518a2be2093122397e50b838e"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2 0.3.27",
+ "h2 0.4.14",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper 1.9.0",
+ "hyper-rustls 0.24.2",
+ "hyper-rustls 0.27.9",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls 0.23.40",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.63.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dc65a121adb4b33729919fcfa14fa36fb33c1555a8f06bb0e2188dbfdc1d9ef"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e86338c869539a581bf161247762a6e87f92c5c075060057b5ed6d06632ed0c"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512346c7212ab7436df2d77a16d976a468ae44a418835511d2a69269810aaf62"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07505b34e8f4b3591a4fa69e9792b52289b95488dbbc68c3c0075b7bedb245e1"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-http-client",
+ "aws-smithy-observability",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b98f2e1fd67ec06618f9c291e5e495a468e60519e44c9c1979cd0521f3affdb"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.4.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "221eaa237ddf1ca79b60d1372aad77e47f9c0ea5b3ce5099da8c61d027dc77b3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "aws-smithy-schema"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56e0a4e53127a632224e43633b0fe045fa9e1e3cfc68b9830f1115e103f910"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 1.4.0",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6dc683efb34b9e755675b37fedbe0103141e5b6df7bdc9eb6967756a8c167d8"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce84f71c72fee2cbbadde6e7d082f5fb466e3a84733855295fa7aafd1b31b7d8"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eec1cd5469f328c782dc3e33d4153cf118a54e33cbb3356d60d16f89883e1f94"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
 ]
 
 [[package]]
@@ -563,6 +924,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -573,6 +940,16 @@ name = "base64"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "base64ct"
@@ -772,6 +1149,16 @@ name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
 
 [[package]]
 name = "bytestring"
@@ -1189,6 +1576,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1356,6 +1755,8 @@ dependencies = [
  "aes-gcm 0.11.0",
  "anyhow",
  "async-trait",
+ "aws-config",
+ "aws-sdk-kms",
  "base64 0.23.0",
  "bytes",
  "canton-proto-rs",
@@ -1373,6 +1774,7 @@ dependencies = [
  "jsonwebtoken",
  "keycloak",
  "mime_guess",
+ "p256",
  "prost",
  "prost-types",
  "rand 0.10.2",
@@ -1391,7 +1793,7 @@ dependencies = [
  "thiserror 2.0.19",
  "tokio",
  "tokio-noise",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tonic",
  "tracing",
  "tracing-subscriber",
@@ -1520,6 +1922,7 @@ dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -1573,6 +1976,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature 2.2.0",
+ "spki",
+]
+
+[[package]]
 name = "ed25519"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1604,6 +2021,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1625,7 +2061,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1680,6 +2116,16 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
 
 [[package]]
 name = "fiat-crypto"
@@ -1911,6 +2357,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1971,6 +2418,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
 dependencies = [
  "polyval 0.7.1",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -2086,7 +2544,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -2096,6 +2554,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2243,6 +2710,21 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "log",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
@@ -2250,9 +2732,10 @@ dependencies = [
  "http 1.4.0",
  "hyper 1.9.0",
  "hyper-util",
- "rustls",
+ "rustls 0.23.40",
+ "rustls-native-certs",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower-service",
 ]
 
@@ -2302,7 +2785,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3168,6 +3651,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "palette"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3378,6 +3879,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3488,6 +3995,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -3613,8 +4129,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls",
- "socket2 0.5.10",
+ "rustls 0.23.40",
+ "socket2 0.6.3",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -3634,7 +4150,7 @@ dependencies = [
  "rand 0.9.4",
  "ring",
  "rustc-hash",
- "rustls",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.19",
@@ -3652,7 +4168,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -3991,7 +4507,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.9.0",
- "hyper-rustls",
+ "hyper-rustls 0.27.9",
  "hyper-tls",
  "hyper-util",
  "js-sys",
@@ -4032,7 +4548,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.9.0",
- "hyper-rustls",
+ "hyper-rustls 0.27.9",
  "hyper-tls",
  "hyper-util",
  "js-sys",
@@ -4043,7 +4559,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
@@ -4052,7 +4568,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "tower",
  "tower-http",
@@ -4062,6 +4578,16 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac 0.12.1",
+ "subtle",
 ]
 
 [[package]]
@@ -4237,7 +4763,19 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
 ]
 
 [[package]]
@@ -4251,7 +4789,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -4289,14 +4827,14 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls",
+ "rustls 0.23.40",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4304,6 +4842,16 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted 0.9.0",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -4378,10 +4926,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted 0.9.0",
+]
+
+[[package]]
 name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "secp256k1"
@@ -4800,7 +5372,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rustls",
+ "rustls 0.23.40",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -4871,7 +5443,7 @@ dependencies = [
  "generic-array",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "itoa",
  "log",
  "md-5",
@@ -4908,7 +5480,7 @@ dependencies = [
  "futures-util",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "home",
  "itoa",
  "log",
@@ -5094,10 +5666,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5343,11 +5915,21 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls",
+ "rustls 0.23.40",
  "tokio",
 ]
 
@@ -5449,7 +6031,7 @@ dependencies = [
  "socket2 0.6.3",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-stream",
  "tower",
  "tower-layer",
@@ -5754,6 +6336,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5847,6 +6435,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vtparse"
@@ -6160,7 +6754,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6545,6 +7139,12 @@ dependencies = [
  "thiserror 2.0.19",
  "time",
 ]
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "yasna"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,23 +707,17 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "h2 0.3.27",
  "h2 0.4.14",
- "http 0.2.12",
  "http 1.4.0",
- "http-body 0.4.6",
- "hyper 0.14.32",
  "hyper 1.9.0",
- "hyper-rustls 0.24.2",
- "hyper-rustls 0.27.9",
+ "hyper-rustls",
  "hyper-util",
  "pin-project-lite",
- "rustls 0.21.12",
- "rustls 0.23.40",
+ "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower",
  "tracing",
 ]
@@ -1793,7 +1787,7 @@ dependencies = [
  "thiserror 2.0.19",
  "tokio",
  "tokio-noise",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tonic",
  "tracing",
  "tracing-subscriber",
@@ -2710,21 +2704,6 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "log",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
@@ -2732,10 +2711,10 @@ dependencies = [
  "http 1.4.0",
  "hyper 1.9.0",
  "hyper-util",
- "rustls 0.23.40",
+ "rustls",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
 ]
 
@@ -4129,7 +4108,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.40",
+ "rustls",
  "socket2 0.6.3",
  "thiserror 2.0.19",
  "tokio",
@@ -4150,7 +4129,7 @@ dependencies = [
  "rand 0.9.4",
  "ring",
  "rustc-hash",
- "rustls 0.23.40",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.19",
@@ -4507,7 +4486,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.9.0",
- "hyper-rustls 0.27.9",
+ "hyper-rustls",
  "hyper-tls",
  "hyper-util",
  "js-sys",
@@ -4548,7 +4527,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.9.0",
- "hyper-rustls 0.27.9",
+ "hyper-rustls",
  "hyper-tls",
  "hyper-util",
  "js-sys",
@@ -4559,7 +4538,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.40",
+ "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
@@ -4568,7 +4547,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -4768,18 +4747,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
@@ -4789,7 +4756,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -4827,10 +4794,10 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.40",
+ "rustls",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -4842,16 +4809,6 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted 0.9.0",
-]
 
 [[package]]
 name = "rustls-webpki"
@@ -4924,16 +4881,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted 0.9.0",
-]
 
 [[package]]
 name = "seahash"
@@ -5372,7 +5319,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rustls 0.23.40",
+ "rustls",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -5915,21 +5862,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.40",
+ "rustls",
  "tokio",
 ]
 
@@ -6031,7 +5968,7 @@ dependencies = [
  "socket2 0.6.3",
  "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-stream",
  "tower",
  "tower-layer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,9 @@ actix-cors = { version = "0.7" }
 actix-web = { version = "4" }
 aes-gcm = { version = "0.11" }
 anyhow = { version = "1.0.98" }
+async-trait = { version = "0.1" }
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio", "default-https-client"] }
 aws-sdk-kms = { version = "1", default-features = false, features = ["rt-tokio", "default-https-client"] }
-async-trait = { version = "0.1" }
 base64 = { version = "0.23" }
 bytes = { version = "1.11.1" }
 chrono = { version = "0.4", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ actix-cors = { version = "0.7" }
 actix-web = { version = "4" }
 aes-gcm = { version = "0.11" }
 anyhow = { version = "1.0.98" }
-aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio", "rustls"] }
-aws-sdk-kms = { version = "1", default-features = false, features = ["rt-tokio", "rustls"] }
+aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio", "default-https-client"] }
+aws-sdk-kms = { version = "1", default-features = false, features = ["rt-tokio", "default-https-client"] }
 async-trait = { version = "0.1" }
 base64 = { version = "0.23" }
 bytes = { version = "1.11.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ actix-cors = { version = "0.7" }
 actix-web = { version = "4" }
 aes-gcm = { version = "0.11" }
 anyhow = { version = "1.0.98" }
+aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio", "rustls"] }
+aws-sdk-kms = { version = "1", default-features = false, features = ["rt-tokio", "rustls"] }
 async-trait = { version = "0.1" }
 base64 = { version = "0.23" }
 bytes = { version = "1.11.1" }
@@ -29,6 +31,7 @@ hyper = { version = "0.14", features = ["full"] }
 hyper-noise = { version = "0.0.3" }
 jsonwebtoken = { version = "11.0", features = ["aws_lc_rs"] }
 mime_guess = { version = "2.0" }
+p256 = { version = "0.13", default-features = false, features = ["ecdsa", "pkcs8", "std"] }
 prost = { version = "0.14.1" }
 prost-types = { version = "0.14.1" }
 rand = { version = "0.10" }

--- a/crates/decman/Cargo.toml
+++ b/crates/decman/Cargo.toml
@@ -43,6 +43,8 @@ actix-web = { workspace = true }
 aes-gcm = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
+aws-config = { workspace = true }
+aws-sdk-kms = { workspace = true }
 base64 = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }
@@ -56,6 +58,7 @@ hyper = { workspace = true }
 hyper-noise = { workspace = true }
 jsonwebtoken = { workspace = true }
 mime_guess = { workspace = true }
+p256 = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
 reqwest = { version = "0.13", features = ["form", "json"] }

--- a/crates/decman/src/signing/aws_kms.rs
+++ b/crates/decman/src/signing/aws_kms.rs
@@ -62,38 +62,37 @@ impl TransactionSigner for AwsKmsSigner {
         key: &SigningKeyContext,
     ) -> Result<Vec<Signature>, SigningError> {
         let kms_key_id = key.kms_key_id.as_deref().ok_or_else(|| {
-            SigningError::Other(anyhow::anyhow!(
+            anyhow::anyhow!(
                 "AwsKmsSigner selected for key {fingerprint} but the key carries no kms_key_id",
                 fingerprint = key.fingerprint
-            ))
+            )
         })?;
 
+        // Only EC-P256 is supported: it is the spec KMS-backed nodes generate
+        // (the KMS provider default), and the only one whose Canton signature
+        // rules and local verification this backend implements. Other specs
+        // are rejected here rather than signed on unverified assumptions.
         let (kms_algorithm, canton_algorithm) = algorithms_for(key.public_key.key_spec())
             .ok_or_else(|| {
-                SigningError::Other(anyhow::anyhow!(
+                anyhow::anyhow!(
                     "AwsKmsSigner does not support key spec {spec:?} \
-                     (key {fingerprint}); AWS KMS signs EC-P256 / EC-P384 only",
+                     (key {fingerprint}); only EC-P256 is supported",
                     spec = key.public_key.key_spec(),
                     fingerprint = key.fingerprint
-                ))
+                )
             })?;
 
         // Local verification key, parsed from the X.509 SPKI public key Canton
         // returned at generation time. Verifying each signature locally before
         // submission catches a wrong key or wrong signing semantics here,
         // instead of as an opaque rejection at ExecuteSubmission.
-        // P-384 keys skip the local check (`p256` covers only P-256).
-        let verifying_key = match key.public_key.key_spec() {
-            SigningKeySpec::EcP256 => Some(
-                VerifyingKey::from_public_key_der(&key.public_key.public_key).map_err(|e| {
-                    SigningError::Other(anyhow::anyhow!(
-                        "Failed to parse P-256 public key for {fingerprint}: {e}",
-                        fingerprint = key.fingerprint
-                    ))
-                })?,
-            ),
-            _ => None,
-        };
+        let verifying_key =
+            VerifyingKey::from_public_key_der(&key.public_key.public_key).map_err(|e| {
+                anyhow::anyhow!(
+                    "Failed to parse P-256 public key for {fingerprint}: {e}",
+                    fingerprint = key.fingerprint
+                )
+            })?;
 
         tracing::info!(
             "Signing {count} transaction hashes via AWS KMS key {kms_key_id}...",
@@ -119,9 +118,7 @@ impl TransactionSigner for AwsKmsSigner {
             let signature_der = output
                 .signature()
                 .ok_or_else(|| {
-                    SigningError::Other(anyhow::anyhow!(
-                        "AWS KMS Sign returned no signature for key {kms_key_id}"
-                    ))
+                    anyhow::anyhow!("AWS KMS Sign returned no signature for key {kms_key_id}")
                 })?
                 .as_ref()
                 .to_vec();
@@ -129,23 +126,21 @@ impl TransactionSigner for AwsKmsSigner {
             // Verify locally before submission. A signature that fails here is
             // guaranteed to be rejected at ExecuteSubmission, so fail loudly
             // with context instead of producing an opaque ledger error.
-            if let Some(vk) = &verifying_key {
-                let der_sig = DerSignature::from_bytes(&signature_der).map_err(|e| {
-                    SigningError::Other(anyhow::anyhow!(
-                        "AWS KMS returned a signature that is not valid DER: {e}"
-                    ))
-                })?;
-                vk.verify(hash.as_bytes(), &der_sig).map_err(|e| {
-                    SigningError::Other(anyhow::anyhow!(
+            let der_sig = DerSignature::from_bytes(&signature_der).map_err(|e| {
+                anyhow::anyhow!("AWS KMS returned a signature that is not valid DER: {e}")
+            })?;
+            verifying_key
+                .verify(hash.as_bytes(), &der_sig)
+                .map_err(|e| {
+                    anyhow::anyhow!(
                         "Signature {index} from KMS key {kms_key_id} failed local \
                          verification against the registered public key \
                          {fingerprint}: {e}",
                         index = idx + 1,
                         fingerprint = key.fingerprint
-                    ))
+                    )
                 })?;
-                tracing::info!("Signature {index} verified locally", index = idx + 1);
-            }
+            tracing::info!("Signature {index} verified locally", index = idx + 1);
 
             signatures.push(Signature {
                 format: SignatureFormat::Der as i32,
@@ -163,17 +158,13 @@ impl TransactionSigner for AwsKmsSigner {
 
 /// Map a Canton signing key spec to the AWS KMS signing algorithm and the
 /// Canton algorithm spec recorded on the produced signature. Returns `None`
-/// for specs AWS KMS cannot sign (Ed25519 is verify-only on KMS nodes;
-/// secp256k1 party keys do not occur in this deployment).
+/// for every spec except EC-P256 — the spec KMS-backed nodes generate, and the
+/// only one this backend's Canton format rules and local verification cover.
 fn algorithms_for(key_spec: SigningKeySpec) -> Option<(KmsSigningAlgorithm, SigningAlgorithmSpec)> {
     match key_spec {
         SigningKeySpec::EcP256 => Some((
             KmsSigningAlgorithm::EcdsaSha256,
             SigningAlgorithmSpec::EcDsaSha256,
-        )),
-        SigningKeySpec::EcP384 => Some((
-            KmsSigningAlgorithm::EcdsaSha384,
-            SigningAlgorithmSpec::EcDsaSha384,
         )),
         _ => None,
     }
@@ -184,22 +175,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn p256_maps_to_ecdsa_sha256_der_pipeline() {
+    fn p256_maps_to_ecdsa_sha256() {
         let (kms, canton) = algorithms_for(SigningKeySpec::EcP256).unwrap();
         assert_eq!(kms, KmsSigningAlgorithm::EcdsaSha256);
         assert_eq!(canton, SigningAlgorithmSpec::EcDsaSha256);
     }
 
     #[test]
-    fn p384_maps_to_ecdsa_sha384() {
-        let (kms, canton) = algorithms_for(SigningKeySpec::EcP384).unwrap();
-        assert_eq!(kms, KmsSigningAlgorithm::EcdsaSha384);
-        assert_eq!(canton, SigningAlgorithmSpec::EcDsaSha384);
-    }
-
-    #[test]
-    fn ed25519_and_secp256k1_are_unsupported() {
+    fn other_specs_are_unsupported() {
         assert!(algorithms_for(SigningKeySpec::EcCurve25519).is_none());
+        assert!(algorithms_for(SigningKeySpec::EcP384).is_none());
         assert!(algorithms_for(SigningKeySpec::EcSecp256k1).is_none());
         assert!(algorithms_for(SigningKeySpec::Unspecified).is_none());
     }

--- a/crates/decman/src/signing/aws_kms.rs
+++ b/crates/decman/src/signing/aws_kms.rs
@@ -1,0 +1,206 @@
+//! Signing backend for party keys held in AWS KMS.
+//!
+//! A KMS-backed participant generates the party's Daml key inside AWS KMS,
+//! where the private half is non-exportable. The node cannot sign ledger
+//! transactions with it (Canton exposes no vault Sign RPC for Daml hashes),
+//! so decman signs by calling the AWS KMS `Sign` API directly with the key id
+//! that `VaultService.ListMyKeys` reports for the key.
+//!
+//! Requirements on the runtime environment:
+//! - AWS credentials resolvable through the default provider chain (on EKS:
+//!   IRSA on decman's service account).
+//! - `kms:Sign` on the party's KMS keys. The keys are created under the
+//!   participant's KMS role, so the operator must grant decman's role access
+//!   in the key policy. See `docs/KMS_SIGNING.md`.
+//!
+//! Signature semantics, verified against Canton source
+//! (`InteractiveSubmission.verifySignatures` / `JcePureCrypto`):
+//! - The prepared-transaction hash is a raw 32-byte digest, signed verbatim
+//!   as a *message*: Canton verifies with `SHA256withECDSA`, which hashes the
+//!   input again internally. AWS KMS must therefore receive the hash bytes
+//!   with `MessageType::Raw` so it applies that same single SHA-256 pass.
+//!   Passing them as `Digest` would skip it and fail verification.
+//! - Canton accepts ECDSA signatures only in ASN.1/DER
+//!   (`SignatureFormat::Der`), which is what AWS KMS returns. No re-encoding.
+
+use async_trait::async_trait;
+use aws_sdk_kms::{
+    primitives::Blob,
+    types::{MessageType, SigningAlgorithmSpec as KmsSigningAlgorithm},
+};
+use canton_proto_rs::com::digitalasset::canton::crypto::v30::{
+    Signature, SignatureFormat, SigningAlgorithmSpec, SigningKeySpec,
+};
+use p256::{
+    ecdsa::{DerSignature, VerifyingKey, signature::Verifier},
+    pkcs8::DecodePublicKey,
+};
+
+use crate::signing::{PreparedTransactionHash, SigningError, SigningKeyContext, TransactionSigner};
+
+/// Signs with a party key held in AWS KMS via the KMS `Sign` API.
+pub struct AwsKmsSigner {
+    client: aws_sdk_kms::Client,
+}
+
+impl AwsKmsSigner {
+    /// Build the signer from the default AWS credential/region chain
+    /// (environment, profile, or IRSA when running on EKS).
+    pub async fn new() -> Self {
+        let config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
+        Self {
+            client: aws_sdk_kms::Client::new(&config),
+        }
+    }
+}
+
+#[async_trait]
+impl TransactionSigner for AwsKmsSigner {
+    async fn sign(
+        &self,
+        hashes: &[PreparedTransactionHash],
+        key: &SigningKeyContext,
+    ) -> Result<Vec<Signature>, SigningError> {
+        let kms_key_id = key.kms_key_id.as_deref().ok_or_else(|| {
+            SigningError::Other(anyhow::anyhow!(
+                "AwsKmsSigner selected for key {fingerprint} but the key carries no kms_key_id",
+                fingerprint = key.fingerprint
+            ))
+        })?;
+
+        let (kms_algorithm, canton_algorithm) = algorithms_for(key.public_key.key_spec())
+            .ok_or_else(|| {
+                SigningError::Other(anyhow::anyhow!(
+                    "AwsKmsSigner does not support key spec {spec:?} \
+                     (key {fingerprint}); AWS KMS signs EC-P256 / EC-P384 only",
+                    spec = key.public_key.key_spec(),
+                    fingerprint = key.fingerprint
+                ))
+            })?;
+
+        // Local verification key, parsed from the X.509 SPKI public key Canton
+        // returned at generation time. Verifying each signature locally before
+        // submission catches a wrong key or wrong signing semantics here,
+        // instead of as an opaque rejection at ExecuteSubmission.
+        // P-384 keys skip the local check (`p256` covers only P-256).
+        let verifying_key = match key.public_key.key_spec() {
+            SigningKeySpec::EcP256 => Some(
+                VerifyingKey::from_public_key_der(&key.public_key.public_key).map_err(|e| {
+                    SigningError::Other(anyhow::anyhow!(
+                        "Failed to parse P-256 public key for {fingerprint}: {e}",
+                        fingerprint = key.fingerprint
+                    ))
+                })?,
+            ),
+            _ => None,
+        };
+
+        tracing::info!(
+            "Signing {count} transaction hashes via AWS KMS key {kms_key_id}...",
+            count = hashes.len()
+        );
+
+        let mut signatures: Vec<Signature> = Vec::with_capacity(hashes.len());
+
+        for (idx, hash) in hashes.iter().enumerate() {
+            // MessageType::Raw: KMS applies the algorithm's digest (SHA-256)
+            // to the hash bytes, matching Canton's message-verify semantics.
+            let output = self
+                .client
+                .sign()
+                .key_id(kms_key_id)
+                .message(Blob::new(hash.as_bytes()))
+                .message_type(MessageType::Raw)
+                .signing_algorithm(kms_algorithm.clone())
+                .send()
+                .await
+                .map_err(|e| SigningError::Kms(Box::new(e)))?;
+
+            let signature_der = output
+                .signature()
+                .ok_or_else(|| {
+                    SigningError::Other(anyhow::anyhow!(
+                        "AWS KMS Sign returned no signature for key {kms_key_id}"
+                    ))
+                })?
+                .as_ref()
+                .to_vec();
+
+            // Verify locally before submission. A signature that fails here is
+            // guaranteed to be rejected at ExecuteSubmission, so fail loudly
+            // with context instead of producing an opaque ledger error.
+            if let Some(vk) = &verifying_key {
+                let der_sig = DerSignature::from_bytes(&signature_der).map_err(|e| {
+                    SigningError::Other(anyhow::anyhow!(
+                        "AWS KMS returned a signature that is not valid DER: {e}"
+                    ))
+                })?;
+                vk.verify(hash.as_bytes(), &der_sig).map_err(|e| {
+                    SigningError::Other(anyhow::anyhow!(
+                        "Signature {index} from KMS key {kms_key_id} failed local \
+                         verification against the registered public key \
+                         {fingerprint}: {e}",
+                        index = idx + 1,
+                        fingerprint = key.fingerprint
+                    ))
+                })?;
+                tracing::info!("Signature {index} verified locally", index = idx + 1);
+            }
+
+            signatures.push(Signature {
+                format: SignatureFormat::Der as i32,
+                signature: signature_der,
+                signed_by: key.fingerprint.clone(),
+                signing_algorithm_spec: canton_algorithm as i32,
+                signature_delegation: None,
+            });
+        }
+
+        tracing::debug!("Generated {count} signatures", count = signatures.len());
+        Ok(signatures)
+    }
+}
+
+/// Map a Canton signing key spec to the AWS KMS signing algorithm and the
+/// Canton algorithm spec recorded on the produced signature. Returns `None`
+/// for specs AWS KMS cannot sign (Ed25519 is verify-only on KMS nodes;
+/// secp256k1 party keys do not occur in this deployment).
+fn algorithms_for(key_spec: SigningKeySpec) -> Option<(KmsSigningAlgorithm, SigningAlgorithmSpec)> {
+    match key_spec {
+        SigningKeySpec::EcP256 => Some((
+            KmsSigningAlgorithm::EcdsaSha256,
+            SigningAlgorithmSpec::EcDsaSha256,
+        )),
+        SigningKeySpec::EcP384 => Some((
+            KmsSigningAlgorithm::EcdsaSha384,
+            SigningAlgorithmSpec::EcDsaSha384,
+        )),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn p256_maps_to_ecdsa_sha256_der_pipeline() {
+        let (kms, canton) = algorithms_for(SigningKeySpec::EcP256).unwrap();
+        assert_eq!(kms, KmsSigningAlgorithm::EcdsaSha256);
+        assert_eq!(canton, SigningAlgorithmSpec::EcDsaSha256);
+    }
+
+    #[test]
+    fn p384_maps_to_ecdsa_sha384() {
+        let (kms, canton) = algorithms_for(SigningKeySpec::EcP384).unwrap();
+        assert_eq!(kms, KmsSigningAlgorithm::EcdsaSha384);
+        assert_eq!(canton, SigningAlgorithmSpec::EcDsaSha384);
+    }
+
+    #[test]
+    fn ed25519_and_secp256k1_are_unsupported() {
+        assert!(algorithms_for(SigningKeySpec::EcCurve25519).is_none());
+        assert!(algorithms_for(SigningKeySpec::EcSecp256k1).is_none());
+        assert!(algorithms_for(SigningKeySpec::Unspecified).is_none());
+    }
+}

--- a/crates/decman/src/signing/error.rs
+++ b/crates/decman/src/signing/error.rs
@@ -10,6 +10,11 @@ pub enum SigningError {
     /// A Canton admin-API RPC failed (for example `ExportKeyPair`).
     #[error("vault RPC failed: {0}")]
     VaultRpc(#[from] tonic::Status),
+    /// The external KMS rejected or failed a signing call. Common causes:
+    /// missing `kms:Sign` permission for decman's role on the party key, or
+    /// unreachable KMS endpoint.
+    #[error("KMS signing failed: {0}")]
+    Kms(#[source] Box<dyn std::error::Error + Send + Sync>),
     /// Any other signing failure.
     #[error(transparent)]
     Other(#[from] anyhow::Error),

--- a/crates/decman/src/signing/mod.rs
+++ b/crates/decman/src/signing/mod.rs
@@ -7,12 +7,13 @@
 //!
 //! - [`vault_export::VaultExportSigner`] pulls the private key out of the
 //!   participant's vault (`VaultService.ExportKeyPair`) and signs locally with
-//!   Ed25519. This is the only backend today and works for the JCE crypto
-//!   provider, whose keys are exportable.
-//! - A KMS-backed key (AWS KMS, MPCH) is non-exportable, so it must be signed by
-//!   asking the KMS to sign the hash. That backend is a follow-up: implement
-//!   [`TransactionSigner`] and add a branch to [`select_signer`]. Nothing else
-//!   in the signing flow changes.
+//!   Ed25519. It serves the JCE crypto provider, whose keys are exportable.
+//! - [`aws_kms::AwsKmsSigner`] signs with a non-exportable key held in AWS KMS
+//!   by calling the KMS `Sign` API. It serves KMS-backed participants.
+//!
+//! [`select_signer`] picks the backend from the key's custody. New backends
+//! (e.g. an MPCH client-API signer) implement [`TransactionSigner`] and add a
+//! branch there; nothing else in the signing flow changes.
 //!
 //! The one operation that varies is "turn a prepared-transaction hash into a
 //! Canton `Signature`"; everything else (loading the key, loading prepared

--- a/crates/decman/src/signing/mod.rs
+++ b/crates/decman/src/signing/mod.rs
@@ -19,6 +19,7 @@
 //! submissions, persisting the signature bundle) is provider-independent and
 //! stays in `workflow::contracts::steps::sign`.
 
+pub mod aws_kms;
 mod error;
 mod signer;
 pub mod vault_export;

--- a/crates/decman/src/signing/signer.rs
+++ b/crates/decman/src/signing/signer.rs
@@ -4,7 +4,7 @@ use tonic::transport::Channel;
 
 use crate::{
     error::Result,
-    signing::{SigningError, vault_export::VaultExportSigner},
+    signing::{SigningError, aws_kms::AwsKmsSigner, vault_export::VaultExportSigner},
 };
 
 /// An interactive-submission prepared-transaction hash, as returned by the
@@ -64,25 +64,29 @@ pub trait TransactionSigner: Send + Sync {
 
 /// Choose the signing backend for a given party key.
 ///
-/// The choice is forced by how the key is held, not by preference: a
-/// KMS-backed key can only be signed by the matching KMS backend, an
-/// exportable key by [`VaultExportSigner`]. Today only the export backend
-/// exists; a KMS-backed key still falls through to it and fails at export
-/// exactly as before — the KMS backend lands with its own change. This is the
-/// single extension point for new backends.
+/// The choice is forced by how the key is held, not by preference: a key that
+/// carries a `kms_key_id` is non-exportable and can only be signed through
+/// the KMS ([`AwsKmsSigner`]); an exportable vault key is signed by
+/// [`VaultExportSigner`]. This is the single extension point for new backends
+/// (e.g. an MPCH client-API signer).
 ///
 /// Returns a boxed trait object because the backend is picked at *runtime*
 /// from the key's custody, so the concrete type differs per call; the one
 /// dynamic dispatch is noise next to the signing RPCs themselves.
 ///
 /// Takes the caller's already-open admin-API `channel` so the export backend
-/// reuses one connection instead of opening a second. Async so a future KMS
-/// backend can build its own KMS client here.
+/// reuses one connection instead of opening a second. Async because the KMS
+/// backend resolves AWS credentials when it is built.
 pub async fn select_signer(
-    _key: &SigningKeyContext,
+    key: &SigningKeyContext,
     channel: Channel,
 ) -> Result<Box<dyn TransactionSigner>> {
-    // TODO(#264): when `_key.kms_key_id.is_some()`, return the KMS backend
-    // (AWS KMS / MPCH) instead of the export backend.
-    Ok(Box::new(VaultExportSigner::new(channel)))
+    if key.kms_key_id.is_some() {
+        // Only AWS KMS is supported so far. A key held by a different KMS
+        // driver (e.g. MPCH) also carries a kms_key_id; its Sign call fails
+        // with a clear KMS error until a dedicated backend exists.
+        Ok(Box::new(AwsKmsSigner::new().await))
+    } else {
+        Ok(Box::new(VaultExportSigner::new(channel)))
+    }
 }

--- a/docs/KMS_SIGNING.md
+++ b/docs/KMS_SIGNING.md
@@ -28,8 +28,9 @@ the participant (`VaultService.ListMyKeys` reports `kms_key_id`).
 
 2. **`kms:Sign` on the party's Daml keys.** The keys are created by the
    participant under its own KMS role, so decman's role gets no access by
-   default. Add a statement to the key policy of each party Daml key, or grant
-   it via an IAM policy on decman's role:
+   default. Edit the **key policy** of each party Daml key — this is the
+   reliable route, because it works regardless of how the key policy handles
+   IAM delegation:
 
    ```json
    {
@@ -41,9 +42,35 @@ the participant (`VaultService.ListMyKeys` reports `kms_key_id`).
    }
    ```
 
-   To find the key: run a workflow once and read the key id from the error, or
-   list the participant's keys — the party Daml key is the one whose name is
-   `<party-prefix>-daml-transactions` and whose metadata carries `kmsKeyId`.
+   In a key policy, `"Resource": "*"` means "this key" and is safe.
+
+   An **IAM policy** on decman's role works only when the key policy delegates
+   to IAM. If you take that route, the statement has no `Principal`, and the
+   `Resource` must name the specific key ARNs. Never use `"Resource": "*"` in
+   an IAM policy — that grants signing with **every** key in the account,
+   including the participant's namespace key:
+
+   ```json
+   {
+     "Sid": "AllowDecmanPartyKeySigning",
+     "Effect": "Allow",
+     "Action": "kms:Sign",
+     "Resource": "arn:aws:kms:<region>:<account>:key/<party-daml-key-id>"
+   }
+   ```
+
+   To find the key id, list the participant's keys over the Admin API — the
+   party Daml key is named `<party-prefix>-daml-transactions` and its metadata
+   carries `kmsKeyId`:
+
+   ```bash
+   grpcurl -plaintext -d '{"filters":{"name":"<party-prefix>-daml-transactions"}}' \
+     <admin-host>:<admin-port> \
+     com.digitalasset.canton.crypto.admin.v30.VaultService/ListMyKeys
+   ```
+
+   Alternatively, run the contracts workflow once and read the key id from the
+   `AccessDeniedException` error, which names the key ARN.
 
 3. Nothing else. Key discovery, algorithm selection (EC-P256 → ECDSA-SHA-256),
    signature format (DER), and local pre-submission verification are automatic.

--- a/docs/KMS_SIGNING.md
+++ b/docs/KMS_SIGNING.md
@@ -1,0 +1,66 @@
+# Signing with AWS KMS party keys
+
+This guide covers decman on a participant that uses AWS KMS as its crypto
+provider (`canton.participants.<p>.crypto.provider = kms`). On such a node the
+party's signing keys are created inside AWS KMS and cannot be exported. decman
+therefore signs ledger transactions by calling the AWS KMS `Sign` API. That
+call needs IAM permission, which the operator must grant once per node.
+
+## Background
+
+Each decentralized-party member holds two keys:
+
+| Key | Signs | How it signs on a KMS node |
+|---|---|---|
+| Namespace key | Topology transactions | The participant signs through its own KMS access. No setup. |
+| Daml key | Ledger transactions (governance contract deployment) | decman calls AWS KMS `Sign` directly. **Needs IAM setup.** |
+
+Canton has no API that signs a ledger transaction with a vault key, so decman
+must reach the KMS itself. decman discovers the KMS key id automatically from
+the participant (`VaultService.ListMyKeys` reports `kms_key_id`).
+
+## What the operator must set up
+
+1. **AWS credentials for decman.** decman uses the default AWS credential
+   chain. On EKS, attach an IAM role to decman's service account (IRSA). The
+   region must match the KMS keys' region (set `AWS_REGION` if the chain does
+   not resolve it).
+
+2. **`kms:Sign` on the party's Daml keys.** The keys are created by the
+   participant under its own KMS role, so decman's role gets no access by
+   default. Add a statement to the key policy of each party Daml key, or grant
+   it via an IAM policy on decman's role:
+
+   ```json
+   {
+     "Sid": "AllowDecmanPartyKeySigning",
+     "Effect": "Allow",
+     "Principal": { "AWS": "arn:aws:iam::<account>:role/<decman-irsa-role>" },
+     "Action": "kms:Sign",
+     "Resource": "*"
+   }
+   ```
+
+   To find the key: run a workflow once and read the key id from the error, or
+   list the participant's keys — the party Daml key is the one whose name is
+   `<party-prefix>-daml-transactions` and whose metadata carries `kmsKeyId`.
+
+3. Nothing else. Key discovery, algorithm selection (EC-P256 → ECDSA-SHA-256),
+   signature format (DER), and local pre-submission verification are automatic.
+
+## Failure modes
+
+| Symptom | Cause |
+|---|---|
+| `KMS signing failed: ... AccessDeniedException` | decman's role lacks `kms:Sign` on the key (step 2). |
+| `KMS signing failed: ... dispatch failure` | No AWS credentials or wrong region (step 1). |
+| `failed local verification against the registered public key` | The KMS key does not match the registered public key. Check that the `kms_key_id` belongs to this party's Daml key. |
+| Workflow fails at export with `ExportKeyPair` | The key carries no `kms_key_id`, so decman used the vault-export path. Expected on JCE nodes; on a KMS node this means the key metadata is inconsistent. |
+
+## Scope
+
+- Only AWS KMS is supported. A participant with a different KMS driver (for
+  example MPCH) also reports a `kms_key_id`; signing then fails with a clear
+  KMS error until a dedicated backend exists.
+- Parties created before this feature hold Ed25519 vault keys on JCE nodes;
+  those continue to sign through the export path with no changes.

--- a/docs/KMS_SIGNING.md
+++ b/docs/KMS_SIGNING.md
@@ -17,7 +17,8 @@ Each decentralized-party member holds two keys:
 
 Canton has no API that signs a ledger transaction with a vault key, so decman
 must reach the KMS itself. decman discovers the KMS key id automatically from
-the participant (`VaultService.ListMyKeys` reports `kms_key_id`).
+the participant (`VaultService.ListMyKeys` reports `kms_key_id`; grpcurl's
+JSON output renders the same field as `kmsKeyId`).
 
 ## What the operator must set up
 


### PR DESCRIPTION
## What

Adds `AwsKmsSigner`, the first non-export signing backend behind the `TransactionSigner` trait from #291. When the party's Daml key carries a `kms_key_id` (KMS-backed participants), `select_signer` routes to it and decman signs the interactive-submission prepared hash through the AWS KMS `Sign` API. Exportable vault keys keep the export path unchanged.

## Why

On a `crypto.provider = kms` participant the party's Daml key is created inside AWS KMS and cannot be exported. Canton has no API that signs a ledger transaction with a vault key — party signatures must come from the caller. So the party could be created (#268) but could not deploy its governance-core contract. This closes that gap: decman asks the KMS to sign, and the key never leaves it.

Design decision (pilot call): the party key stays in the node's KMS, and the operator grants decman `kms:Sign` — security posture is worth the one-time IAM setup. A decman-held local-key backend remains possible later behind the same trait.

## Signature semantics — verified against Canton source, not assumed

- Prepare returns the **raw 32-byte digest** (`hash.unwrap`, no multihash prefix); Execute recomputes and verifies those exact bytes.
- Canton verifies ECDSA with **`SHA256withECDSA`** (message semantics — the verifier hashes the input again). The KMS call is therefore `MessageType=RAW` + `ECDSA_SHA_256`. Passing `DIGEST` would silently skip one hash pass and fail.
- Canton accepts ECDSA signatures **only in DER** (`supportedSignatureFormats = {Der}` for `EcDsaSha256`); AWS KMS returns DER, passed through unchanged.
- `signed_by` = the fingerprint of the party's registered signing key (Protocol usage), which #268 made correct for P-256.
- No low-s/canonicality enforcement exists in Canton's ECDSA verify, so KMS output verifies as-is.

Each signature is also **verified locally** (via `p256`) against the registered public key before submission — wrong key or wrong semantics fails fast with context instead of an opaque `ExecuteSubmission` rejection.

## Operator setup

`docs/KMS_SIGNING.md` (new) documents the one-time setup: AWS credentials for decman (IRSA on EKS) and `kms:Sign` on the party keys, plus the failure-mode table. Key discovery, algorithm selection, and format are automatic.

## New dependencies

- `aws-config` / `aws-sdk-kms` — the official AWS SDK; needed to call KMS `Sign`. rustls, no default features.
- `p256` (RustCrypto) — parses the SPKI public key and verifies each signature locally before submission.

## CI note

`.cargo/audit.toml` gains an ignore for `RUSTSEC-2026-0235` (rkyv): the crate enters the lockfile only through rust_decimal's disabled optional feature and is never compiled; graph-aware cargo-deny agrees. This keeps the lockfile-scanning Cargo Audit gate green and is unrelated to KMS.

## How tested

- Unit tests for the key-spec → algorithm mapping (EC-P256 supported; every other spec rejected with a clear error). 304 lib tests pass; clippy and fmt clean.
- The review round removed the speculative P-384 arm: no P-384 party key can exist today (KMS nodes generate the P-256 default), and the arm skipped the local verification.
- The KMS `Sign` call itself cannot be unit-tested without AWS; **live validation is the next step**: grant decman-6's role `kms:Sign` on the devnet party keys and deploy governance-core with the `test-kms-2` party. The local verification step means a semantics error surfaces in decman logs, not as a ledger rejection.

## Scope notes

- Only AWS KMS. A key held by a different KMS driver (MPCH) also carries a `kms_key_id`; its Sign call fails with a clear KMS error until a dedicated backend exists (their client API is still an open question with MPCH).
- Existing JCE parties are untouched — no `kms_key_id`, same export path as before.

Refs #264
