### PR TITLE
chore(deps): adopt Canton 3.5.11 protos

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -15,4 +15,16 @@ ignore = [
   # by ratatui (the decman-cli TUI). Trivial compile-time proc-macro, no
   # runtime/security surface. Mirrors the ignore in deny.toml.
   "RUSTSEC-2024-0436",
+  # rkyv 0.7 is an *optional* dependency of rust_decimal (behind its `rkyv`
+  # feature, which nothing here enables), so it is recorded in Cargo.lock but
+  # never compiled: `cargo tree -e normal -i rkyv --target all --all-features`
+  # finds no path to it, and cargo-deny does not flag it. The advisory is an
+  # out-of-bounds read while *deserializing* an rkyv archive; we never call
+  # rkyv, and no untrusted archive reaches it.
+  #
+  # Not fixable by upgrading: rust_decimal requires `rkyv ^0.7.46` and the fix
+  # only landed in 0.8.17, a semver break, so the bump has to come from
+  # rust_decimal upstream. Latest (1.42.1) still requires 0.7. Drop this ignore
+  # once it moves.
+  "RUSTSEC-2026-0235",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -801,8 +801,8 @@ dependencies = [
 
 [[package]]
 name = "canton-proto-rs"
-version = "3.5.3"
-source = "git+ssh://git@github.com/DLC-link/canton-lib?rev=e80d7c1acc012a23665dadeaf7c8761e9ea73ef7#e80d7c1acc012a23665dadeaf7c8761e9ea73ef7"
+version = "3.4.0"
+source = "git+ssh://git@github.com/DLC-link/canton-lib?rev=651ea5221b4794f55bd152e9f3e762a92af69afd#651ea5221b4794f55bd152e9f3e762a92af69afd"
 dependencies = [
  "prost",
  "prost-types",
@@ -1003,7 +1003,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.6.1"
-source = "git+ssh://git@github.com/DLC-link/canton-lib?rev=e80d7c1acc012a23665dadeaf7c8761e9ea73ef7#e80d7c1acc012a23665dadeaf7c8761e9ea73ef7"
+source = "git+ssh://git@github.com/DLC-link/canton-lib?rev=651ea5221b4794f55bd152e9f3e762a92af69afd#651ea5221b4794f55bd152e9f3e762a92af69afd"
 dependencies = [
  "canton-api-client",
  "rust_decimal",
@@ -2648,7 +2648,7 @@ dependencies = [
 [[package]]
 name = "keycloak"
 version = "0.6.1"
-source = "git+ssh://git@github.com/DLC-link/canton-lib?rev=e80d7c1acc012a23665dadeaf7c8761e9ea73ef7#e80d7c1acc012a23665dadeaf7c8761e9ea73ef7"
+source = "git+ssh://git@github.com/DLC-link/canton-lib?rev=651ea5221b4794f55bd152e9f3e762a92af69afd#651ea5221b4794f55bd152e9f3e762a92af69afd"
 dependencies = [
  "base64 0.22.1",
  "reqwest 0.12.28",
@@ -3957,7 +3957,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 [[package]]
 name = "registry"
 version = "0.6.1"
-source = "git+ssh://git@github.com/DLC-link/canton-lib?rev=e80d7c1acc012a23665dadeaf7c8761e9ea73ef7#e80d7c1acc012a23665dadeaf7c8761e9ea73ef7"
+source = "git+ssh://git@github.com/DLC-link/canton-lib?rev=651ea5221b4794f55bd152e9f3e762a92af69afd#651ea5221b4794f55bd152e9f3e762a92af69afd"
 dependencies = [
  "common 0.6.1",
  "reqwest 0.12.28",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,11 +90,11 @@ wiremock = { version = "0.6" }
 x509-parser = { version = "0.18" }
 zeroize = { version = "1.8", features = ["derive"] }
 
-canton-common = { package = "common", git = "ssh://git@github.com/DLC-link/canton-lib", rev = "e80d7c1acc012a23665dadeaf7c8761e9ea73ef7" }
-canton-proto-rs = { git = "ssh://git@github.com/DLC-link/canton-lib", rev = "e80d7c1acc012a23665dadeaf7c8761e9ea73ef7" }
-canton-registry = { package = "registry", git = "ssh://git@github.com/DLC-link/canton-lib", rev = "e80d7c1acc012a23665dadeaf7c8761e9ea73ef7" }
+canton-common = { package = "common", git = "ssh://git@github.com/DLC-link/canton-lib", rev = "651ea5221b4794f55bd152e9f3e762a92af69afd" }
+canton-proto-rs = { git = "ssh://git@github.com/DLC-link/canton-lib", rev = "651ea5221b4794f55bd152e9f3e762a92af69afd" }
+canton-registry = { package = "registry", git = "ssh://git@github.com/DLC-link/canton-lib", rev = "651ea5221b4794f55bd152e9f3e762a92af69afd" }
 common = { path = "crates/common" }
-keycloak = { git = "ssh://git@github.com/DLC-link/canton-lib", rev = "e80d7c1acc012a23665dadeaf7c8761e9ea73ef7" }
+keycloak = { git = "ssh://git@github.com/DLC-link/canton-lib", rev = "651ea5221b4794f55bd152e9f3e762a92af69afd" }
 
 [profile.release]
 opt-level = 3

--- a/crates/decman/src/server/chain_audit.rs
+++ b/crates/decman/src/server/chain_audit.rs
@@ -476,6 +476,7 @@ async fn stream_entries(
         begin_exclusive,
         end_inclusive: Some(end_inclusive),
         update_format: Some(update_format),
+        descending_order: false,
     };
 
     let mut stream = update_client

--- a/crates/decman/src/server/handlers/governance.rs
+++ b/crates/decman/src/server/handlers/governance.rs
@@ -1326,6 +1326,7 @@ pub async fn propose_action(
         synchronizer_id: String::new(),
         package_id_selection_preference: vec![],
         prefetch_contract_keys: vec![],
+        taps_max_passes: None,
     };
 
     let channel = match data.config.ledger_channel().await {
@@ -1449,6 +1450,7 @@ pub async fn propose_action(
         synchronizer_id: String::new(),
         package_id_selection_preference: vec![],
         prefetch_contract_keys: vec![],
+        taps_max_passes: None,
     };
 
     let mut confirm_req = tonic::Request::new(SubmitAndWaitRequest {
@@ -2039,6 +2041,7 @@ async fn get_party_threshold(data: &web::Data<AppState>, party_id: &CantonId) ->
                     time_query: Some(base_query::TimeQuery::HeadState(())),
                     filter_signed_key: String::new(),
                     protocol_version: None,
+                    client_version: None,
                 }),
                 filter_namespace: namespace,
             },
@@ -2202,6 +2205,7 @@ async fn execute_confirm_action(
         synchronizer_id: String::new(),
         package_id_selection_preference: vec![],
         prefetch_contract_keys: vec![],
+        taps_max_passes: None,
     };
 
     let mut req = tonic::Request::new(SubmitAndWaitRequest {
@@ -2399,6 +2403,7 @@ async fn execute_confirmed_action(
         synchronizer_id: String::new(),
         package_id_selection_preference: vec![],
         prefetch_contract_keys: vec![],
+        taps_max_passes: None,
     };
 
     let mut req = tonic::Request::new(SubmitAndWaitRequest {
@@ -2539,6 +2544,7 @@ async fn execute_expire_confirmation(
         synchronizer_id: String::new(),
         package_id_selection_preference: vec![],
         prefetch_contract_keys: vec![],
+        taps_max_passes: None,
     };
 
     let mut req = tonic::Request::new(SubmitAndWaitRequest {
@@ -2664,6 +2670,7 @@ async fn execute_cancel_confirmation(
         synchronizer_id: String::new(),
         package_id_selection_preference: vec![],
         prefetch_contract_keys: vec![],
+        taps_max_passes: None,
     };
 
     let mut req = tonic::Request::new(SubmitAndWaitRequest {

--- a/crates/decman/src/server/handlers/parties.rs
+++ b/crates/decman/src/server/handlers/parties.rs
@@ -8,12 +8,16 @@ use actix_web::{HttpResponse, Responder, get, web};
 use canton_proto_rs::com::digitalasset::canton::{
     admin::participant::v30::{ListPackagesRequest, package_service_client::PackageServiceClient},
     crypto::{
-        admin::v30::{ListMyKeysRequest, vault_service_client::VaultServiceClient},
+        admin::v30::{
+            ListMyKeysRequest, private_key_metadata, vault_service_client::VaultServiceClient,
+        },
         v30::public_key,
     },
     topology::admin::v30::{
         BaseQuery, ListDecentralizedNamespaceDefinitionRequest, ListNamespaceDelegationRequest,
-        ListPartyToParticipantRequest, StoreId, Synchronizer, base_query, store_id, synchronizer,
+        ListPartyToParticipantRequest, StoreId, Synchronizer, base_query,
+        list_namespace_delegation_response::result::Item as NsDelegationItem,
+        list_party_to_participant_response::result::Item as P2pItem, store_id, synchronizer,
         topology_manager_read_service_client::TopologyManagerReadServiceClient,
     },
 };
@@ -381,6 +385,7 @@ async fn supplement_owner_keys_from_topology(
         time_query: Some(base_query::TimeQuery::HeadState(())),
         filter_signed_key: String::new(),
         protocol_version: None,
+        client_version: None,
     };
 
     // Cache per-namespace fingerprints so a participant who appears in many
@@ -420,7 +425,7 @@ async fn supplement_owner_keys_from_topology(
                 };
                 let mut fingerprints: HashSet<String> = HashSet::new();
                 for result in resp.results {
-                    if let Some(item) = result.item
+                    if let Some(NsDelegationItem::V30(item)) = result.item
                         && let Some(target_key) = item.target_key
                     {
                         fingerprints.insert(utils::compute_fingerprint(&target_key));
@@ -646,6 +651,7 @@ fn build_party_to_participant_request(
             time_query: Some(base_query::TimeQuery::HeadState(())),
             filter_signed_key: String::new(),
             protocol_version: None,
+            client_version: None,
         }),
         filter_party: prefix_filter.unwrap_or_default().to_string(),
         filter_participant: participant_id.to_string(),
@@ -670,13 +676,17 @@ pub async fn fetch_decentralized_parties(
 
     // Get all namespace keys from this participant
     let keys_response = vault_client
-        .list_my_keys(tonic::Request::new(ListMyKeysRequest { filters: None }))
+        .list_my_keys(tonic::Request::new(ListMyKeysRequest {
+            filters: None,
+            base_request: None,
+        }))
         .await?
         .into_inner();
 
     let mut namespace_key_fingerprints = HashMap::new();
     for key_meta in keys_response.private_keys_metadata {
-        if let Some(pub_key_with_name) = &key_meta.public_key_with_name
+        if let Some(private_key_metadata::PublicKeyWithName::V30(pub_key_with_name)) =
+            &key_meta.public_key_with_name
             && let Some(pub_key) = &pub_key_with_name.public_key
             && let Some(public_key::Key::SigningPublicKey(signing_key)) = &pub_key.key
             && signing_key.usage.contains(&1)
@@ -702,6 +712,7 @@ pub async fn fetch_decentralized_parties(
                     time_query: Some(base_query::TimeQuery::HeadState(())),
                     filter_signed_key: String::new(),
                     protocol_version: None,
+                    client_version: None,
                 }),
                 filter_namespace: String::new(),
             },
@@ -725,7 +736,9 @@ pub async fn fetch_decentralized_parties(
         .results
         .into_iter()
         .filter_map(|r| {
-            let p = r.item?;
+            let Some(P2pItem::V30(p)) = r.item else {
+                return None;
+            };
             let ns = p.party.rsplit_once("::")?.1.to_string();
             Some((ns, p))
         })
@@ -1181,13 +1194,17 @@ async fn get_local_namespace_fingerprints(config: &NodeConfig) -> Result<HashSet
         VaultServiceClient::new(channel).max_decoding_message_size(utils::MAX_GRPC_MESSAGE_SIZE);
 
     let keys_response = vault_client
-        .list_my_keys(tonic::Request::new(ListMyKeysRequest { filters: None }))
+        .list_my_keys(tonic::Request::new(ListMyKeysRequest {
+            filters: None,
+            base_request: None,
+        }))
         .await?
         .into_inner();
 
     let mut fingerprints = HashSet::new();
     for key_meta in keys_response.private_keys_metadata {
-        if let Some(pub_key_with_name) = &key_meta.public_key_with_name
+        if let Some(private_key_metadata::PublicKeyWithName::V30(pub_key_with_name)) =
+            &key_meta.public_key_with_name
             && let Some(pub_key) = &pub_key_with_name.public_key
             && let Some(public_key::Key::SigningPublicKey(signing_key)) = &pub_key.key
             && signing_key.usage.contains(&1)

--- a/crates/decman/src/server/handlers/tenant.rs
+++ b/crates/decman/src/server/handlers/tenant.rs
@@ -353,6 +353,8 @@ pub async fn tenant_prepare_submission(
         verbose_hashing: false,
         prefetch_contract_keys: vec![],
         estimate_traffic_cost: None,
+        hashing_scheme_version: None,
+        taps_max_passes: None,
     };
 
     match client
@@ -559,6 +561,7 @@ async fn fetch_party_acs(
             // `create_arguments` render as a labelled JSON object.
             verbose: true,
         }),
+        stream_continuation_token: None,
     };
 
     let mut stream = client.get_active_contracts(request).await?.into_inner();

--- a/crates/decman/src/server/mod.rs
+++ b/crates/decman/src/server/mod.rs
@@ -32,7 +32,9 @@ use actix_web::{App, HttpServer, web};
 use canton_proto_rs::com::digitalasset::canton::{
     admin::participant::v30::{ListPackagesRequest, package_service_client::PackageServiceClient},
     crypto::{
-        admin::v30::{ListMyKeysRequest, vault_service_client::VaultServiceClient},
+        admin::v30::{
+            ListMyKeysRequest, private_key_metadata, vault_service_client::VaultServiceClient,
+        },
         v30::public_key,
     },
     topology::admin::v30::{
@@ -2237,13 +2239,17 @@ async fn list_my_owner_keys(
 
     // Get this node's namespace key fingerprints
     let keys_response = vault_client
-        .list_my_keys(tonic::Request::new(ListMyKeysRequest { filters: None }))
+        .list_my_keys(tonic::Request::new(ListMyKeysRequest {
+            filters: None,
+            base_request: None,
+        }))
         .await?
         .into_inner();
 
     let mut my_fingerprints = Vec::new();
     for key_meta in keys_response.private_keys_metadata {
-        if let Some(pub_key_with_name) = &key_meta.public_key_with_name
+        if let Some(private_key_metadata::PublicKeyWithName::V30(pub_key_with_name)) =
+            &key_meta.public_key_with_name
             && let Some(pub_key) = &pub_key_with_name.public_key
             && let Some(public_key::Key::SigningPublicKey(signing_key)) = &pub_key.key
             && signing_key.usage.contains(&1)
@@ -2266,6 +2272,7 @@ async fn list_my_owner_keys(
         time_query: Some(base_query::TimeQuery::HeadState(())),
         filter_signed_key: String::new(),
         protocol_version: None,
+        client_version: None,
     };
 
     // Get all decentralized namespace definitions. The response is bounded by

--- a/crates/decman/src/server/queries.rs
+++ b/crates/decman/src/server/queries.rs
@@ -487,6 +487,7 @@ async fn fetch_contracts_with_wildcard(
             filters_for_any_party: None,
             verbose: false,
         }),
+        stream_continuation_token: None,
     };
 
     let mut stream = state_client
@@ -559,6 +560,7 @@ async fn fetch_contracts_for_template(
             filters_for_any_party: None,
             verbose: false,
         }),
+        stream_continuation_token: None,
     };
 
     let mut stream = state_client
@@ -590,6 +592,7 @@ pub async fn get_party_metadata(
             identity_provider_id: String::new(),
             page_token: String::new(),
             page_size: 1000,
+            filter_party: String::new(),
         }))
         .await?
         .into_inner();
@@ -851,6 +854,7 @@ async fn fetch_governance_with_wildcard(
             filters_for_any_party: None,
             verbose: true,
         }),
+        stream_continuation_token: None,
     };
 
     let mut stream = state_client
@@ -924,6 +928,7 @@ async fn fetch_governance_for_template(
             filters_for_any_party: None,
             verbose: true,
         }),
+        stream_continuation_token: None,
     };
 
     let mut stream = state_client
@@ -1435,6 +1440,7 @@ async fn fetch_proposal_infos(
             filters_for_any_party: None,
             verbose: true,
         }),
+        stream_continuation_token: None,
     };
 
     let mut stream = state_client
@@ -1610,6 +1616,7 @@ async fn fetch_governance_state_with_wildcard(
             filters_for_any_party: None,
             verbose: true,
         }),
+        stream_continuation_token: None,
     };
 
     let mut stream = state_client
@@ -1677,6 +1684,7 @@ async fn fetch_governance_state_for_template(
             filters_for_any_party: None,
             verbose: true,
         }),
+        stream_continuation_token: None,
     };
 
     let mut stream = state_client
@@ -1969,6 +1977,7 @@ async fn fetch_vaults_with_wildcard(
             filters_for_any_party: None,
             verbose: true,
         }),
+        stream_continuation_token: None,
     };
 
     let mut stream = state_client
@@ -2033,6 +2042,7 @@ async fn fetch_vaults_for_template(
             filters_for_any_party: None,
             verbose: true,
         }),
+        stream_continuation_token: None,
     };
 
     let mut stream = state_client
