### PR TITLE
fix(ci): unbreak Cargo Audit on the unreachable rkyv advisory

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -15,4 +15,16 @@ ignore = [
   # by ratatui (the decman-cli TUI). Trivial compile-time proc-macro, no
   # runtime/security surface. Mirrors the ignore in deny.toml.
   "RUSTSEC-2024-0436",
+  # rkyv 0.7 is an *optional* dependency of rust_decimal (behind its `rkyv`
+  # feature, which nothing here enables), so it is recorded in Cargo.lock but
+  # never compiled: `cargo tree -e normal -i rkyv --target all --all-features`
+  # finds no path to it, and cargo-deny does not flag it. The advisory is an
+  # out-of-bounds read while *deserializing* an rkyv archive; we never call
+  # rkyv, and no untrusted archive reaches it.
+  #
+  # Not fixable by upgrading: rust_decimal requires `rkyv ^0.7.46` and the fix
+  # only landed in 0.8.17, a semver break, so the bump has to come from
+  # rust_decimal upstream. Latest (1.42.1) still requires 0.7. Drop this ignore
+  # once it moves.
+  "RUSTSEC-2026-0235",
 ]


### PR DESCRIPTION
`main` has been failing **Cargo Audit** since a new advisory landed — `f4822b5` and the two commits before it — with no change on our side. Every open PR inherits the red.

## What it is

`RUSTSEC-2026-0235`: an out-of-bounds read while *deserializing* an rkyv archive containing `Rc`/`Arc`, in `rkyv 0.7.46`.

## Why it isn't reachable

`rkyv` is an **optional** dependency of `rust_decimal`, behind a feature nothing in this workspace enables. It is recorded in `Cargo.lock` — which is all cargo-audit reads — but never compiled:

```
$ cargo tree -e normal -i rkyv --target all --all-features
warning: nothing to print.
```

cargo-deny, which respects feature gating, does not flag it — and indeed **Cargo Deny passes** on the same commits where Cargo Audit fails. We never call rkyv, so no untrusted archive reaches the vulnerable path.

## Why not just upgrade

`rust_decimal` requires `rkyv ^0.7.46`; the fix landed in **0.8.17**, a semver break:

```
$ cargo update -p rkyv --precise 0.8.17
error: failed to select a version for the requirement `rkyv = "^0.7.46"`
candidate versions found which didn't match: 0.8.17
required by package `rust_decimal v1.42.0`
```

I also checked the newest `rust_decimal` (1.42.1) — still on `rkyv ^0.7`. So the bump has to come from upstream; there is nothing to upgrade here.

## The change

One ignore in `.cargo/audit.toml` with that reasoning recorded, matching the two entries already there (`rsa` via unused `sqlx-mysql`, `paste` via `ratatui`) which are justified the same way — plus a note to drop it when `rust_decimal` moves to rkyv 0.8.

Verified locally: `cargo audit` exits 0, leaving only the two pre-existing allowed warnings (`event-listener` unsound, `spin` yanked).

Once this merges, #302 and #307 go fully green on rebase.