@@ -2187,6 +2197,7 @@ async fn fetch_provider_services_with_wildcard(
             filters_for_any_party: None,
             verbose: true,
         }),
+        stream_continuation_token: None,
     };
 
     let mut stream = state_client
@@ -2251,6 +2262,7 @@ async fn fetch_provider_services_for_template(
             filters_for_any_party: None,
             verbose: true,
         }),
+        stream_continuation_token: None,
     };
 
     let mut stream = state_client
@@ -2357,6 +2369,7 @@ async fn fetch_user_services_with_wildcard(
             filters_for_any_party: None,
             verbose: true,
         }),
+        stream_continuation_token: None,
     };
 
     let mut stream = state_client
@@ -2421,6 +2434,7 @@ async fn fetch_user_services_for_template(
             filters_for_any_party: None,
             verbose: true,
         }),
+        stream_continuation_token: None,
     };
 
     let mut stream = state_client
@@ -2533,6 +2547,7 @@ async fn fetch_credential_offers_with_wildcard(
             filters_for_any_party: None,
             verbose: true,
         }),
+        stream_continuation_token: None,
     };
 
     let mut stream = state_client
@@ -2597,6 +2612,7 @@ async fn fetch_credential_offers_for_template(
             filters_for_any_party: None,
             verbose: true,
         }),
+        stream_continuation_token: None,
     };
 
     let mut stream = state_client
@@ -2709,6 +2725,7 @@ async fn fetch_registrar_services_with_wildcard(
             filters_for_any_party: None,
             verbose: true,
         }),
+        stream_continuation_token: None,
     };
 
     let mut stream = state_client
@@ -2773,6 +2790,7 @@ async fn fetch_registrar_services_for_template(
             filters_for_any_party: None,
             verbose: true,
         }),
+        stream_continuation_token: None,
     };
 
     let mut stream = state_client
@@ -2895,6 +2913,7 @@ async fn fetch_instruments_with_wildcard(
             filters_for_any_party: None,
             verbose: true,
         }),
+        stream_continuation_token: None,
     };
 
     let mut stream = state_client
@@ -2958,6 +2977,7 @@ async fn fetch_instruments_for_template(
             filters_for_any_party: None,
             verbose: true,
         }),
+        stream_continuation_token: None,
     };
 
     let mut stream = state_client
@@ -3098,6 +3118,7 @@ pub async fn query_contracts_by_template(
             filters_for_any_party: None,
             verbose: true,
         }),
+        stream_continuation_token: None,
     };
 
     let mut stream = state_client
@@ -3196,6 +3217,7 @@ pub async fn get_open_transfer_instructions(
             filters_for_any_party: None,
             verbose: true,
         }),
+        stream_continuation_token: None,
     };
 
     let mut stream = state_client
@@ -3409,6 +3431,7 @@ async fn fetch_token_requests_for_template(
             filters_for_any_party: None,
             verbose: true,
         }),
+        stream_continuation_token: None,
     };
 
     let mut stream = state_client
@@ -3654,6 +3677,7 @@ pub async fn get_transfer_factories(
             filters_for_any_party: None,
             verbose: true,
         }),
+        stream_continuation_token: None,
     };
 
     let mut stream = state_client
@@ -3832,6 +3856,7 @@ async fn fetch_holding_views(
             filters_for_any_party: None,
             verbose: true,
         }),
+        stream_continuation_token: None,
     };
 
     let mut stream = state_client
@@ -4048,6 +4073,7 @@ async fn fetch_utility_preapproval_instruments(
             filters_for_any_party: None,
             verbose: true,
         }),
+        stream_continuation_token: None,
     };
 
     let mut stream = state_client
@@ -4281,6 +4307,7 @@ mod tests {
                     field("transfer", transfer),
                 ],
             }),
+            implementation_package_id: String::new(),
         };
         CreatedEvent {
             offset: 0,
@@ -4298,6 +4325,7 @@ mod tests {
             package_name: String::new(),
             representative_package_id: String::new(),
             acs_delta: false,
+            contract_key_hash: Vec::new(),
         }
     }
 
@@ -4371,6 +4399,7 @@ mod tests {
                     field("lock", optional_value(lock)),
                 ],
             }),
+            implementation_package_id: String::new(),
         };
         CreatedEvent {
             offset: 0,
@@ -4388,6 +4417,7 @@ mod tests {
             package_name: String::new(),
             representative_package_id: String::new(),
             acs_delta: false,
+            contract_key_hash: Vec::new(),
         }
     }
 
@@ -4549,6 +4579,7 @@ mod tests {
             package_name: String::new(),
             representative_package_id: String::new(),
             acs_delta: false,
+            contract_key_hash: Vec::new(),
         }
     }
 

--- a/crates/decman/src/workflow/add_party/steps/proposals/create.rs
+++ b/crates/decman/src/workflow/add_party/steps/proposals/create.rs
@@ -212,9 +212,9 @@ pub(crate) fn proposal_request(
             authorize_request::Proposal {
                 change: enums::TopologyChangeOp::AddReplace as i32,
                 serial: 0,
-                mapping: Some(TopologyMapping {
+                mapping: Some(authorize_request::proposal::Mapping::V30(TopologyMapping {
                     mapping: Some(mapping),
-                }),
+                })),
             },
         )),
         must_fully_authorize: false,

--- a/crates/decman/src/workflow/change_threshold/steps/export_state.rs
+++ b/crates/decman/src/workflow/change_threshold/steps/export_state.rs
@@ -50,6 +50,7 @@ pub async fn export_state(
             time_query: Some(base_query::TimeQuery::HeadState(())),
             filter_signed_key: String::new(),
             protocol_version: None,
+            client_version: None,
         }),
         filter_namespace: namespace_hex.clone(),
     });

--- a/crates/decman/src/workflow/change_threshold/steps/proposals/create.rs
+++ b/crates/decman/src/workflow/change_threshold/steps/proposals/create.rs
@@ -112,11 +112,11 @@ pub async fn create_proposals(
             authorize_request::Proposal {
                 change: enums::TopologyChangeOp::AddReplace as i32,
                 serial: 0,
-                mapping: Some(TopologyMapping {
+                mapping: Some(authorize_request::proposal::Mapping::V30(TopologyMapping {
                     mapping: Some(topology_mapping::Mapping::DecentralizedNamespaceDefinition(
                         new_namespace_def.clone(),
                     )),
-                }),
+                })),
             },
         )),
         must_fully_authorize: false,
@@ -138,9 +138,9 @@ pub async fn create_proposals(
             authorize_request::Proposal {
                 change: enums::TopologyChangeOp::AddReplace as i32,
                 serial: 0,
-                mapping: Some(TopologyMapping {
+                mapping: Some(authorize_request::proposal::Mapping::V30(TopologyMapping {
                     mapping: Some(topology_mapping::Mapping::PartyToParticipant(new_p2p)),
-                }),
+                })),
             },
         )),
         must_fully_authorize: false,

--- a/crates/decman/src/workflow/change_threshold/steps/proposals/submit.rs
+++ b/crates/decman/src/workflow/change_threshold/steps/proposals/submit.rs
@@ -2,6 +2,7 @@ use canton_proto_rs::com::digitalasset::canton::{
     protocol::v30::DecentralizedNamespaceDefinition,
     topology::admin::v30::{
         ListDecentralizedNamespaceDefinitionRequest, ListPartyToParticipantRequest,
+        list_party_to_participant_response::result::Item as P2pItem,
         topology_manager_read_service_client::TopologyManagerReadServiceClient,
     },
 };
@@ -184,11 +185,11 @@ async fn wait_for_p2p_in_topology(
             .await?
             .into_inner();
 
-        if response.results.iter().any(|r| {
-            r.item
-                .as_ref()
-                .is_some_and(|p| p.threshold == expected_threshold)
-        }) {
+        if response
+            .results
+            .iter()
+            .any(|r| matches!(&r.item, Some(P2pItem::V30(p)) if p.threshold == expected_threshold))
+        {
             tracing::info!(
                 "P2P threshold {expected_threshold} confirmed in topology after {attempt} attempt(s)"
             );

--- a/crates/decman/src/workflow/contracts/steps/prepare.rs
+++ b/crates/decman/src/workflow/contracts/steps/prepare.rs
@@ -159,6 +159,8 @@ pub async fn prepare_submissions(
                 verbose_hashing: false,
                 prefetch_contract_keys: vec![],
                 estimate_traffic_cost: None,
+                hashing_scheme_version: None,
+                taps_max_passes: None,
             }))
             .await?
             .into_inner();

--- a/crates/decman/src/workflow/contracts/steps/sign.rs
+++ b/crates/decman/src/workflow/contracts/steps/sign.rs
@@ -10,7 +10,9 @@ use canton_proto_rs::com::{
         },
         topology::admin::v30::{
             BaseQuery, ListPartyToKeyMappingRequest, ListPartyToParticipantRequest, StoreId,
-            Synchronizer, base_query, store_id, synchronizer,
+            Synchronizer, base_query,
+            list_party_to_key_mapping_response::result::Item as PartyToKeyItem,
+            list_party_to_participant_response::result::Item as P2pItem, store_id, synchronizer,
             topology_manager_read_service_client::TopologyManagerReadServiceClient,
         },
     },
@@ -148,8 +150,9 @@ pub async fn sign_submissions(
                 fingerprint: key_fingerprint.clone(),
                 name: String::new(), // Search by fingerprint, not name
                 purpose: vec![],
-                usage: vec![],
+                usage_v30: vec![],
             }),
+            base_request: None,
         }))
         .await?
         .into_inner();
@@ -310,6 +313,7 @@ async fn backfill_peer_keys_from_chain(
         time_query: Some(base_query::TimeQuery::HeadState(())),
         filter_signed_key: String::new(),
         protocol_version: None,
+        client_version: None,
     };
 
     // 1. Current format: signing keys embedded on the PartyToParticipant.
@@ -326,7 +330,7 @@ async fn backfill_peer_keys_from_chain(
     let mut signing_keys: Vec<SigningPublicKey> = p2p_response
         .results
         .into_iter()
-        .find_map(|r| r.item)
+        .find_map(|r| r.item.map(|P2pItem::V30(mapping)| mapping))
         .and_then(|item| item.party_signing_keys)
         .map(|k| k.keys)
         .unwrap_or_default();
@@ -348,7 +352,7 @@ async fn backfill_peer_keys_from_chain(
         signing_keys = ptk_response
             .results
             .into_iter()
-            .find_map(|r| r.item)
+            .find_map(|r| r.item.map(|PartyToKeyItem::V30(mapping)| mapping))
             .map(|item| item.signing_keys)
             .unwrap_or_default();
     }
@@ -373,8 +377,9 @@ async fn backfill_peer_keys_from_chain(
                     fingerprint: fingerprint.clone(),
                     name: String::new(),
                     purpose: vec![],
-                    usage: vec![],
+                    usage_v30: vec![],
                 }),
+                base_request: None,
             }))
             .await?
             .into_inner();

--- a/crates/decman/src/workflow/external_party/steps.rs
+++ b/crates/decman/src/workflow/external_party/steps.rs
@@ -20,7 +20,8 @@ use canton_proto_rs::com::digitalasset::canton::{
     protocol::v30::enums::ParticipantPermission,
     topology::admin::v30::{
         BaseQuery, ListDecentralizedNamespaceDefinitionRequest, ListPartyToParticipantRequest,
-        StoreId, Synchronizer, base_query, store_id, synchronizer,
+        StoreId, Synchronizer, base_query,
+        list_party_to_participant_response::result::Item as P2pItem, store_id, synchronizer,
         topology_manager_read_service_client::TopologyManagerReadServiceClient,
     },
 };
@@ -186,6 +187,8 @@ pub async fn allocate_party(
         onboarding_transactions,
         multi_hash_signatures: vec![signature],
         identity_provider_id: String::new(),
+        user_id: String::new(),
+        wait_for_allocation: None,
     };
 
     let mut client = utils::create_party_client(config, external_party_token_required()?).await?;
@@ -221,6 +224,7 @@ fn party_query(synchronizer_id: &str, proposals: bool) -> BaseQuery {
         time_query: Some(base_query::TimeQuery::HeadState(())),
         filter_signed_key: String::new(),
         protocol_version: None,
+        client_version: None,
     }
 }
 
@@ -263,7 +267,7 @@ pub async fn host_onboarding_status(
             .await?
             .into_inner();
         let names_self = response.results.iter().any(|r| {
-            r.item.as_ref().is_some_and(|p| {
+            matches!(&r.item, Some(P2pItem::V30(p)) if {
                 p.participants.iter().any(|h| {
                     h.participant_uid == self_uid
                         && h.permission == ParticipantPermission::Confirmation as i32
@@ -332,7 +336,9 @@ pub async fn list_hosted_external_parties(config: &NodeConfig) -> Result<Vec<Hos
 
     let mut parties = Vec::new();
     for result in p2p.results {
-        let Some(mapping) = result.item else { continue };
+        let Some(P2pItem::V30(mapping)) = result.item else {
+            continue;
+        };
         let hosts_us_confirming = mapping.participants.iter().any(|h| {
             h.participant_uid == self_uid
                 && h.permission == ParticipantPermission::Confirmation as i32

--- a/crates/decman/src/workflow/kick/steps/export_state.rs
+++ b/crates/decman/src/workflow/kick/steps/export_state.rs
@@ -1,5 +1,6 @@
 use canton_proto_rs::com::digitalasset::canton::topology::admin::v30::{
     ListDecentralizedNamespaceDefinitionRequest, ListPartyToParticipantRequest,
+    list_party_to_participant_response::result::Item as P2pItem,
     topology_manager_read_service_client::TopologyManagerReadServiceClient,
 };
 use sqlx::SqlitePool;
@@ -109,7 +110,7 @@ pub async fn export_state(
     let p2p_mapping = p2p_response
         .results
         .first()
-        .and_then(|r| r.item.as_ref())
+        .and_then(|r| r.item.as_ref().map(|P2pItem::V30(mapping)| mapping))
         .ok_or_else(|| anyhow::anyhow!("No P2P mapping found for party {party_id}"))?;
 
     let kick_participant = &kick_config.participant_id;

--- a/crates/decman/src/workflow/kick/steps/proposals/create.rs
+++ b/crates/decman/src/workflow/kick/steps/proposals/create.rs
@@ -150,11 +150,11 @@ pub async fn create_proposals(
             authorize_request::Proposal {
                 change: enums::TopologyChangeOp::AddReplace as i32,
                 serial: 0,
-                mapping: Some(TopologyMapping {
+                mapping: Some(authorize_request::proposal::Mapping::V30(TopologyMapping {
                     mapping: Some(topology_mapping::Mapping::DecentralizedNamespaceDefinition(
                         new_namespace_def.clone(),
                     )),
-                }),
+                })),
             },
         )),
         must_fully_authorize: false,
@@ -176,9 +176,9 @@ pub async fn create_proposals(
             authorize_request::Proposal {
                 change: enums::TopologyChangeOp::AddReplace as i32,
                 serial: 0,
-                mapping: Some(TopologyMapping {
+                mapping: Some(authorize_request::proposal::Mapping::V30(TopologyMapping {
                     mapping: Some(topology_mapping::Mapping::PartyToParticipant(new_p2p)),
-                }),
+                })),
             },
         )),
         must_fully_authorize: false,

--- a/crates/decman/src/workflow/onboarding/steps/generate_keys.rs
+++ b/crates/decman/src/workflow/onboarding/steps/generate_keys.rs
@@ -3,6 +3,7 @@ use canton_proto_rs::com::digitalasset::canton::{
     crypto::{
         admin::v30::{
             GenerateSigningKeyRequest, ListKeysFilters, ListMyKeysRequest,
+            generate_signing_key_response, private_key_metadata,
             vault_service_client::VaultServiceClient,
         },
         v30::{SigningKeySpec, SigningKeyUsage, SigningPublicKey, public_key},
@@ -146,14 +147,15 @@ pub(crate) async fn get_or_create_signing_key(
                 fingerprint: String::new(),
                 name: name.to_string(),
                 purpose: vec![],
-                usage: vec![usage as i32],
+                usage_v30: vec![usage as i32],
             }),
+            base_request: None,
         }))
         .await?
         .into_inner();
 
     for meta in existing.private_keys_metadata {
-        if let Some(pkn) = meta.public_key_with_name
+        if let Some(private_key_metadata::PublicKeyWithName::V30(pkn)) = meta.public_key_with_name
             && let Some(pk) = pkn.public_key
             && let Some(public_key::Key::SigningPublicKey(spk)) = pk.key
         {
@@ -174,13 +176,14 @@ pub(crate) async fn get_or_create_signing_key(
         .generate_signing_key(tonic::Request::new(GenerateSigningKeyRequest {
             key_spec: SigningKeySpec::Unspecified as i32,
             name: name.to_string(),
-            usage: vec![usage as i32],
+            usage_v30: vec![usage as i32],
+            base_request: None,
         }))
         .await?
         .into_inner();
-    let spk = response
-        .public_key
-        .ok_or_else(|| anyhow::anyhow!("No public key returned from VaultService"))?;
+    let Some(generate_signing_key_response::PublicKey::V30(spk)) = response.public_key else {
+        anyhow::bail!("No public key returned from VaultService");
+    };
     Ok((spk, false))
 }
 
@@ -227,6 +230,7 @@ async fn namespace_delegation_exists(
                 time_query: Some(base_query::TimeQuery::HeadState(())),
                 filter_signed_key: String::new(),
                 protocol_version: None,
+                client_version: None,
             }),
             filter_namespace: namespace_fingerprint.to_string(),
             filter_target_key_fingerprint: namespace_fingerprint.to_string(),
@@ -276,11 +280,11 @@ pub(crate) async fn propose_namespace_delegation(
             authorize_request::Proposal {
                 change: TopologyChangeOp::AddReplace as i32,
                 serial: 0,
-                mapping: Some(TopologyMapping {
+                mapping: Some(authorize_request::proposal::Mapping::V30(TopologyMapping {
                     mapping: Some(topology_mapping::Mapping::NamespaceDelegation(
                         namespace_delegation,
                     )),
-                }),
+                })),
             },
         )),
         must_fully_authorize: true,

--- a/crates/decman/src/workflow/onboarding/steps/proposals/create.rs
+++ b/crates/decman/src/workflow/onboarding/steps/proposals/create.rs
@@ -254,11 +254,11 @@ pub async fn create_proposals(
             authorize_request::Proposal {
                 change: enums::TopologyChangeOp::AddReplace as i32,
                 serial: 1,
-                mapping: Some(TopologyMapping {
+                mapping: Some(authorize_request::proposal::Mapping::V30(TopologyMapping {
                     mapping: Some(topology_mapping::Mapping::DecentralizedNamespaceDefinition(
                         namespace_def.clone(),
                     )),
-                }),
+                })),
             },
         )),
         must_fully_authorize: false,
@@ -282,9 +282,9 @@ pub async fn create_proposals(
             authorize_request::Proposal {
                 change: enums::TopologyChangeOp::AddReplace as i32,
                 serial: 0,
-                mapping: Some(TopologyMapping {
+                mapping: Some(authorize_request::proposal::Mapping::V30(TopologyMapping {
                     mapping: Some(topology_mapping::Mapping::PartyToParticipant(p2p_mapping)),
-                }),
+                })),
             },
         )),
         must_fully_authorize: false,

--- a/crates/decman/src/workflow/onboarding/steps/proposals/submit.rs
+++ b/crates/decman/src/workflow/onboarding/steps/proposals/submit.rs
@@ -141,6 +141,7 @@ async fn wait_for_dns_in_topology(
                 time_query: Some(base_query::TimeQuery::HeadState(())),
                 filter_signed_key: String::new(),
                 protocol_version: None,
+                client_version: None,
             }),
             filter_namespace: namespace.to_string(),
         });
@@ -455,6 +456,7 @@ async fn wait_for_p2p_in_topology(
                 time_query: Some(base_query::TimeQuery::HeadState(())),
                 filter_signed_key: String::new(),
                 protocol_version: None,
+                client_version: None,
             }),
             filter_party: party_id_str.clone(),
             filter_participant: String::new(),

--- a/crates/decman/src/workflow/topology.rs
+++ b/crates/decman/src/workflow/topology.rs
@@ -21,7 +21,7 @@ use canton_proto_rs::com::digitalasset::canton::{
         AddTransactionsRequest, AuthorizeRequest, AuthorizeResponse, BaseQuery,
         ListDecentralizedNamespaceDefinitionRequest, ListPartyToParticipantRequest,
         SignTransactionsRequest, SignTransactionsResponse, StoreId, Synchronizer, base_query,
-        store_id, synchronizer,
+        list_party_to_participant_response::result::Item as P2pItem, store_id, synchronizer,
         topology_manager_read_service_client::TopologyManagerReadServiceClient,
         topology_manager_write_service_client::TopologyManagerWriteServiceClient,
     },
@@ -197,6 +197,7 @@ pub fn head_state_query(synchronizer_id: &str) -> BaseQuery {
         time_query: Some(base_query::TimeQuery::HeadState(())),
         filter_signed_key: String::new(),
         protocol_version: None,
+        client_version: None,
     }
 }
 
@@ -242,7 +243,7 @@ pub async fn fetch_p2p_mapping(
     response
         .results
         .first()
-        .and_then(|r| r.item.as_ref())
+        .and_then(|r| r.item.as_ref().map(|P2pItem::V30(mapping)| mapping))
         .cloned()
         .ok_or_else(|| anyhow::anyhow!("No P2P mapping found for party {party_id}"))
 }


### PR DESCRIPTION
Companion to **DLC-link/canton-lib#28**, which replaces the whole vendored proto set with Canton v3.5.11. This is the DecMan side: pin it, and fix the fallout.

That tree had been patched file-by-file as needs arose and had drifted — of 121 vendored protos only 68 still matched upstream, and 45 upstream files were missing entirely. Syncing the lot is what surfaced everything below.

**No behaviour change is intended.** Every value here is the one that preserves what DecMan does today.

## Newly-required fields

63 across 13 files, all set to "unset":

| field | value |
|---|---|
| `stream_continuation_token`, `client_version`, `taps_max_passes`, `base_request`, `wait_for_allocation` | `None` |
| `descending_order` | `false` |
| `contract_key_hash` | `Vec::new()` |
| `implementation_package_id`, `filter_party` | `String::new()` |

Two needed a decision rather than a default:

- **`PrepareSubmissionRequest.hashing_scheme_version` → `None`.** The proto marks it `Required`, but [`SubmitRequestValidator`](https://github.com/digital-asset/canton/blob/v3.5.11/community/ledger/ledger-api-core/src/main/scala/com/digitalasset/canton/ledger/api/validation/SubmitRequestValidator.scala#L72-L77) treats *absent* as V2 "for backward compatibility" and **rejects** an explicit `UNSPECIFIED`. So `None` is correct and `0` would break every submission.
- **`AllocateExternalPartyRequest.user_id` → `String::new()`.** Giving this a real value is what unlocks external-party onboarding without a participant admin token — that's #302's job, not a proto adoption's.

## Versioning oneofs

Canton 3.5 wrapped several payloads in a oneof whose only arm is `v30`, so plain field reads become matches:

| was | now |
|---|---|
| `PrivateKeyMetadata.public_key_with_name` | `private_key_metadata::PublicKeyWithName::V30` |
| `GenerateSigningKeyResponse.public_key` | `generate_signing_key_response::PublicKey::V30` |
| `AuthorizeRequest.Proposal.mapping` | `authorize_request::proposal::Mapping::V30` |
| every topology list result's `.item` | `<response>::result::Item::V30` |

The topology ones are imported under short aliases (`P2pItem`, `NsDelegationItem`, `PartyToKeyItem`) so call sites stay readable and each file names the version arm once — ready for a `v31` arm without touching every read. Single-arm oneofs make every match exhaustive, so there's no new error path.

Plus the `ListKeysFilters` / `GenerateSigningKeyRequest` `usage` → `usage_v30` rename, and `ListKnownPartiesRequest.filter_party` (left empty — that call already filters client-side).

## What this touches, and how it's covered

The oneof changes land in topology reads and key handling, i.e. the paths behind onboarding, add-party, kick, and threshold changes. Those are exactly what the integration test exercises end to end, so CI is the real check here — `cargo check`/`clippy --all-targets --all-features -D warnings`/`fmt`/`machete` are all clean locally, but green ITs are the signal that matters.
## Sequencing

- **canton-lib#28 is merged** (`651ea52`), and this pins that commit on canton-lib `main` — no branch pins left here.
- Stacked on #308 (the Cargo Audit fix) so this PR's CI is fully green rather than inheriting `main`'s red. Base is `fix/audit-ignore-rkyv`; retarget to `main` once #308 merges, or just merge #308 first and this rebases cleanly.
- **Retires an orphan pin:** the 3.5.11 sync carries `ImportPartyAcsRequest` with exactly the field numbering the unmerged `fix/import-party-acs-canton-3.5.3` branch hand-patched, verified field for field. After this, nothing pins an unmerged canton-lib branch and that one can be closed.
- #302 (wallet library + demo + non-admin onboarding) still pins a now-orphaned canton-lib test branch and must be rebased onto this before it can merge — it needs the field fixes here to compile against 3.5.11.
