### PR TITLE
perf(canton): use 3.5.1 query pagination for ACS and update reads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,15 @@ jobs:
       # build doesn't itself try to build the frontend.
       - name: Generate frontend TypeScript bindings
         run: DECMAN_SKIP_FRONTEND=1 cargo run -p decman --all-features --bin gen-types
+      # Frontend unit tests (vitest). Runs after the bindings step above, which
+      # writes the gitignored types.generated.ts the tests read PAGE_SIZE from.
+      # Installs only on a cold npm cache, same as build.rs does — `npm ci`
+      # unconditionally would wipe the restored node_modules on every run.
+      - name: Frontend tests
+        working-directory: crates/decman/frontend
+        run: |
+          [ -d node_modules ] || npm ci
+          npm test
       - name: cargo fmt
         run: cargo fmt -- --check
       # Build the test binaries first (rlibs + sidecar rmeta) so both

--- a/crates/common/src/api.rs
+++ b/crates/common/src/api.rs
@@ -21,6 +21,12 @@ use crate::{
     },
 };
 
+/// Rows per page for every paginated list, on the wire and in the UI. Drives
+/// the Canton `max_page_size` on ledger-API reads and the frontend's page size
+/// (re-exported into `types.generated.ts` by `gen-types`, so the two cannot
+/// drift). `i32` to match the ledger API's page-size fields.
+pub const PAGE_SIZE: i32 = 25;
+
 // ============================================================================
 // Config DTOs (shared with the server's config layer)
 // ============================================================================
@@ -1330,4 +1336,7 @@ pub struct ChainAuditEntry {
 pub struct ChainAuditResponse {
     pub entries: Vec<ChainAuditEntry>,
     pub total_returned: usize,
+    /// Cursor for the next (older) page: pass back as `before_offset`. `None`
+    /// when the page was short, i.e. there is nothing older left to read.
+    pub next_before_offset: Option<i64>,
 }

--- a/crates/decman/frontend/package-lock.json
+++ b/crates/decman/frontend/package-lock.json
@@ -22,6 +22,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@testing-library/react": "^16.3.2",
         "@types/node": "^25.7.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -30,12 +31,67 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.6.0",
+        "jsdom": "^30.0.1",
         "typescript": "~6.0.3",
         "typescript-eslint": "^8.59.3",
-        "vite": "^8.0.16"
+        "vite": "^8.0.16",
+        "vitest": "^4.1.10"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
+      "integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.3.0",
+        "@csstools/css-color-parser": "^4.1.10",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/@auth0/auth0-auth-js": {
@@ -317,6 +373,159 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+      "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -625,6 +834,24 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@fontsource/space-grotesk": {
@@ -1284,6 +1511,62 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
@@ -1294,6 +1577,32 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
@@ -1641,6 +1950,126 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1681,6 +2110,52 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/babel-plugin-macros": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
@@ -1717,6 +2192,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -1805,6 +2290,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/clsx": {
       "version": "2.1.1",
@@ -1902,11 +2397,54 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1925,12 +2463,30 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -1941,6 +2497,14 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -1968,6 +2532,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
@@ -1991,6 +2568,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -2186,6 +2770,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2194,6 +2788,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2396,6 +3000,19 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2476,6 +3093,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2497,6 +3121,57 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+        "@exodus/bytes": "^1.15.1",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.9.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^17.1.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.2.3"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -2900,6 +3575,34 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -2971,6 +3674,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/openid-client": {
@@ -3066,6 +3783,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3100,6 +3830,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -3158,6 +3895,30 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -3255,6 +4016,16 @@
         "react-dom": ">=16.6.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
@@ -3326,6 +4097,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -3365,6 +4149,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/simple-swizzle": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
@@ -3399,6 +4190,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stylis": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
@@ -3417,6 +4222,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -3432,6 +4261,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
+      "integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.10"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -3504,6 +4389,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {
@@ -3632,6 +4527,144 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3648,6 +4681,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -3657,6 +4707,23 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/crates/decman/frontend/package.json
+++ b/crates/decman/frontend/package.json
@@ -12,6 +12,7 @@
     "dev:mock": "MOCK=true vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "test": "vitest run",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -28,6 +29,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^25.7.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
@@ -36,8 +38,10 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.6.0",
+    "jsdom": "^30.0.1",
     "typescript": "~6.0.3",
     "typescript-eslint": "^8.59.3",
-    "vite": "^8.0.16"
+    "vite": "^8.0.16",
+    "vitest": "^4.1.10"
   }
 }

--- a/crates/decman/frontend/src/components/ExternalPartyList.tsx
+++ b/crates/decman/frontend/src/components/ExternalPartyList.tsx
@@ -8,6 +8,8 @@ import {
   Typography,
 } from "@mui/material";
 import { CopyableText } from "./CopyableText";
+import { PaginationControls } from "./Pagination";
+import { usePagination } from "../usePagination";
 import { zebraRow } from "../styles";
 import type { ExternalPartyInfo } from "../types";
 
@@ -16,6 +18,8 @@ interface ExternalPartyListProps {
 }
 
 export const ExternalPartyList = ({ parties }: ExternalPartyListProps) => {
+  const { page, setPage, pageCount, pageItems, total } = usePagination(parties);
+
   if (parties.length === 0) {
     return (
       <Typography
@@ -41,7 +45,7 @@ export const ExternalPartyList = ({ parties }: ExternalPartyListProps) => {
           </TableRow>
         </TableHead>
         <TableBody>
-          {parties.map((party, idx) => (
+          {pageItems.map((party, idx) => (
             <TableRow key={party.party_id} sx={{ ...zebraRow(idx) }}>
               <TableCell sx={{ py: 1.5 }}>
                 <CopyableText
@@ -66,6 +70,12 @@ export const ExternalPartyList = ({ parties }: ExternalPartyListProps) => {
           ))}
         </TableBody>
       </Table>
+      <PaginationControls
+        page={page}
+        pageCount={pageCount}
+        total={total}
+        onChange={setPage}
+      />
     </Box>
   );
 };

--- a/crates/decman/frontend/src/components/GovernanceAuditTrail.tsx
+++ b/crates/decman/frontend/src/components/GovernanceAuditTrail.tsx
@@ -34,8 +34,10 @@ interface GovernanceAuditTrailProps {
   /// trigger a fresh fetch.
   refreshNonce?: number;
   /// Reports the loaded entry count to the parent so it can render a badge in
-  /// the section header (matches the Contracts pattern).
-  onCountChange?: (count: number) => void;
+  /// the section header (matches the Contracts pattern). `hasMore` says whether
+  /// older entries exist beyond this page — a page can legally hold more than
+  /// `CHAIN_LIMIT` rows, so the count alone can't tell the parent that.
+  onCountChange?: (count: number, hasMore: boolean) => void;
   /// Reports fetch in-flight state up so the parent can disable its Refresh
   /// icon while a request is pending.
   onLoadingChange?: (loading: boolean) => void;
@@ -225,6 +227,12 @@ export const GovernanceAuditTrail = ({
     fetchAudit(true);
   }, [refreshNonce, fetchAudit]);
 
+  // A new page is read from its top, same as the client-paged views — see
+  // `usePagination`, which scrolls for the same reason.
+  const scrollToFirstRow = useCallback(() => {
+    scrollRef.current?.scrollTo({ top: 0 });
+  }, []);
+
   // Both advance the page only once the fetch has landed. Moving first would
   // leave the indicator and the cursor stack describing a page whose rows
   // never arrived, and the next Prev would then walk from the wrong cursor.
@@ -234,19 +242,21 @@ export const GovernanceAuditTrail = ({
     if (await fetchAudit(false, cursor)) {
       setCursors((prev) => [...prev.slice(0, page + 1), cursor]);
       setPage(page + 1);
+      scrollToFirstRow();
     }
-  }, [nextCursor, page, fetchAudit]);
+  }, [nextCursor, page, fetchAudit, scrollToFirstRow]);
 
   const goToPrevPage = useCallback(async () => {
     if (page === 0) return;
     if (await fetchAudit(false, cursors[page - 1])) {
       setPage(page - 1);
+      scrollToFirstRow();
     }
-  }, [page, cursors, fetchAudit]);
+  }, [page, cursors, fetchAudit, scrollToFirstRow]);
 
   useEffect(() => {
-    onCountChange?.(entries.length);
-  }, [entries.length, onCountChange]);
+    onCountChange?.(entries.length, nextCursor !== null);
+  }, [entries.length, nextCursor, onCountChange]);
 
   useEffect(() => {
     onLoadingChange?.(loading);

--- a/crates/decman/frontend/src/components/GovernanceAuditTrail.tsx
+++ b/crates/decman/frontend/src/components/GovernanceAuditTrail.tsx
@@ -20,10 +20,11 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import { JSONTree } from "react-json-tree";
-import { API_BASE } from "../constants";
+import { API_BASE, PAGE_SIZE } from "../constants";
 import { authenticatedFetch } from "../api";
 import { zebraRow } from "../styles";
 import { CopyableText } from "./CopyableText";
+import { CursorPagination } from "./Pagination";
 import type { ChainAuditEntry, ChainAuditResponse } from "../types";
 
 interface GovernanceAuditTrailProps {
@@ -40,7 +41,7 @@ interface GovernanceAuditTrailProps {
   onLoadingChange?: (loading: boolean) => void;
 }
 
-export const CHAIN_LIMIT = 200;
+export const CHAIN_LIMIT = PAGE_SIZE;
 
 const formatTimestamp = (epochSeconds: number): string =>
   new Date(epochSeconds * 1000).toLocaleString();
@@ -135,6 +136,12 @@ export const GovernanceAuditTrail = ({
   );
   const [expandedRow, setExpandedRow] = useState<string | null>(null);
   const [cacheLoaded, setCacheLoaded] = useState(false);
+  // One cursor per visited page. Index 0 is `undefined` (newest page); each
+  // Next pushes the `next_before_offset` the server handed back, so Previous
+  // is a pop rather than a re-query from the top.
+  const [cursors, setCursors] = useState<(number | undefined)[]>([undefined]);
+  const [page, setPage] = useState(0);
+  const [nextCursor, setNextCursor] = useState<number | null>(null);
   const [canScrollUp, setCanScrollUp] = useState(false);
   const [canScrollDown, setCanScrollDown] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -162,15 +169,22 @@ export const GovernanceAuditTrail = ({
   }, [entries, updateScrollShadows]);
 
   const fetchAudit = useCallback(
-    async (refresh: boolean) => {
+    async (refresh: boolean, before?: number) => {
       setLoading(true);
       setError(null);
+      // A refresh pulls in events newer than anything we've paged past, which
+      // invalidates every cursor below — start the stack over at the top.
+      if (refresh && before === undefined) {
+        setCursors([undefined]);
+        setPage(0);
+      }
       try {
         const params = new URLSearchParams({
           party_id: partyId,
           limit: String(CHAIN_LIMIT),
         });
         if (refresh) params.set("refresh", "true");
+        if (before !== undefined) params.set("before_offset", String(before));
 
         const res = await authenticatedFetch(
           `${API_BASE}/governance/chain-audit?${params}`,
@@ -178,6 +192,7 @@ export const GovernanceAuditTrail = ({
         if (res.ok) {
           const response: ChainAuditResponse = await res.json();
           setEntries(response.entries);
+          setNextCursor(response.next_before_offset ?? null);
         } else {
           const errData = await res.json().catch(() => ({}));
           setError(errData.error || "Failed to fetch audit trail");
@@ -207,6 +222,19 @@ export const GovernanceAuditTrail = ({
     if (refreshNonce === undefined || refreshNonce === 0) return;
     fetchAudit(true);
   }, [refreshNonce, fetchAudit]);
+
+  const goToNextPage = useCallback(() => {
+    if (nextCursor === null) return;
+    setCursors((prev) => [...prev.slice(0, page + 1), nextCursor]);
+    setPage(page + 1);
+    fetchAudit(false, nextCursor);
+  }, [nextCursor, page, fetchAudit]);
+
+  const goToPrevPage = useCallback(() => {
+    if (page === 0) return;
+    setPage(page - 1);
+    fetchAudit(false, cursors[page - 1]);
+  }, [page, cursors, fetchAudit]);
 
   useEffect(() => {
     onCountChange?.(entries.length);
@@ -458,6 +486,13 @@ export const GovernanceAuditTrail = ({
           />
         </Box>
       )}
+      <CursorPagination
+        page={page}
+        hasNext={nextCursor !== null}
+        disabled={loading}
+        onPrev={goToPrevPage}
+        onNext={goToNextPage}
+      />
     </Box>
   );
 };

--- a/crates/decman/frontend/src/components/GovernanceAuditTrail.tsx
+++ b/crates/decman/frontend/src/components/GovernanceAuditTrail.tsx
@@ -169,7 +169,7 @@ export const GovernanceAuditTrail = ({
   }, [entries, updateScrollShadows]);
 
   const fetchAudit = useCallback(
-    async (refresh: boolean, before?: number) => {
+    async (refresh: boolean, before?: number): Promise<boolean> => {
       setLoading(true);
       setError(null);
       // A refresh pulls in events newer than anything we've paged past, which
@@ -193,14 +193,16 @@ export const GovernanceAuditTrail = ({
           const response: ChainAuditResponse = await res.json();
           setEntries(response.entries);
           setNextCursor(response.next_before_offset ?? null);
-        } else {
-          const errData = await res.json().catch(() => ({}));
-          setError(errData.error || "Failed to fetch audit trail");
+          return true;
         }
+        const errData = await res.json().catch(() => ({}));
+        setError(errData.error || "Failed to fetch audit trail");
+        return false;
       } catch (e) {
         setError(
           e instanceof Error ? e.message : "Failed to fetch audit trail",
         );
+        return false;
       } finally {
         setLoading(false);
       }
@@ -223,17 +225,23 @@ export const GovernanceAuditTrail = ({
     fetchAudit(true);
   }, [refreshNonce, fetchAudit]);
 
-  const goToNextPage = useCallback(() => {
+  // Both advance the page only once the fetch has landed. Moving first would
+  // leave the indicator and the cursor stack describing a page whose rows
+  // never arrived, and the next Prev would then walk from the wrong cursor.
+  const goToNextPage = useCallback(async () => {
     if (nextCursor === null) return;
-    setCursors((prev) => [...prev.slice(0, page + 1), nextCursor]);
-    setPage(page + 1);
-    fetchAudit(false, nextCursor);
+    const cursor = nextCursor;
+    if (await fetchAudit(false, cursor)) {
+      setCursors((prev) => [...prev.slice(0, page + 1), cursor]);
+      setPage(page + 1);
+    }
   }, [nextCursor, page, fetchAudit]);
 
-  const goToPrevPage = useCallback(() => {
+  const goToPrevPage = useCallback(async () => {
     if (page === 0) return;
-    setPage(page - 1);
-    fetchAudit(false, cursors[page - 1]);
+    if (await fetchAudit(false, cursors[page - 1])) {
+      setPage(page - 1);
+    }
   }, [page, cursors, fetchAudit]);
 
   useEffect(() => {

--- a/crates/decman/frontend/src/components/HoldingsSection.tsx
+++ b/crates/decman/frontend/src/components/HoldingsSection.tsx
@@ -212,6 +212,7 @@ export const HoldingsSection = ({
         pageCount={pageCount}
         total={total}
         onChange={setPage}
+        sx={{ px: 3 }}
       />
     </Box>
   );

--- a/crates/decman/frontend/src/components/HoldingsSection.tsx
+++ b/crates/decman/frontend/src/components/HoldingsSection.tsx
@@ -131,82 +131,87 @@ export const HoldingsSection = ({
   }
 
   return (
-    <Box sx={{ overflowX: "auto" }}>
-      <Table size="small">
-        <TableHead>
-          <TableRow>
-            <TableCell sx={{ py: 1 }}>
-              <TextHelp text="The token's id (for Canton Coin this is 'Amulet', displayed as 'CC' here).">
-                Asset
-              </TextHelp>
-            </TableCell>
-            <TableCell sx={{ py: 1 }}>
-              <TextHelp text="The party that issues / administers the token.">
-                Admin
-              </TextHelp>
-            </TableCell>
-            <TableCell sx={{ py: 1 }} align="right">
-              <TextHelp text="Total amount this party holds for the asset, summed across all Holding contracts.">
-                Amount
-              </TextHelp>
-            </TableCell>
-            <TableCell sx={{ py: 1 }}>
-              <TextHelp text="Whether a TransferPreapproval exists for this party on this instrument — needed to receive transfers without manual accept.">
-                Preapproval set up
-              </TextHelp>
-            </TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {pageItems.map((h, idx) => (
-            <TableRow
-              key={`${h.instrument_admin}::${h.instrument_id}`}
-              sx={zebraRow(idx)}
-            >
-              <TableCell
-                sx={{ py: 1, fontFamily: "monospace", fontSize: "0.85rem" }}
-              >
-                {/* Canton Coin's instrument id on the Splice token-standard
-                  * is the literal "Amulet" — display it as "CC" since that's
-                  * what users actually call it everywhere else in the UI. */}
-                {h.instrument_id === "Amulet" ? "CC" : h.instrument_id}
+    // The horizontal scroller wraps the table only: an overflow ancestor would
+    // capture the footer's `position: sticky` and pin it to a box that never
+    // scrolls vertically.
+    <Box>
+      <Box sx={{ overflowX: "auto" }}>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell sx={{ py: 1 }}>
+                <TextHelp text="The token's id (for Canton Coin this is 'Amulet', displayed as 'CC' here).">
+                  Asset
+                </TextHelp>
               </TableCell>
               <TableCell sx={{ py: 1 }}>
-                <CopyableText
-                  text={h.instrument_admin}
-                  truncate={{ start: 8, end: 8 }}
-                  variant="caption"
-                />
+                <TextHelp text="The party that issues / administers the token.">
+                  Admin
+                </TextHelp>
               </TableCell>
-              <TableCell
-                sx={{
-                  py: 1,
-                  fontFamily: "monospace",
-                  fontSize: "0.85rem",
-                }}
-                align="right"
-              >
-                {h.amount}
-                {Number(h.locked_amount) > 0 && (
-                  <Box
-                    component="span"
-                    sx={{ color: "warning.main", ml: 0.5 }}
-                  >
-                    ({h.locked_amount} locked)
-                  </Box>
-                )}
+              <TableCell sx={{ py: 1 }} align="right">
+                <TextHelp text="Total amount this party holds for the asset, summed across all Holding contracts.">
+                  Amount
+                </TextHelp>
               </TableCell>
               <TableCell sx={{ py: 1 }}>
-                <Chip
-                  label={h.preapproval_set_up ? "Yes" : "No"}
-                  size="small"
-                  color={h.preapproval_set_up ? "success" : "default"}
-                />
+                <TextHelp text="Whether a TransferPreapproval exists for this party on this instrument — needed to receive transfers without manual accept.">
+                  Preapproval set up
+                </TextHelp>
               </TableCell>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+          </TableHead>
+          <TableBody>
+            {pageItems.map((h, idx) => (
+              <TableRow
+                key={`${h.instrument_admin}::${h.instrument_id}`}
+                sx={zebraRow(idx)}
+              >
+                <TableCell
+                  sx={{ py: 1, fontFamily: "monospace", fontSize: "0.85rem" }}
+                >
+                  {/* Canton Coin's instrument id on the Splice token-standard
+                    * is the literal "Amulet" — display it as "CC" since that's
+                    * what users actually call it everywhere else in the UI. */}
+                  {h.instrument_id === "Amulet" ? "CC" : h.instrument_id}
+                </TableCell>
+                <TableCell sx={{ py: 1 }}>
+                  <CopyableText
+                    text={h.instrument_admin}
+                    truncate={{ start: 8, end: 8 }}
+                    variant="caption"
+                  />
+                </TableCell>
+                <TableCell
+                  sx={{
+                    py: 1,
+                    fontFamily: "monospace",
+                    fontSize: "0.85rem",
+                  }}
+                  align="right"
+                >
+                  {h.amount}
+                  {Number(h.locked_amount) > 0 && (
+                    <Box
+                      component="span"
+                      sx={{ color: "warning.main", ml: 0.5 }}
+                    >
+                      ({h.locked_amount} locked)
+                    </Box>
+                  )}
+                </TableCell>
+                <TableCell sx={{ py: 1 }}>
+                  <Chip
+                    label={h.preapproval_set_up ? "Yes" : "No"}
+                    size="small"
+                    color={h.preapproval_set_up ? "success" : "default"}
+                  />
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Box>
       <PaginationControls
         page={page}
         pageCount={pageCount}

--- a/crates/decman/frontend/src/components/HoldingsSection.tsx
+++ b/crates/decman/frontend/src/components/HoldingsSection.tsx
@@ -18,6 +18,8 @@ import { TextHelp } from "./FieldHelp";
 import { API_BASE } from "../constants";
 import { authenticatedFetch } from "../api";
 import { zebraRow } from "../styles";
+import { PaginationControls } from "./Pagination";
+import { usePagination } from "../usePagination";
 import type { Holding, HoldingsResponse } from "../types";
 
 interface HoldingsSectionProps {
@@ -41,6 +43,7 @@ export const HoldingsSection = ({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [holdings, setHoldings] = useState<Holding[]>([]);
+  const { page, setPage, pageCount, pageItems, total } = usePagination(holdings);
 
   const fetchHoldings = useCallback(async () => {
     setLoading(true);
@@ -155,7 +158,7 @@ export const HoldingsSection = ({
           </TableRow>
         </TableHead>
         <TableBody>
-          {holdings.map((h, idx) => (
+          {pageItems.map((h, idx) => (
             <TableRow
               key={`${h.instrument_admin}::${h.instrument_id}`}
               sx={zebraRow(idx)}
@@ -204,6 +207,12 @@ export const HoldingsSection = ({
           ))}
         </TableBody>
       </Table>
+      <PaginationControls
+        page={page}
+        pageCount={pageCount}
+        total={total}
+        onChange={setPage}
+      />
     </Box>
   );
 };

--- a/crates/decman/frontend/src/components/NotificationsView.tsx
+++ b/crates/decman/frontend/src/components/NotificationsView.tsx
@@ -2025,6 +2025,7 @@ export const NotificationsView = ({
         pageCount={pageCount}
         total={total}
         onChange={setPage}
+        sx={{ px: 0 }}
       />
     </Box>
   );

--- a/crates/decman/frontend/src/components/NotificationsView.tsx
+++ b/crates/decman/frontend/src/components/NotificationsView.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import {
   Alert,
   Box,
@@ -19,6 +19,8 @@ import { copyToClipboard } from "../clipboard";
 import { useSnackbar } from "../contexts";
 import { formatActionDetails, formatActionType } from "../governanceFormat";
 import { ExecuteDialog } from "./ExecuteDialog";
+import { PaginationControls } from "./Pagination";
+import { usePagination } from "../usePagination";
 import type {
   CancelConfirmationRequest,
   ConfirmActionRequest,
@@ -1915,17 +1917,9 @@ export const NotificationsView = ({
   onWorkflowsChanged,
   onSelectParty,
 }: NotificationsViewProps) => {
-  if (loading) {
-    return (
-      <Box sx={{ display: "flex", flexDirection: "column", gap: 1, p: 3 }}>
-        <NotificationSkeleton />
-        <NotificationSkeleton />
-        <NotificationSkeleton />
-      </Box>
-    );
-  }
-
-  const feed: FeedEntry[] = [
+  // Built above the loading early-return so the pagination hook below runs on
+  // every render, loading or not.
+  const feed: FeedEntry[] = useMemo(() => [
     ...pendingInvitations.map<FeedEntry>((invitation) => ({
       kind: "invitation",
       ts: invitation.received_at,
@@ -1958,8 +1952,19 @@ export const NotificationsView = ({
       ts: run.updated_at,
       run,
     })),
-  ];
-  feed.sort((a, b) => b.ts - a.ts);
+  ].sort((a, b) => b.ts - a.ts), [pendingInvitations, partyActions, workflowRuns]);
+
+  const { page, setPage, pageCount, pageItems, total } = usePagination(feed);
+
+  if (loading) {
+    return (
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 1, p: 3 }}>
+        <NotificationSkeleton />
+        <NotificationSkeleton />
+        <NotificationSkeleton />
+      </Box>
+    );
+  }
 
   if (feed.length === 0) {
     return (
@@ -1973,7 +1978,7 @@ export const NotificationsView = ({
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 1, p: 3 }}>
-      {feed.map((entry) => {
+      {pageItems.map((entry) => {
         if (entry.kind === "invitation") {
           return (
             <InvitationCard
@@ -2015,6 +2020,12 @@ export const NotificationsView = ({
           />
         );
       })}
+      <PaginationControls
+        page={page}
+        pageCount={pageCount}
+        total={total}
+        onChange={setPage}
+      />
     </Box>
   );
 };

--- a/crates/decman/frontend/src/components/PackagesPanel.tsx
+++ b/crates/decman/frontend/src/components/PackagesPanel.tsx
@@ -105,6 +105,8 @@ export const PackagesPanel = ({
 
   const localPaging = usePagination(filteredSorted);
   const comparisonPaging = usePagination(sortedComparison);
+  // The peer-comparison view swaps in its own table, so it pages its own rows.
+  const paging = comparison ? comparisonPaging : localPaging;
 
   const updateScrollShadows = useCallback(() => {
     const el = scrollRef.current;
@@ -436,21 +438,13 @@ export const PackagesPanel = ({
             }}
           />
         </Box>
-        {comparison ? (
-          <PaginationControls
-            page={comparisonPaging.page}
-            pageCount={comparisonPaging.pageCount}
-            total={comparisonPaging.total}
-            onChange={comparisonPaging.setPage}
-          />
-        ) : (
-          <PaginationControls
-            page={localPaging.page}
-            pageCount={localPaging.pageCount}
-            total={localPaging.total}
-            onChange={localPaging.setPage}
-          />
-        )}
+        <PaginationControls
+          page={paging.page}
+          pageCount={paging.pageCount}
+          total={paging.total}
+          onChange={paging.setPage}
+          sx={{ px: 3 }}
+        />
     </Box>
   );
 };

--- a/crates/decman/frontend/src/components/PackagesPanel.tsx
+++ b/crates/decman/frontend/src/components/PackagesPanel.tsx
@@ -21,6 +21,8 @@ import SignalWifiOffIcon from "@mui/icons-material/SignalWifiOff";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import ErrorIcon from "@mui/icons-material/Error";
 import { CopyableText } from "./CopyableText";
+import { PaginationControls } from "./Pagination";
+import { usePagination } from "../usePagination";
 import { API_BASE } from "../constants";
 import { authenticatedFetch } from "../api";
 import { zebraRow } from "../styles";
@@ -95,6 +97,14 @@ export const PackagesPanel = ({
       (p.name || "").toLowerCase().includes(q),
     );
   }, [comparison, search]);
+
+  const sortedComparison = useMemo(
+    () => [...(filteredComparison ?? [])].sort((a, b) => a.name.localeCompare(b.name)),
+    [filteredComparison],
+  );
+
+  const localPaging = usePagination(filteredSorted);
+  const comparisonPaging = usePagination(sortedComparison);
 
   const updateScrollShadows = useCallback(() => {
     const el = scrollRef.current;
@@ -321,9 +331,7 @@ export const PackagesPanel = ({
                   </TableRow>
                 </TableHead>
                 <TableBody>
-                  {(filteredComparison ?? [])
-                    .slice()
-                    .sort((a, b) => a.name.localeCompare(b.name))
+                  {comparisonPaging.pageItems
                     .map((pkg, idx) => (
                       <TableRow key={pkg.package_id} sx={zebraRow(idx)}>
                         <TableCell sx={{ py: 0.75 }}>
@@ -391,7 +399,7 @@ export const PackagesPanel = ({
                   </TableRow>
                 </TableHead>
                 <TableBody>
-                  {filteredSorted.map((p, idx) => (
+                  {localPaging.pageItems.map((p, idx) => (
                     <TableRow key={p.package_id} sx={zebraRow(idx)}>
                       <TableCell sx={{ py: 1 }}>
                         {p.package_name || "-"}
@@ -428,6 +436,21 @@ export const PackagesPanel = ({
             }}
           />
         </Box>
+        {comparison ? (
+          <PaginationControls
+            page={comparisonPaging.page}
+            pageCount={comparisonPaging.pageCount}
+            total={comparisonPaging.total}
+            onChange={comparisonPaging.setPage}
+          />
+        ) : (
+          <PaginationControls
+            page={localPaging.page}
+            pageCount={localPaging.pageCount}
+            total={localPaging.total}
+            onChange={localPaging.setPage}
+          />
+        )}
     </Box>
   );
 };

--- a/crates/decman/frontend/src/components/PackagesPanel.tsx
+++ b/crates/decman/frontend/src/components/PackagesPanel.tsx
@@ -103,8 +103,10 @@ export const PackagesPanel = ({
     [filteredComparison],
   );
 
-  const localPaging = usePagination(filteredSorted);
-  const comparisonPaging = usePagination(sortedComparison);
+  // This panel scrolls its rows in `scrollRef`, not the window, so paging has to
+  // reset that container rather than the document.
+  const localPaging = usePagination(filteredSorted, scrollRef);
+  const comparisonPaging = usePagination(sortedComparison, scrollRef);
   // The peer-comparison view swaps in its own table, so it pages its own rows.
   const paging = comparison ? comparisonPaging : localPaging;
 

--- a/crates/decman/frontend/src/components/Pagination.tsx
+++ b/crates/decman/frontend/src/components/Pagination.tsx
@@ -27,6 +27,15 @@ const footerSx = {
   mt: 0.5,
   borderTop: 1,
   borderColor: "divider",
+  // Pinned to the bottom of whatever scrolls. Pages differ in height — the
+  // last one is usually short — so a static footer jumps out of view the
+  // moment you change page and has to be chased back down. Needs an opaque
+  // fill so rows don't show through it while they scroll past. A no-op in
+  // containers that don't scroll (the Packages panel already pins it).
+  position: "sticky",
+  bottom: 0,
+  zIndex: 2,
+  bgcolor: "background.paper",
 };
 
 const rangeSx = {

--- a/crates/decman/frontend/src/components/Pagination.tsx
+++ b/crates/decman/frontend/src/components/Pagination.tsx
@@ -1,0 +1,98 @@
+import { Box, IconButton, Typography } from "@mui/material";
+import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
+import { PAGE_SIZE } from "../constants";
+
+const controlsSx = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "flex-end",
+  gap: 1,
+  pt: 1,
+};
+
+/** Range and prev/next for a client-side paged list, from `usePagination`. */
+export const PaginationControls = ({
+  page,
+  pageCount,
+  total,
+  onChange,
+}: {
+  page: number;
+  pageCount: number;
+  total: number;
+  onChange: (page: number) => void;
+}) => {
+  if (total <= PAGE_SIZE) return null;
+
+  const first = page * PAGE_SIZE + 1;
+  const last = Math.min(total, (page + 1) * PAGE_SIZE);
+
+  return (
+    <Box sx={controlsSx}>
+      <Typography variant="caption" color="text.secondary">
+        {first}–{last} of {total}
+      </Typography>
+      <IconButton
+        size="small"
+        aria-label="Previous page"
+        disabled={page === 0}
+        onClick={() => onChange(page - 1)}
+      >
+        <ChevronLeftIcon fontSize="small" />
+      </IconButton>
+      <IconButton
+        size="small"
+        aria-label="Next page"
+        disabled={page >= pageCount - 1}
+        onClick={() => onChange(page + 1)}
+      >
+        <ChevronRightIcon fontSize="small" />
+      </IconButton>
+    </Box>
+  );
+};
+
+/**
+ * Prev/next for a cursor-paged endpoint, where the total is unknown — the
+ * server only says whether an older page exists.
+ */
+export const CursorPagination = ({
+  page,
+  hasNext,
+  disabled,
+  onPrev,
+  onNext,
+}: {
+  page: number;
+  hasNext: boolean;
+  disabled?: boolean;
+  onPrev: () => void;
+  onNext: () => void;
+}) => {
+  if (page === 0 && !hasNext) return null;
+
+  return (
+    <Box sx={controlsSx}>
+      <Typography variant="caption" color="text.secondary">
+        Page {page + 1}
+      </Typography>
+      <IconButton
+        size="small"
+        aria-label="Previous page"
+        disabled={disabled || page === 0}
+        onClick={onPrev}
+      >
+        <ChevronLeftIcon fontSize="small" />
+      </IconButton>
+      <IconButton
+        size="small"
+        aria-label="Next page"
+        disabled={disabled || !hasNext}
+        onClick={onNext}
+      >
+        <ChevronRightIcon fontSize="small" />
+      </IconButton>
+    </Box>
+  );
+};

--- a/crates/decman/frontend/src/components/Pagination.tsx
+++ b/crates/decman/frontend/src/components/Pagination.tsx
@@ -1,27 +1,98 @@
-import { Box, IconButton, Typography } from "@mui/material";
+import { Box, IconButton, Pagination, Tooltip, Typography } from "@mui/material";
+import type { SxProps } from "@mui/material";
+import { alpha, type Theme } from "@mui/material/styles";
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import { PAGE_SIZE } from "../constants";
 
-const controlsSx = {
+// Numerics are monospaced so page numbers and ranges don't reflow as digits
+// change width. Matches the `monospace` stack used for ids and amounts
+// elsewhere in the app.
+const MONO = "ui-monospace, SFMono-Regular, Menlo, monospace";
+
+/**
+ * Footer bar the table sits on: top rule, range on the left, controls right.
+ *
+ * Horizontal padding is overridable because the containers this drops into pad
+ * their content differently — the bar has to line up with the rows above it.
+ */
+const footerSx = {
   display: "flex",
   alignItems: "center",
-  justifyContent: "flex-end",
-  gap: 1,
-  pt: 1,
+  justifyContent: "space-between",
+  flexWrap: "wrap",
+  gap: 1.5,
+  px: 2,
+  py: 1.25,
+  mt: 0.5,
+  borderTop: 1,
+  borderColor: "divider",
 };
 
-/** Range and prev/next for a client-side paged list, from `usePagination`. */
+const rangeSx = {
+  fontFamily: MONO,
+  fontSize: "0.75rem",
+  letterSpacing: "0.02em",
+  color: "text.secondary",
+  fontVariantNumeric: "tabular-nums",
+};
+
+/**
+ * Pill styling for the page items.
+ *
+ * The selected page is an accent *tint* with accent text rather than a solid
+ * accent fill: the brand's action orange doesn't clear AA against white at this
+ * size, so white-on-orange numerals would be unreadable.
+ */
+const paginationSx = {
+  "& .MuiPagination-ul": { flexWrap: "nowrap" },
+  "& .MuiPaginationItem-root": {
+    fontFamily: MONO,
+    fontSize: "0.75rem",
+    fontVariantNumeric: "tabular-nums",
+    minWidth: 30,
+    height: 30,
+    margin: 0,
+    marginInline: "2px",
+    borderRadius: "6px",
+    color: "text.secondary",
+    transition:
+      "background-color 150ms ease-out, border-color 150ms ease-out, color 150ms ease-out",
+    "&:hover": { backgroundColor: "action.hover" },
+  },
+  "& .MuiPaginationItem-root.Mui-selected": {
+    backgroundColor: (theme: Theme) =>
+      alpha(theme.palette.primary.main, 0.14),
+    border: 1,
+    borderColor: (theme: Theme) =>
+      alpha(theme.palette.primary.main, 0.4),
+    color: "primary.main",
+    fontWeight: 600,
+    "&:hover": {
+      backgroundColor: (theme: Theme) =>
+        alpha(theme.palette.primary.main, 0.22),
+    },
+  },
+  "& .MuiPaginationItem-ellipsis": {
+    height: 30,
+    lineHeight: "30px",
+    color: "text.disabled",
+  },
+};
+
+/** Range and page pills for a client-side paged list, from `usePagination`. */
 export const PaginationControls = ({
   page,
   pageCount,
   total,
   onChange,
+  sx,
 }: {
   page: number;
   pageCount: number;
   total: number;
   onChange: (page: number) => void;
+  sx?: SxProps<Theme>;
 }) => {
   if (total <= PAGE_SIZE) return null;
 
@@ -29,33 +100,39 @@ export const PaginationControls = ({
   const last = Math.min(total, (page + 1) * PAGE_SIZE);
 
   return (
-    <Box sx={controlsSx}>
-      <Typography variant="caption" color="text.secondary">
+    <Box sx={[footerSx, ...(Array.isArray(sx) ? sx : [sx])]}>
+      <Typography sx={rangeSx}>
         {first}–{last} of {total}
       </Typography>
-      <IconButton
+      <Pagination
+        count={pageCount}
+        page={page + 1}
+        onChange={(_, next) => onChange(next - 1)}
         size="small"
-        aria-label="Previous page"
-        disabled={page === 0}
-        onClick={() => onChange(page - 1)}
-      >
-        <ChevronLeftIcon fontSize="small" />
-      </IconButton>
-      <IconButton
-        size="small"
-        aria-label="Next page"
-        disabled={page >= pageCount - 1}
-        onClick={() => onChange(page + 1)}
-      >
-        <ChevronRightIcon fontSize="small" />
-      </IconButton>
+        shape="rounded"
+        siblingCount={1}
+        boundaryCount={1}
+        sx={paginationSx}
+      />
     </Box>
   );
 };
 
+const stepSx = {
+  width: 30,
+  height: 30,
+  borderRadius: "6px",
+  border: 1,
+  borderColor: "divider",
+  color: "text.secondary",
+  transition: "background-color 150ms ease-out, border-color 150ms ease-out",
+  "&:hover": { backgroundColor: "action.hover", borderColor: "text.disabled" },
+  "&.Mui-disabled": { opacity: 0.4, borderColor: "divider" },
+};
+
 /**
- * Prev/next for a cursor-paged endpoint, where the total is unknown — the
- * server only says whether an older page exists.
+ * Prev/next for a cursor-paged endpoint. The total is unknown — the server only
+ * says whether an older page exists — so there are no page numbers to render.
  */
 export const CursorPagination = ({
   page,
@@ -63,36 +140,51 @@ export const CursorPagination = ({
   disabled,
   onPrev,
   onNext,
+  sx,
 }: {
   page: number;
   hasNext: boolean;
   disabled?: boolean;
   onPrev: () => void;
   onNext: () => void;
+  sx?: SxProps<Theme>;
 }) => {
   if (page === 0 && !hasNext) return null;
 
+  const atStart = disabled || page === 0;
+  const atEnd = disabled || !hasNext;
+
   return (
-    <Box sx={controlsSx}>
-      <Typography variant="caption" color="text.secondary">
-        Page {page + 1}
-      </Typography>
-      <IconButton
-        size="small"
-        aria-label="Previous page"
-        disabled={disabled || page === 0}
-        onClick={onPrev}
-      >
-        <ChevronLeftIcon fontSize="small" />
-      </IconButton>
-      <IconButton
-        size="small"
-        aria-label="Next page"
-        disabled={disabled || !hasNext}
-        onClick={onNext}
-      >
-        <ChevronRightIcon fontSize="small" />
-      </IconButton>
+    <Box sx={[footerSx, ...(Array.isArray(sx) ? sx : [sx])]}>
+      <Typography sx={rangeSx}>Page {page + 1}</Typography>
+      <Box sx={{ display: "flex", gap: 0.5 }}>
+        <Tooltip title={atStart ? "" : "Newer"}>
+          <span>
+            <IconButton
+              size="small"
+              aria-label="Newer entries"
+              disabled={atStart}
+              onClick={onPrev}
+              sx={stepSx}
+            >
+              <ChevronLeftIcon fontSize="small" />
+            </IconButton>
+          </span>
+        </Tooltip>
+        <Tooltip title={atEnd ? "" : "Older"}>
+          <span>
+            <IconButton
+              size="small"
+              aria-label="Older entries"
+              disabled={atEnd}
+              onClick={onNext}
+              sx={stepSx}
+            >
+              <ChevronRightIcon fontSize="small" />
+            </IconButton>
+          </span>
+        </Tooltip>
+      </Box>
     </Box>
   );
 };

--- a/crates/decman/frontend/src/components/PartyDetail.tsx
+++ b/crates/decman/frontend/src/components/PartyDetail.tsx
@@ -29,6 +29,8 @@ import UploadFileIcon from "@mui/icons-material/UploadFile";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import RefreshIcon from "@mui/icons-material/Refresh";
 import { CopyableText } from "./CopyableText";
+import { PaginationControls } from "./Pagination";
+import { usePagination } from "../usePagination";
 import { TextHelp } from "./FieldHelp";
 import { AddPartyDialog } from "./AddPartyDialog";
 import { ChangeThresholdDialog } from "./ChangeThresholdDialog";
@@ -216,6 +218,7 @@ export const PartyDetail = ({
   const [auditTrailLoading, setAuditTrailLoading] = useState(false);
   const [canScrollUp, setCanScrollUp] = useState(false);
   const [canScrollDown, setCanScrollDown] = useState(false);
+  const contractsPaging = usePagination(party.contracts ?? []);
   const contractsScrollRef = useRef<HTMLDivElement>(null);
 
   const isGovRulesContract = (template_id: string) =>
@@ -578,7 +581,7 @@ export const PartyDetail = ({
                   </TableRow>
                 </TableHead>
                 <TableBody>
-                  {party.contracts.map((c, idx) => (
+                  {contractsPaging.pageItems.map((c, idx) => (
                     <TableRow key={c.contract_id} sx={zebraRow(idx)}>
                       <TableCell sx={{ py: 1 }}>
                         {c.package_name || "—"}
@@ -626,6 +629,12 @@ export const PartyDetail = ({
               }}
             />
           </Box>
+          <PaginationControls
+            page={contractsPaging.page}
+            pageCount={contractsPaging.pageCount}
+            total={contractsPaging.total}
+            onChange={contractsPaging.setPage}
+          />
         </CollapsibleSection>
       )}
 

--- a/crates/decman/frontend/src/components/PartyDetail.tsx
+++ b/crates/decman/frontend/src/components/PartyDetail.tsx
@@ -38,7 +38,7 @@ import { KickDialog } from "./KickDialog";
 import { ContractsDialog } from "./ContractsDialog";
 import { PartyConfigDialog } from "./PartyConfigDialog";
 import { GovernanceActionsDialog } from "./GovernanceActionsDialog";
-import { GovernanceAuditTrail, CHAIN_LIMIT } from "./GovernanceAuditTrail";
+import { GovernanceAuditTrail } from "./GovernanceAuditTrail";
 import { HoldingsSection } from "./HoldingsSection";
 import { AuthSection, getAuthStatusIcon } from "./AuthSection";
 import { zebraRow } from "../styles";
@@ -215,6 +215,10 @@ export const PartyDetail = ({
   );
   const [governanceRefreshNonce, setGovernanceRefreshNonce] = useState(0);
   const [auditTrailCount, setAuditTrailCount] = useState(0);
+  // Whether older audit entries exist beyond the loaded page, straight from the
+  // server's cursor. The page size is not a reliable stand-in: it can overshoot
+  // to keep a transaction whole.
+  const [auditTrailHasMore, setAuditTrailHasMore] = useState(false);
   const [auditTrailLoading, setAuditTrailLoading] = useState(false);
   const [canScrollUp, setCanScrollUp] = useState(false);
   const [canScrollDown, setCanScrollDown] = useState(false);
@@ -243,6 +247,16 @@ export const PartyDetail = ({
       : undefined;
 
   const isOwner = Boolean(party.my_owner_key);
+
+  // Stable identity: the audit trail reports through this from an effect, so a
+  // fresh callback each render would re-run it on every parent render.
+  const onAuditTrailCountChange = useCallback(
+    (count: number, hasMore: boolean) => {
+      setAuditTrailCount(count);
+      setAuditTrailHasMore(hasMore);
+    },
+    [],
+  );
 
   const updateScrollShadows = useCallback(() => {
     const el = contractsScrollRef.current;
@@ -688,7 +702,7 @@ export const PartyDetail = ({
             <>
               {auditTrailCount > 0 && (
                 <Chip
-                  label={`${auditTrailCount}${auditTrailCount === CHAIN_LIMIT ? "+" : ""}`}
+                  label={`${auditTrailCount}${auditTrailHasMore ? "+" : ""}`}
                   size="small"
                   sx={{ ml: 1 }}
                 />
@@ -715,7 +729,7 @@ export const PartyDetail = ({
           <GovernanceAuditTrail
             partyId={party.party_id}
             refreshNonce={governanceRefreshNonce}
-            onCountChange={setAuditTrailCount}
+            onCountChange={onAuditTrailCountChange}
             onLoadingChange={setAuditTrailLoading}
           />
         </CollapsibleSection>

--- a/crates/decman/frontend/src/components/PartyList.tsx
+++ b/crates/decman/frontend/src/components/PartyList.tsx
@@ -17,6 +17,8 @@ import VisibilityIcon from "@mui/icons-material/Visibility";
 import VisibilityOffIcon from "@mui/icons-material/VisibilityOff";
 import { CopyableText } from "./CopyableText";
 import { zebraRow } from "../styles";
+import { PaginationControls } from "./Pagination";
+import { usePagination } from "../usePagination";
 import type { DecentralizedParty, PartyAuthStatus } from "../types";
 
 interface PartyListProps {
@@ -60,6 +62,8 @@ export const PartyList = ({
   isHidden,
   onToggleHidden,
 }: PartyListProps) => {
+  const { page, setPage, pageCount, pageItems, total } = usePagination(parties);
+
   if (parties.length === 0) {
     return (
       <Typography variant="body2" color="text.secondary" sx={{ textAlign: "center", py: 6 }}>
@@ -83,7 +87,7 @@ export const PartyList = ({
           </TableRow>
         </TableHead>
         <TableBody>
-          {parties.map((party, idx) => {
+          {pageItems.map((party, idx) => {
             const auth = authStatuses.find(
               (a) => a.dec_party_id === party.party_id,
             );
@@ -158,6 +162,12 @@ export const PartyList = ({
           })}
         </TableBody>
       </Table>
+      <PaginationControls
+        page={page}
+        pageCount={pageCount}
+        total={total}
+        onChange={setPage}
+      />
     </Box>
   );
 };

--- a/crates/decman/frontend/src/components/PartyList.tsx
+++ b/crates/decman/frontend/src/components/PartyList.tsx
@@ -162,11 +162,14 @@ export const PartyList = ({
           })}
         </TableBody>
       </Table>
+      {/* Extra right padding clears the fixed Create-Party FAB (56px wide,
+        * offset 24px), which this view renders over the bottom-right corner. */}
       <PaginationControls
         page={page}
         pageCount={pageCount}
         total={total}
         onChange={setPage}
+        sx={{ pr: 11 }}
       />
     </Box>
   );

--- a/crates/decman/frontend/src/constants.ts
+++ b/crates/decman/frontend/src/constants.ts
@@ -1,5 +1,11 @@
 import type { DisclosedContract } from "./types";
 
+// Rows per page for every paginated list. Generated from the Rust
+// `common::api::PAGE_SIZE` so the wire page size and the UI page size are the
+// same number; re-exported here because this is where UI constants are looked
+// for.
+export { PAGE_SIZE } from "./types.generated";
+
 export const API_BASE = "";
 export const ADMIN_ACCESS = import.meta.env.VITE_ADMIN_ACCESS === "true";
 /// When true (default), show the full BitSafe wordmark everywhere.

--- a/crates/decman/frontend/src/index.css
+++ b/crates/decman/frontend/src/index.css
@@ -23,7 +23,11 @@ html, body {
   padding: 0;
   width: 100%;
   min-height: 100vh;
-  overflow-x: hidden;
+  /* `clip` rather than `hidden`: both suppress the horizontal scrollbar, but
+     `hidden` makes this a scroll container, and `position: sticky` binds to the
+     nearest scrolling ancestor — which would stop the paginated tables' footers
+     from ever pinning to the viewport. */
+  overflow-x: clip;
 }
 
 @media (prefers-reduced-motion: no-preference) {

--- a/crates/decman/frontend/src/usePagination.test.ts
+++ b/crates/decman/frontend/src/usePagination.test.ts
@@ -1,0 +1,88 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { PAGE_SIZE } from "./constants";
+import { usePagination } from "./usePagination";
+
+const rows = (count: number): number[] =>
+  Array.from({ length: count }, (_, i) => i);
+
+describe("usePagination", () => {
+  it("slices the list into PAGE_SIZE pages", () => {
+    const items = rows(PAGE_SIZE * 2 + 3);
+    const { result } = renderHook(() => usePagination(items));
+
+    expect(result.current.pageCount).toBe(3);
+    expect(result.current.total).toBe(items.length);
+    expect(result.current.pageItems).toEqual(items.slice(0, PAGE_SIZE));
+
+    act(() => result.current.setPage(2));
+    expect(result.current.page).toBe(2);
+    expect(result.current.pageItems).toEqual(items.slice(PAGE_SIZE * 2));
+  });
+
+  it("reports one page for an empty list", () => {
+    const { result } = renderHook(() => usePagination([]));
+
+    expect(result.current.pageCount).toBe(1);
+    expect(result.current.page).toBe(0);
+    expect(result.current.pageItems).toEqual([]);
+  });
+
+  // The clamp is what keeps a shrinking list (a filter typed, a refresh that
+  // returns fewer rows) from rendering an empty page.
+  it("clamps to the last page when the list shrinks", () => {
+    const { result, rerender } = renderHook(
+      ({ items }) => usePagination(items),
+      { initialProps: { items: rows(PAGE_SIZE * 3) } },
+    );
+
+    act(() => result.current.setPage(2));
+    expect(result.current.page).toBe(2);
+
+    rerender({ items: rows(PAGE_SIZE + 1) });
+    expect(result.current.pageCount).toBe(2);
+    expect(result.current.page).toBe(1);
+  });
+
+  // The requested page has to be forgotten, not just clamped: if the list grows
+  // back, the view must stay where the clamp left it rather than jumping to a
+  // page the user last asked for before the shrink.
+  it("does not jump back to a stale page when the list regrows", () => {
+    const { result, rerender } = renderHook(
+      ({ items }) => usePagination(items),
+      { initialProps: { items: rows(PAGE_SIZE * 3) } },
+    );
+
+    act(() => result.current.setPage(2));
+    rerender({ items: rows(1) });
+    expect(result.current.page).toBe(0);
+
+    rerender({ items: rows(PAGE_SIZE * 3) });
+    expect(result.current.pageCount).toBe(3);
+    expect(result.current.page).toBe(0);
+  });
+
+  it("returns to the first row of the scroll container on a page change", () => {
+    const container = document.createElement("div");
+    container.scrollTo = vi.fn();
+
+    const { result } = renderHook(() =>
+      usePagination(rows(PAGE_SIZE * 2), { current: container }),
+    );
+
+    act(() => result.current.setPage(1));
+    expect(container.scrollTo).toHaveBeenCalledWith({ top: 0 });
+  });
+
+  // Without a scroll container the rows scroll with the page itself.
+  it("scrolls the window when no container is given", () => {
+    const scrollTo = vi.fn();
+    window.scrollTo = scrollTo;
+
+    const { result } = renderHook(() => usePagination(rows(PAGE_SIZE * 2)));
+
+    act(() => result.current.setPage(1));
+    expect(scrollTo).toHaveBeenCalledWith({ top: 0 });
+  });
+});

--- a/crates/decman/frontend/src/usePagination.ts
+++ b/crates/decman/frontend/src/usePagination.ts
@@ -25,6 +25,14 @@ export function usePagination<T>(
   // intermediate render showing an empty one.
   const page = Math.min(requestedPage, pageCount - 1);
 
+  // The clamp above only hides an out-of-range request; it has to be forgotten
+  // too, or a list that shrinks and later grows back jumps to the stale page the
+  // user never asked for again. Adjusted while rendering rather than in an
+  // effect, which is what keeps the empty page from ever being shown.
+  if (requestedPage > page) {
+    setRequestedPage(page);
+  }
+
   const setPage = useCallback(
     (next: number) => {
       setRequestedPage(next);

--- a/crates/decman/frontend/src/usePagination.ts
+++ b/crates/decman/frontend/src/usePagination.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState, type RefObject } from "react";
 import { PAGE_SIZE } from "./constants";
 
 /**
@@ -8,9 +8,15 @@ import { PAGE_SIZE } from "./constants";
  * still reads Canton a page at a time; it just can't hand out a cursor for a
  * list it assembles from several template queries, so the paging surfaces here
  * instead. Views backed by a cursor endpoint use `CursorPagination`.
+ *
+ * `scrollRef` is the element that scrolls the rows, when it isn't the window —
+ * pass it so changing page can return to the first row.
  */
-export function usePagination<T>(items: T[]) {
-  const [requestedPage, setPage] = useState(0);
+export function usePagination<T>(
+  items: T[],
+  scrollRef?: RefObject<HTMLElement | null>,
+) {
+  const [requestedPage, setRequestedPage] = useState(0);
 
   const pageCount = Math.max(1, Math.ceil(items.length / PAGE_SIZE));
   // Clamped while rendering rather than corrected in an effect: when the list
@@ -18,6 +24,22 @@ export function usePagination<T>(items: T[]) {
   // fewer rows) the view lands on the last real page immediately, with no
   // intermediate render showing an empty one.
   const page = Math.min(requestedPage, pageCount - 1);
+
+  const setPage = useCallback(
+    (next: number) => {
+      setRequestedPage(next);
+      // Back to the first row of the new page. Two reasons: a page is read from
+      // its top, and pages differ in height — the last one is short, so leaving
+      // the scroll position alone lets the browser clamp it upward and the
+      // header appears to lurch into view.
+      if (scrollRef?.current) {
+        scrollRef.current.scrollTo({ top: 0 });
+      } else {
+        window.scrollTo({ top: 0 });
+      }
+    },
+    [scrollRef],
+  );
 
   const pageItems = useMemo(
     () => items.slice(page * PAGE_SIZE, page * PAGE_SIZE + PAGE_SIZE),

--- a/crates/decman/frontend/src/usePagination.ts
+++ b/crates/decman/frontend/src/usePagination.ts
@@ -1,0 +1,28 @@
+import { useMemo, useState } from "react";
+import { PAGE_SIZE } from "./constants";
+
+/**
+ * Slice a fully-loaded list into PAGE_SIZE pages.
+ *
+ * Used by the views whose endpoint returns the whole result set. The backend
+ * still reads Canton a page at a time; it just can't hand out a cursor for a
+ * list it assembles from several template queries, so the paging surfaces here
+ * instead. Views backed by a cursor endpoint use `CursorPagination`.
+ */
+export function usePagination<T>(items: T[]) {
+  const [requestedPage, setPage] = useState(0);
+
+  const pageCount = Math.max(1, Math.ceil(items.length / PAGE_SIZE));
+  // Clamped while rendering rather than corrected in an effect: when the list
+  // shrinks under the current page (a filter is typed, a refresh returns
+  // fewer rows) the view lands on the last real page immediately, with no
+  // intermediate render showing an empty one.
+  const page = Math.min(requestedPage, pageCount - 1);
+
+  const pageItems = useMemo(
+    () => items.slice(page * PAGE_SIZE, page * PAGE_SIZE + PAGE_SIZE),
+    [items, page],
+  );
+
+  return { page, setPage, pageCount, pageItems, total: items.length };
+}

--- a/crates/decman/frontend/src/vitest.setup.ts
+++ b/crates/decman/frontend/src/vitest.setup.ts
@@ -1,0 +1,4 @@
+// jsdom has no layout engine, so `window.scrollTo` is unimplemented and every
+// call logs "Not implemented". The paging hooks scroll to the top on a page
+// change, so stub it here; a test that asserts on the call installs its own spy.
+window.scrollTo = () => {};

--- a/crates/decman/frontend/vite.config.ts
+++ b/crates/decman/frontend/vite.config.ts
@@ -2,7 +2,9 @@ import { existsSync, readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import { defineConfig, type Plugin } from 'vite'
+// `vitest/config` rather than `vite`: same defineConfig, plus the `test` key.
+import { defineConfig } from 'vitest/config'
+import type { Plugin } from 'vite'
 import react from '@vitejs/plugin-react'
 
 const rootDir = dirname(fileURLToPath(import.meta.url))
@@ -71,5 +73,12 @@ export default defineConfig({
   plugins: [react(), ...(process.env.MOCK === 'true' ? [mockApi()] : [])],
   define: {
     __BUILD_DATE__: JSON.stringify(new Date().toISOString()),
+  },
+  // `npm test`. jsdom because the hooks under test render components and touch
+  // the DOM (scroll containers); `include` keeps the runner off node_modules.
+  test: {
+    environment: 'jsdom',
+    include: ['src/**/*.test.{ts,tsx}'],
+    setupFiles: ['src/vitest.setup.ts'],
   },
 })

--- a/crates/decman/src/bin/gen_types.rs
+++ b/crates/decman/src/bin/gen_types.rs
@@ -213,6 +213,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
+    // ts-rs only emits types, so the shared page size is appended by hand from
+    // the Rust constant — that keeps `common::api::PAGE_SIZE` the only place
+    // the value is written down.
+    blocks.push(format!(
+        "export const PAGE_SIZE = {page_size};",
+        page_size = common::api::PAGE_SIZE
+    ));
+
     let header = "// Code generated from the Rust wire DTOs by `gen-types` (ts-rs).\n\
                   // DO NOT EDIT. Regenerate with `just gen-types`.\n\n";
     let dest = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("frontend/src/types.generated.ts");

--- a/crates/decman/src/db/schema.rs
+++ b/crates/decman/src/db/schema.rs
@@ -87,6 +87,7 @@ pub trait SchemaRead {
         &self,
         party_id: &CantonId,
         limit: i64,
+        before_offset: Option<i64>,
     ) -> Result<Vec<ChainAuditCacheRow>>;
 
     /// Get all persisted pending invitations

--- a/crates/decman/src/db/sqlite.rs
+++ b/crates/decman/src/db/sqlite.rs
@@ -1844,6 +1844,150 @@ mod tests {
     }
 
     // ====================================================================
+    // Chain audit cache
+    // ====================================================================
+
+    /// One cached chain-audit row. `contract_id` is part of the primary key, so
+    /// it is what lets several rows share an offset — the case the paging query
+    /// has to keep together.
+    async fn insert_chain_audit_row(
+        pool: &SqlitePool,
+        party_id: &str,
+        offset: i64,
+        contract_id: &str,
+    ) -> Result {
+        sqlx::query(
+            r"
+            INSERT INTO chain_audit_cache (
+                party_id, offset, timestamp, event_type, contract_id,
+                template_id, package_id, governance_type, action_summary,
+                choice, acting_parties, update_id, details
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ",
+        )
+        .bind(party_id)
+        .bind(offset)
+        .bind(offset)
+        .bind("propose")
+        .bind(contract_id)
+        .bind("Governance:Action")
+        .bind("pkg-1")
+        .bind("core_domain")
+        .bind("propose_add_member")
+        .bind(None::<String>)
+        .bind("[]")
+        .bind(format!("update-{offset}"))
+        .bind("null")
+        .execute(pool)
+        .await?;
+
+        Ok(())
+    }
+
+    /// Party A holds a trail whose middle offset carries three entries, plus a
+    /// second party's row at an interleaving offset to prove the party filter.
+    async fn seed_chain_audit_trail(pool: &SqlitePool, party_a: &str, party_b: &str) -> Result {
+        for (offset, contract_id) in [
+            (30, "c-30"),
+            (20, "c-20-a"),
+            (20, "c-20-b"),
+            (20, "c-20-c"),
+            (10, "c-10"),
+        ] {
+            insert_chain_audit_row(pool, party_a, offset, contract_id).await?;
+        }
+        insert_chain_audit_row(pool, party_b, 25, "other-25").await?;
+
+        Ok(())
+    }
+
+    fn cached_offsets(rows: &[crate::db::rows::ChainAuditCacheRow]) -> Vec<i64> {
+        rows.iter().map(|r| r.offset).collect()
+    }
+
+    /// The page is cut on whole offsets, not on rows: `limit = 2` reaches
+    /// offset 20 and then keeps all three of its entries. Cutting at two rows
+    /// would strand the rest of offset 20 — the next page asks for
+    /// `offset < 20` and would never return them.
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn test_chain_audit_cache_keeps_offset_groups_whole(pool: SqlitePool) -> Result {
+        let party_a = test_party_id("party-a");
+        let party_b = test_party_id("party-b");
+        seed_chain_audit_trail(&pool, &party_a.to_string(), &party_b.to_string()).await?;
+
+        let rows = pool.get_chain_audit_cache(&party_a, 2, None).await?;
+        assert_eq!(cached_offsets(&rows), vec![30, 20, 20, 20]);
+
+        Ok(())
+    }
+
+    /// The cursor is exclusive, so paging from offset 20 returns what is
+    /// strictly older and never repeats that offset's group.
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn test_chain_audit_cache_pages_before_a_cursor(pool: SqlitePool) -> Result {
+        let party_a = test_party_id("party-a");
+        let party_b = test_party_id("party-b");
+        seed_chain_audit_trail(&pool, &party_a.to_string(), &party_b.to_string()).await?;
+
+        let rows = pool.get_chain_audit_cache(&party_a, 2, Some(20)).await?;
+        assert_eq!(cached_offsets(&rows), vec![10]);
+
+        // Past the oldest cached offset there is nothing left to hand back —
+        // the handler treats this empty result as a miss and reads Canton.
+        let rows = pool.get_chain_audit_cache(&party_a, 2, Some(10)).await?;
+        assert!(rows.is_empty());
+
+        Ok(())
+    }
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn test_chain_audit_cache_returns_all_rows_for_an_oversized_limit(
+        pool: SqlitePool,
+    ) -> Result {
+        let party_a = test_party_id("party-a");
+        let party_b = test_party_id("party-b");
+        seed_chain_audit_trail(&pool, &party_a.to_string(), &party_b.to_string()).await?;
+
+        let rows = pool.get_chain_audit_cache(&party_a, 500, None).await?;
+        assert_eq!(cached_offsets(&rows), vec![30, 20, 20, 20, 10]);
+
+        Ok(())
+    }
+
+    /// A single offset bigger than the page still comes back whole, since the
+    /// cursor cannot address part of an offset group.
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn test_chain_audit_cache_keeps_an_oversized_group_intact(pool: SqlitePool) -> Result {
+        let party_a = test_party_id("party-a");
+        let party_a_str = party_a.to_string();
+        for contract_id in ["c-a", "c-b", "c-c"] {
+            insert_chain_audit_row(&pool, &party_a_str, 20, contract_id).await?;
+        }
+
+        let rows = pool.get_chain_audit_cache(&party_a, 1, None).await?;
+        assert_eq!(cached_offsets(&rows), vec![20, 20, 20]);
+
+        Ok(())
+    }
+
+    /// Another party's rows never leak into a page, even at an offset that
+    /// interleaves with the queried party's trail.
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn test_chain_audit_cache_filters_by_party(pool: SqlitePool) -> Result {
+        let party_a = test_party_id("party-a");
+        let party_b = test_party_id("party-b");
+        seed_chain_audit_trail(&pool, &party_a.to_string(), &party_b.to_string()).await?;
+
+        let rows = pool.get_chain_audit_cache(&party_b, 50, None).await?;
+        assert_eq!(cached_offsets(&rows), vec![25]);
+
+        let rows = pool.get_chain_audit_cache(&party_a, 50, None).await?;
+        assert!(rows.iter().all(|r| r.offset != 25));
+
+        Ok(())
+    }
+
+    // ====================================================================
     // Pending invitations
     // ====================================================================
 

--- a/crates/decman/src/db/sqlite.rs
+++ b/crates/decman/src/db/sqlite.rs
@@ -302,16 +302,32 @@ impl SchemaRead for SqlitePool {
         &self,
         party_id: &CantonId,
         limit: i64,
+        before_offset: Option<i64>,
     ) -> Result<Vec<ChainAuditCacheRow>> {
+        // Selects whole offset groups for the newest `limit` distinct offsets
+        // rather than the newest `limit` rows. One transaction can produce
+        // several entries sharing an offset, and the cursor handed to the
+        // client is an offset — a page cut mid-offset would make the next page
+        // skip the remainder. Matches how the live path pages.
         let rows = sqlx::query_as::<_, ChainAuditCacheRow>(
             r"
             SELECT * FROM chain_audit_cache
-            WHERE party_id = ?
+            WHERE party_id = ?1
+              AND (?2 IS NULL OR offset < ?2)
+              AND offset >= (
+                SELECT MIN(offset) FROM (
+                  SELECT DISTINCT offset FROM chain_audit_cache
+                  WHERE party_id = ?1
+                    AND (?2 IS NULL OR offset < ?2)
+                  ORDER BY offset DESC
+                  LIMIT ?3
+                )
+              )
             ORDER BY offset DESC
-            LIMIT ?
             ",
         )
         .bind(party_id.to_string())
+        .bind(before_offset)
         .bind(limit)
         .fetch_all(self)
         .await?;

--- a/crates/decman/src/server/chain_audit.rs
+++ b/crates/decman/src/server/chain_audit.rs
@@ -1,10 +1,9 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, future::Future};
 
 use anyhow::{Context, Result};
 use canton_proto_rs::com::daml::ledger::api::v2::{
-    CumulativeFilter, EventFormat, Filters, GetLatestPrunedOffsetsRequest, GetLedgerEndRequest,
-    Identifier, InterfaceFilter, Record, TemplateFilter, Transaction, TransactionFormat,
-    TransactionShape, UpdateFormat, Value, WildcardFilter, cumulative_filter, event::Event, value,
+    CumulativeFilter, GetLatestPrunedOffsetsRequest, GetLedgerEndRequest, Identifier, Record,
+    Transaction, TransactionFormat, TransactionShape, UpdateFormat, Value, event::Event, value,
 };
 use serde_json::{Value as JsonValue, json};
 use sqlx::SqlitePool;
@@ -16,7 +15,8 @@ use crate::{
 };
 
 use super::{
-    ledger_paging::fetch_transactions_page,
+    event_filters::{interface_filter, party_event_format, template_filter, wildcard_filter},
+    ledger_paging::{TransactionPage, fetch_transactions_page},
     package_inventory::{fetch_package_names, matching_names, package_name_prefix},
     types::ChainAuditEntry,
 };
@@ -135,36 +135,27 @@ fn build_canton_filters(filters: &ChainFilters, package_names: &[String]) -> Vec
 
     for t in &filters.templates {
         for name in matching_names(package_names, &t.package_prefix) {
-            cumulative.push(CumulativeFilter {
-                identifier_filter: Some(cumulative_filter::IdentifierFilter::TemplateFilter(
-                    TemplateFilter {
-                        template_id: Some(Identifier {
-                            package_id: format!("#{name}"),
-                            module_name: t.module_name.to_string(),
-                            entity_name: t.entity_name.to_string(),
-                        }),
-                        include_created_event_blob: false,
-                    },
-                )),
-            });
+            cumulative.push(template_filter(
+                Identifier {
+                    package_id: format!("#{name}"),
+                    module_name: t.module_name.to_string(),
+                    entity_name: t.entity_name.to_string(),
+                },
+                false,
+            ));
         }
     }
 
     for i in &filters.interfaces {
         for name in matching_names(package_names, &i.package_prefix) {
-            cumulative.push(CumulativeFilter {
-                identifier_filter: Some(cumulative_filter::IdentifierFilter::InterfaceFilter(
-                    InterfaceFilter {
-                        interface_id: Some(Identifier {
-                            package_id: format!("#{name}"),
-                            module_name: i.module_name.to_string(),
-                            entity_name: i.entity_name.to_string(),
-                        }),
-                        include_interface_view: true,
-                        include_created_event_blob: false,
-                    },
-                )),
-            });
+            cumulative.push(interface_filter(
+                Identifier {
+                    package_id: format!("#{name}"),
+                    module_name: i.module_name.to_string(),
+                    entity_name: i.entity_name.to_string(),
+                },
+                false,
+            ));
         }
     }
 
@@ -174,13 +165,7 @@ fn build_canton_filters(filters: &ChainFilters, package_names: &[String]) -> Vec
 /// The wildcard fallback filter: every event for the party, classified and
 /// trimmed client-side.
 fn wildcard_filters() -> Vec<CumulativeFilter> {
-    vec![CumulativeFilter {
-        identifier_filter: Some(cumulative_filter::IdentifierFilter::WildcardFilter(
-            WildcardFilter {
-                include_created_event_blob: false,
-            },
-        )),
-    }]
+    vec![wildcard_filter(false)]
 }
 
 /// Whether an entry is a governance action worth showing in the audit trail:
@@ -478,9 +463,7 @@ pub struct AuditPage {
 ///
 /// Paging descending is what makes the early exit sound: every later page holds
 /// strictly lower offsets, so the first `limit` governance entries seen *are*
-/// the most recent `limit`. The previous implementation drained the whole
-/// retained ledger before sorting and truncating, which grew without bound as
-/// the ledger aged.
+/// the most recent `limit`.
 ///
 /// The returned page can slightly exceed `limit`: it is extended to the end of
 /// the last offset group rather than cut mid-transaction.
@@ -493,24 +476,46 @@ async fn collect_entries(
     template_index: &HashMap<(String, String), &'static str>,
     limit: usize,
 ) -> Result<AuditPage> {
-    let mut filters_by_party = HashMap::new();
-    filters_by_party.insert(party_id.to_string(), Filters { cumulative });
-
-    let event_format = EventFormat {
-        filters_by_party,
-        filters_for_any_party: None,
-        verbose: true,
-    };
-
     let update_format = UpdateFormat {
         include_transactions: Some(TransactionFormat {
-            event_format: Some(event_format),
+            event_format: Some(party_event_format(party_id, cumulative, true)),
             transaction_shape: TransactionShape::LedgerEffects as i32,
         }),
         include_reassignments: None,
         include_topology_events: None,
     };
 
+    collect_from_pages(
+        |page_token| {
+            fetch_transactions_page(
+                config,
+                token.clone(),
+                range.begin_exclusive,
+                range.end_inclusive,
+                update_format.clone(),
+                page_token,
+            )
+        },
+        template_index,
+        limit,
+    )
+    .await
+}
+
+/// The page-walk behind [`collect_entries`], over an arbitrary page source.
+///
+/// `fetch_page` takes the token of the page to read and is a parameter so the
+/// walk — and the `has_more` it derives from where it stopped — can be tested
+/// against scripted pages. Production passes [`fetch_transactions_page`].
+async fn collect_from_pages<F, Fut>(
+    mut fetch_page: F,
+    template_index: &HashMap<(String, String), &'static str>,
+    limit: usize,
+) -> Result<AuditPage>
+where
+    F: FnMut(Option<Vec<u8>>) -> Fut,
+    Fut: Future<Output = Result<TransactionPage>>,
+{
     if limit == 0 {
         return Ok(AuditPage::default());
     }
@@ -523,16 +528,9 @@ async fn collect_entries(
     let mut pages_remain = false;
 
     loop {
-        let page = fetch_transactions_page(
-            config,
-            token.clone(),
-            range.begin_exclusive,
-            range.end_inclusive,
-            update_format.clone(),
-            page_token,
-        )
-        .await
-        .context("Failed to read ledger updates")?;
+        let page = fetch_page(page_token)
+            .await
+            .context("Failed to read ledger updates")?;
 
         for tx in page.transactions {
             entries.extend(
@@ -739,8 +737,10 @@ pub async fn save_chain_audit_cache(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::VecDeque;
+
     use canton_proto_rs::com::daml::ledger::api::v2::{
-        Enum, Optional, RecordField, TextMap, Variant,
+        CreatedEvent, Enum, Event as EventEnvelope, Optional, RecordField, TextMap, Variant,
     };
 
     use super::*;
@@ -1032,5 +1032,155 @@ mod tests {
 
         // One template filter per core package version + one interface filter
         assert_eq!(cumulative.len(), 3);
+    }
+
+    // ====================================================================
+    // Page walk
+    // ====================================================================
+
+    /// One transaction carrying a governable-action Create per offset — each
+    /// classifies as `propose`, so all of them survive the governance filter.
+    fn tx_at(offsets: &[i64]) -> Transaction {
+        Transaction {
+            events: offsets
+                .iter()
+                .map(|offset| EventEnvelope {
+                    event: Some(Event::Created(CreatedEvent {
+                        offset: *offset,
+                        contract_id: format!("c-{offset}"),
+                        template_id: Some(Identifier {
+                            package_id: "#governance-action-v1".to_string(),
+                            module_name: "Governance.Action".to_string(),
+                            entity_name: "GovernableAction".to_string(),
+                        }),
+                        ..Default::default()
+                    })),
+                })
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    /// A scripted page holding one transaction, and whether Canton claims more
+    /// pages follow it.
+    fn scripted_page(offsets: &[i64], more: bool) -> TransactionPage {
+        TransactionPage {
+            transactions: vec![tx_at(offsets)],
+            next_page_token: more.then(|| b"next".to_vec()),
+        }
+    }
+
+    /// Run the walk over `pages`. Asking for a page beyond the script is an
+    /// error, so a test that over-reads fails rather than quietly passing.
+    async fn walk(pages: Vec<TransactionPage>, limit: usize) -> AuditPage {
+        let mut remaining = VecDeque::from(pages);
+        let template_index = HashMap::new();
+
+        collect_from_pages(
+            |_page_token| {
+                let page = remaining.pop_front();
+                async move { page.context("asked for a page beyond the script") }
+            },
+            &template_index,
+            limit,
+        )
+        .await
+        .expect("the scripted walk succeeds")
+    }
+
+    /// The edge the cursor contract turns on: the limit is met exactly on
+    /// Canton's last page, so nothing older exists and the endpoint must not
+    /// advertise another page.
+    #[tokio::test]
+    async fn walk_reports_no_more_when_the_limit_lands_on_the_last_page() {
+        let page = walk(vec![scripted_page(&[30, 20], false)], 2).await;
+
+        assert_eq!(offsets_of(&page.entries), vec![30, 20]);
+        assert!(!page.has_more);
+    }
+
+    /// Stopped on a full page with a token still in hand — there is more.
+    #[tokio::test]
+    async fn walk_reports_more_when_pages_remain() {
+        let page = walk(vec![scripted_page(&[30, 20], true)], 2).await;
+
+        assert_eq!(offsets_of(&page.entries), vec![30, 20]);
+        assert!(page.has_more);
+    }
+
+    /// A page short of `limit` is followed, and only as far as needed: a third
+    /// page is never requested.
+    #[tokio::test]
+    async fn walk_follows_pages_until_the_limit_is_met() {
+        let pages = vec![
+            scripted_page(&[30], true),
+            scripted_page(&[20], true),
+            scripted_page(&[10], true),
+        ];
+        let page = walk(pages, 2).await;
+
+        assert_eq!(offsets_of(&page.entries), vec![30, 20]);
+        assert!(page.has_more);
+    }
+
+    /// The range ran out before `limit` was reached, so this is the last page
+    /// however short it is.
+    #[tokio::test]
+    async fn walk_reports_no_more_when_the_range_runs_out() {
+        let page = walk(vec![scripted_page(&[30], false)], 5).await;
+
+        assert_eq!(offsets_of(&page.entries), vec![30]);
+        assert!(!page.has_more);
+    }
+
+    /// Canton had no further pages, but the offset-group trim dropped entries —
+    /// which are strictly older than what is returned, so they are themselves
+    /// proof of an older page.
+    #[tokio::test]
+    async fn walk_reports_more_when_the_trim_drops_entries() {
+        let page = walk(vec![scripted_page(&[30, 20, 20, 10], false)], 2).await;
+
+        assert_eq!(offsets_of(&page.entries), vec![30, 20, 20]);
+        assert!(page.has_more);
+    }
+
+    /// A zero-row page reads nothing at all — the script is empty, so any fetch
+    /// would fail the walk.
+    #[tokio::test]
+    async fn walk_at_zero_limit_reads_no_pages() {
+        let page = walk(Vec::new(), 0).await;
+
+        assert!(page.entries.is_empty());
+        assert!(!page.has_more);
+    }
+
+    /// Events that are not governance actions are dropped without counting
+    /// toward the limit, so the walk keeps reading for the ones that are.
+    #[tokio::test]
+    async fn walk_skips_non_governance_events() {
+        let noise = Transaction {
+            events: vec![EventEnvelope {
+                event: Some(Event::Created(CreatedEvent {
+                    offset: 40,
+                    contract_id: "c-40".to_string(),
+                    // Ends with `Rules`, so it classifies as `create`.
+                    template_id: Some(id("GovernanceRules")),
+                    ..Default::default()
+                })),
+            }],
+            ..Default::default()
+        };
+        let pages = vec![
+            TransactionPage {
+                transactions: vec![noise],
+                next_page_token: Some(b"next".to_vec()),
+            },
+            scripted_page(&[30], false),
+        ];
+
+        let page = walk(pages, 1).await;
+
+        assert_eq!(offsets_of(&page.entries), vec![30]);
+        assert!(!page.has_more);
     }
 }

--- a/crates/decman/src/server/chain_audit.rs
+++ b/crates/decman/src/server/chain_audit.rs
@@ -311,7 +311,7 @@ pub async fn get_chain_audit(
     packages: &PackageConfig,
     limit: usize,
     before_offset: Option<i64>,
-) -> Result<Vec<ChainAuditEntry>> {
+) -> Result<AuditPage> {
     let party_id_str = party_id.to_string();
     let party_id = party_id_str.as_str();
     let mut state_client = utils::create_state_client(config, token.clone()).await?;
@@ -323,7 +323,7 @@ pub async fn get_chain_audit(
         .offset;
 
     if ledger_end == 0 {
-        return Ok(Vec::new());
+        return Ok(AuditPage::default());
     }
 
     let pruned_offset = state_client
@@ -344,7 +344,7 @@ pub async fn get_chain_audit(
         None => ledger_end,
     };
     if end_offset <= begin_offset {
-        return Ok(Vec::new());
+        return Ok(AuditPage::default());
     }
     let range = OffsetRange {
         begin_exclusive: begin_offset,
@@ -354,7 +354,7 @@ pub async fn get_chain_audit(
     let filters = chain_filters(packages);
     if filters.templates.is_empty() && filters.interfaces.is_empty() {
         tracing::warn!("No governance templates configured; returning empty chain audit");
-        return Ok(Vec::new());
+        return Ok(AuditPage::default());
     }
 
     // The (module, entity) → governance_type index used to classify events
@@ -400,8 +400,8 @@ pub async fn get_chain_audit(
     };
 
     // `collect_entries` already keeps governance entries only, sorted newest
-    // first and capped at `limit`.
-    let entries = match canton_filters {
+    // first and trimmed to whole offset groups around `limit`.
+    let page = match canton_filters {
         Some(cumulative) => {
             let filtered = collect_entries(
                 config,
@@ -447,11 +447,12 @@ pub async fn get_chain_audit(
     };
 
     tracing::info!(
-        "Chain audit for {party_id}: {count} entries (ledger_end={ledger_end})",
-        count = entries.len()
+        "Chain audit for {party_id}: {count} entries (ledger_end={ledger_end}, has_more={more})",
+        count = page.entries.len(),
+        more = page.has_more
     );
 
-    Ok(entries)
+    Ok(page)
 }
 
 /// The ledger-offset window a chain-audit read covers.
@@ -461,14 +462,28 @@ struct OffsetRange {
     end_inclusive: i64,
 }
 
-/// Read governance audit entries newest-first until `limit` of them have been
-/// collected.
+/// One page of the audit trail, newest-first.
+#[derive(Default)]
+pub struct AuditPage {
+    pub entries: Vec<ChainAuditEntry>,
+    /// Whether entries older than this page exist. Derived from what the read
+    /// actually saw, not from the row count — a page can hold *more* than
+    /// `limit` rows (see [`trim_to_offset_groups`]), so counting rows would
+    /// hand out a cursor to a page that turns out to be empty.
+    pub has_more: bool,
+}
+
+/// Read governance audit entries newest-first until at least `limit` of them
+/// have been collected.
 ///
 /// Paging descending is what makes the early exit sound: every later page holds
 /// strictly lower offsets, so the first `limit` governance entries seen *are*
 /// the most recent `limit`. The previous implementation drained the whole
 /// retained ledger before sorting and truncating, which grew without bound as
 /// the ledger aged.
+///
+/// The returned page can slightly exceed `limit`: it is extended to the end of
+/// the last offset group rather than cut mid-transaction.
 async fn collect_entries(
     config: &NodeConfig,
     token: Option<String>,
@@ -477,7 +492,7 @@ async fn collect_entries(
     cumulative: Vec<CumulativeFilter>,
     template_index: &HashMap<(String, String), &'static str>,
     limit: usize,
-) -> Result<Vec<ChainAuditEntry>> {
+) -> Result<AuditPage> {
     let mut filters_by_party = HashMap::new();
     filters_by_party.insert(party_id.to_string(), Filters { cumulative });
 
@@ -497,11 +512,15 @@ async fn collect_entries(
     };
 
     if limit == 0 {
-        return Ok(Vec::new());
+        return Ok(AuditPage::default());
     }
 
     let mut entries: Vec<ChainAuditEntry> = Vec::new();
     let mut page_token = None;
+    // Whether Canton still had pages left when we stopped. Distinguishes
+    // "stopped because the page was full" from "stopped because the range ran
+    // out", which is what decides if an older page exists.
+    let mut pages_remain = false;
 
     loop {
         let page = fetch_transactions_page(
@@ -524,6 +543,7 @@ async fn collect_entries(
         }
 
         if entries.len() >= limit {
+            pages_remain = page.next_page_token.is_some();
             break;
         }
 
@@ -534,24 +554,42 @@ async fn collect_entries(
     }
 
     entries.sort_by_key(|e| std::cmp::Reverse(e.offset));
+    let dropped = trim_to_offset_groups(&mut entries, limit);
 
-    // Never end a page part-way through an offset. One transaction can yield
-    // several entries that all share its offset, and the cursor handed to the
-    // client is an offset — so a page cut mid-offset would make the next page
-    // (`offset < cursor`) skip the remainder outright. Overshooting `limit` by
-    // the tail of one transaction is the cheaper trade. Everything for a given
-    // offset is already in hand: `GetUpdatesPage` returns whole transactions,
-    // and the loop above consumes a full page before stopping.
-    if entries.len() > limit {
-        let boundary = entries[limit - 1].offset;
-        let keep = entries
-            .iter()
-            .position(|e| e.offset < boundary)
-            .unwrap_or(entries.len());
-        entries.truncate(keep);
+    Ok(AuditPage {
+        entries,
+        // Anything trimmed is strictly older than what we return, so it is
+        // itself proof that an older page exists.
+        has_more: dropped || pages_remain,
+    })
+}
+
+/// Trim `entries` — sorted newest-first — to roughly `limit`, never ending
+/// part-way through an offset group. Returns whether anything was dropped.
+///
+/// One transaction can yield several entries that all share its offset, and the
+/// cursor handed to the client is an offset — so a page cut mid-offset would
+/// make the next page (`offset < cursor`) skip the remainder outright.
+/// Overshooting `limit` by the tail of one transaction is the cheaper trade.
+/// Every entry for a given offset is in hand by construction: `GetUpdatesPage`
+/// returns whole transactions, and the caller consumes a full page before
+/// stopping.
+fn trim_to_offset_groups(entries: &mut Vec<ChainAuditEntry>, limit: usize) -> bool {
+    if limit == 0 || entries.len() <= limit {
+        return false;
     }
 
-    Ok(entries)
+    let boundary = entries[limit - 1].offset;
+    let keep = entries
+        .iter()
+        .position(|e| e.offset < boundary)
+        .unwrap_or(entries.len());
+
+    if keep >= entries.len() {
+        return false;
+    }
+    entries.truncate(keep);
+    true
 }
 
 /// Convert one transaction's Created/Exercised events into audit entries.
@@ -722,6 +760,72 @@ mod tests {
             update_id: String::new(),
             details: JsonValue::Null,
         }
+    }
+
+    /// Entries at the given offsets, newest-first, as `trim_to_offset_groups`
+    /// expects its input.
+    fn entries_at(offsets: &[i64]) -> Vec<ChainAuditEntry> {
+        offsets
+            .iter()
+            .map(|offset| ChainAuditEntry {
+                offset: *offset,
+                ..entry_with_event_type("propose")
+            })
+            .collect()
+    }
+
+    fn offsets_of(entries: &[ChainAuditEntry]) -> Vec<i64> {
+        entries.iter().map(|e| e.offset).collect()
+    }
+
+    #[test]
+    fn trim_keeps_everything_when_within_limit() {
+        let mut entries = entries_at(&[30, 20, 10]);
+        assert!(!trim_to_offset_groups(&mut entries, 5));
+        assert_eq!(offsets_of(&entries), vec![30, 20, 10]);
+    }
+
+    #[test]
+    fn trim_cuts_cleanly_on_an_offset_boundary() {
+        let mut entries = entries_at(&[30, 20, 10]);
+        assert!(trim_to_offset_groups(&mut entries, 2));
+        assert_eq!(offsets_of(&entries), vec![30, 20]);
+    }
+
+    /// The case the cursor depends on: the limit lands mid-transaction, so the
+    /// page is extended to the end of that offset group. Cutting at exactly
+    /// `limit` would strand offset 20's third entry — the next page asks for
+    /// `offset < 20` and would never return it.
+    #[test]
+    fn trim_never_splits_an_offset_group() {
+        let mut entries = entries_at(&[30, 20, 20, 20, 10]);
+        assert!(trim_to_offset_groups(&mut entries, 2));
+        assert_eq!(offsets_of(&entries), vec![30, 20, 20, 20]);
+    }
+
+    /// A single transaction bigger than the whole page still comes back whole
+    /// rather than being cut into a page the cursor can never revisit.
+    #[test]
+    fn trim_keeps_an_oversized_group_intact() {
+        let mut entries = entries_at(&[20, 20, 20, 20]);
+        assert!(!trim_to_offset_groups(&mut entries, 2));
+        assert_eq!(offsets_of(&entries), vec![20, 20, 20, 20]);
+    }
+
+    /// Nothing was dropped, so the caller must not report `has_more` — the
+    /// trailing group runs to the end of what we read.
+    #[test]
+    fn trim_reports_no_drop_when_the_group_runs_to_the_end() {
+        let mut entries = entries_at(&[30, 20, 20]);
+        assert!(!trim_to_offset_groups(&mut entries, 2));
+        assert_eq!(offsets_of(&entries), vec![30, 20, 20]);
+    }
+
+    #[test]
+    fn trim_is_a_no_op_at_zero_limit() {
+        let mut entries = entries_at(&[30, 20]);
+        assert!(!trim_to_offset_groups(&mut entries, 0));
+        assert_eq!(offsets_of(&entries), vec![30, 20]);
     }
 
     #[test]

--- a/crates/decman/src/server/chain_audit.rs
+++ b/crates/decman/src/server/chain_audit.rs
@@ -3,9 +3,8 @@ use std::collections::HashMap;
 use anyhow::{Context, Result};
 use canton_proto_rs::com::daml::ledger::api::v2::{
     CumulativeFilter, EventFormat, Filters, GetLatestPrunedOffsetsRequest, GetLedgerEndRequest,
-    GetUpdatesRequest, Identifier, InterfaceFilter, Record, TemplateFilter, TransactionFormat,
-    TransactionShape, UpdateFormat, Value, WildcardFilter, cumulative_filter, event::Event,
-    get_updates_response::Update, value,
+    Identifier, InterfaceFilter, Record, TemplateFilter, Transaction, TransactionFormat,
+    TransactionShape, UpdateFormat, Value, WildcardFilter, cumulative_filter, event::Event, value,
 };
 use serde_json::{Value as JsonValue, json};
 use sqlx::SqlitePool;
@@ -17,6 +16,7 @@ use crate::{
 };
 
 use super::{
+    ledger_paging::fetch_transactions_page,
     package_inventory::{fetch_package_names, matching_names, package_name_prefix},
     types::ChainAuditEntry,
 };
@@ -310,6 +310,7 @@ pub async fn get_chain_audit(
     token: Option<String>,
     packages: &PackageConfig,
     limit: usize,
+    before_offset: Option<i64>,
 ) -> Result<Vec<ChainAuditEntry>> {
     let party_id_str = party_id.to_string();
     let party_id = party_id_str.as_str();
@@ -333,6 +334,22 @@ pub async fn get_chain_audit(
         .participant_pruned_up_to_inclusive;
 
     let begin_offset = pruned_offset.max(0);
+
+    // Paging back through the trail means capping the range instead of moving
+    // a Canton page token across HTTP requests: ledger offsets are stable and
+    // survive a cache round trip, whereas a page token is only valid against
+    // the exact query that produced it.
+    let end_offset = match before_offset {
+        Some(cursor) => cursor.saturating_sub(1).min(ledger_end),
+        None => ledger_end,
+    };
+    if end_offset <= begin_offset {
+        return Ok(Vec::new());
+    }
+    let range = OffsetRange {
+        begin_exclusive: begin_offset,
+        end_inclusive: end_offset,
+    };
 
     let filters = chain_filters(packages);
     if filters.templates.is_empty() && filters.interfaces.is_empty() {
@@ -382,16 +399,18 @@ pub async fn get_chain_audit(
         }
     };
 
-    let mut entries = match canton_filters {
+    // `collect_entries` already keeps governance entries only, sorted newest
+    // first and capped at `limit`.
+    let entries = match canton_filters {
         Some(cumulative) => {
-            let filtered = stream_entries(
+            let filtered = collect_entries(
                 config,
                 token.clone(),
                 party_id,
-                begin_offset,
-                ledger_end,
+                range,
                 cumulative,
                 &template_index,
+                limit,
             )
             .await;
             match filtered {
@@ -400,39 +419,32 @@ pub async fn get_chain_audit(
                     tracing::warn!(
                         "Filtered chain audit query failed: {e:#}; retrying with wildcard"
                     );
-                    stream_entries(
+                    collect_entries(
                         config,
                         token,
                         party_id,
-                        begin_offset,
-                        ledger_end,
+                        range,
                         wildcard_filters(),
                         &template_index,
+                        limit,
                     )
                     .await?
                 }
             }
         }
         None => {
-            stream_entries(
+            collect_entries(
                 config,
                 token,
                 party_id,
-                begin_offset,
-                ledger_end,
+                range,
                 wildcard_filters(),
                 &template_index,
+                limit,
             )
             .await?
         }
     };
-
-    // The trail shows governance actions only — drop downstream creates,
-    // unrelated choices and the like before caching and returning.
-    entries.retain(is_governance_entry);
-
-    entries.sort_by_key(|e| std::cmp::Reverse(e.offset));
-    entries.truncate(limit);
 
     tracing::info!(
         "Chain audit for {party_id}: {count} entries (ledger_end={ledger_end})",
@@ -442,16 +454,29 @@ pub async fn get_chain_audit(
     Ok(entries)
 }
 
-/// Stream `GetUpdates` between the offsets with the given event filters and
-/// convert matching Created/Exercised events into audit entries.
-async fn stream_entries(
+/// The ledger-offset window a chain-audit read covers.
+#[derive(Clone, Copy)]
+struct OffsetRange {
+    begin_exclusive: i64,
+    end_inclusive: i64,
+}
+
+/// Read governance audit entries newest-first until `limit` of them have been
+/// collected.
+///
+/// Paging descending is what makes the early exit sound: every later page holds
+/// strictly lower offsets, so the first `limit` governance entries seen *are*
+/// the most recent `limit`. The previous implementation drained the whole
+/// retained ledger before sorting and truncating, which grew without bound as
+/// the ledger aged.
+async fn collect_entries(
     config: &NodeConfig,
     token: Option<String>,
     party_id: &str,
-    begin_exclusive: i64,
-    end_inclusive: i64,
+    range: OffsetRange,
     cumulative: Vec<CumulativeFilter>,
     template_index: &HashMap<(String, String), &'static str>,
+    limit: usize,
 ) -> Result<Vec<ChainAuditEntry>> {
     let mut filters_by_party = HashMap::new();
     filters_by_party.insert(party_id.to_string(), Filters { cumulative });
@@ -471,126 +496,164 @@ async fn stream_entries(
         include_topology_events: None,
     };
 
-    let mut update_client = utils::create_update_client(config, token).await?;
-    let req = GetUpdatesRequest {
-        begin_exclusive,
-        end_inclusive: Some(end_inclusive),
-        update_format: Some(update_format),
-        descending_order: false,
-    };
-
-    let mut stream = update_client
-        .get_updates(tonic::Request::new(req))
-        .await
-        .context("Failed to call GetUpdates")?
-        .into_inner();
+    if limit == 0 {
+        return Ok(Vec::new());
+    }
 
     let mut entries: Vec<ChainAuditEntry> = Vec::new();
+    let mut page_token = None;
 
-    while let Some(response) = stream
-        .message()
+    loop {
+        let page = fetch_transactions_page(
+            config,
+            token.clone(),
+            range.begin_exclusive,
+            range.end_inclusive,
+            update_format.clone(),
+            page_token,
+        )
         .await
-        .context("Stream error while reading ledger updates")?
-    {
-        let Some(Update::Transaction(tx)) = response.update else {
-            continue;
-        };
+        .context("Failed to read ledger updates")?;
 
-        let tx_ts = tx.effective_at.as_ref().map(|t| t.seconds).unwrap_or(0);
-        let update_id = tx.update_id.clone();
+        for tx in page.transactions {
+            entries.extend(
+                transaction_entries(tx, template_index)
+                    .into_iter()
+                    .filter(is_governance_entry),
+            );
+        }
 
-        // Collect (node_id, last_descendant_node_id) for every Exercise in this
-        // transaction so we can later detect Created events that are downstream
-        // effects of an Exercise — those aren't fresh proposals.
-        let exercise_ranges: Vec<(i32, i32)> = tx
-            .events
+        if entries.len() >= limit {
+            break;
+        }
+
+        match page.next_page_token {
+            Some(next) => page_token = Some(next),
+            None => break,
+        }
+    }
+
+    entries.sort_by_key(|e| std::cmp::Reverse(e.offset));
+
+    // Never end a page part-way through an offset. One transaction can yield
+    // several entries that all share its offset, and the cursor handed to the
+    // client is an offset — so a page cut mid-offset would make the next page
+    // (`offset < cursor`) skip the remainder outright. Overshooting `limit` by
+    // the tail of one transaction is the cheaper trade. Everything for a given
+    // offset is already in hand: `GetUpdatesPage` returns whole transactions,
+    // and the loop above consumes a full page before stopping.
+    if entries.len() > limit {
+        let boundary = entries[limit - 1].offset;
+        let keep = entries
             .iter()
-            .filter_map(|evt| match evt.event.as_ref()? {
-                Event::Exercised(x) => Some((x.node_id, x.last_descendant_node_id)),
-                _ => None,
-            })
-            .collect();
+            .position(|e| e.offset < boundary)
+            .unwrap_or(entries.len());
+        entries.truncate(keep);
+    }
 
-        for evt in tx.events {
-            let Some(e) = evt.event else { continue };
-            match e {
-                Event::Created(c) => {
-                    let Some(tid) = c.template_id.as_ref() else {
-                        continue;
-                    };
-                    let gov_type = template_index
-                        .get(&(tid.module_name.clone(), tid.entity_name.clone()))
-                        .copied()
-                        .or_else(|| {
-                            c.interface_views.iter().find_map(|iv| {
-                                let iid = iv.interface_id.as_ref()?;
-                                template_index
-                                    .get(&(iid.module_name.clone(), iid.entity_name.clone()))
-                                    .copied()
-                            })
-                        })
-                        .unwrap_or("unknown");
+    Ok(entries)
+}
 
-                    let is_child_of_exercise = exercise_ranges
-                        .iter()
-                        .any(|(start, end)| c.node_id > *start && c.node_id <= *end);
-                    let (event_type, action_summary) = classify_created(tid, is_child_of_exercise);
+/// Convert one transaction's Created/Exercised events into audit entries.
+fn transaction_entries(
+    tx: Transaction,
+    template_index: &HashMap<(String, String), &'static str>,
+) -> Vec<ChainAuditEntry> {
+    let mut entries: Vec<ChainAuditEntry> = Vec::new();
+    let tx_ts = tx.effective_at.as_ref().map(|t| t.seconds).unwrap_or(0);
+    let update_id = tx.update_id.clone();
 
-                    entries.push(ChainAuditEntry {
-                        offset: c.offset,
-                        timestamp: tx_ts,
-                        event_type,
-                        contract_id: c.contract_id,
-                        template_id: format!("{}:{}", tid.module_name, tid.entity_name),
-                        package_id: tid.package_id.clone(),
-                        governance_type: gov_type.to_string(),
-                        action_summary,
-                        choice: None,
-                        acting_parties: c.signatories,
-                        update_id: update_id.clone(),
-                        details: record_to_json(&c.create_arguments),
-                    });
-                }
-                Event::Exercised(x) => {
-                    let Some(tid) = x.template_id.as_ref() else {
-                        continue;
-                    };
-                    let gov_type = template_index
-                        .get(&(tid.module_name.clone(), tid.entity_name.clone()))
-                        .copied()
-                        .or_else(|| {
-                            let iid = x.interface_id.as_ref()?;
+    // Collect (node_id, last_descendant_node_id) for every Exercise in this
+    // transaction so we can later detect Created events that are downstream
+    // effects of an Exercise — those aren't fresh proposals.
+    let exercise_ranges: Vec<(i32, i32)> = tx
+        .events
+        .iter()
+        .filter_map(|evt| match evt.event.as_ref()? {
+            Event::Exercised(x) => Some((x.node_id, x.last_descendant_node_id)),
+            _ => None,
+        })
+        .collect();
+
+    for evt in tx.events {
+        let Some(e) = evt.event else { continue };
+        match e {
+            Event::Created(c) => {
+                let Some(tid) = c.template_id.as_ref() else {
+                    continue;
+                };
+                let gov_type = template_index
+                    .get(&(tid.module_name.clone(), tid.entity_name.clone()))
+                    .copied()
+                    .or_else(|| {
+                        c.interface_views.iter().find_map(|iv| {
+                            let iid = iv.interface_id.as_ref()?;
                             template_index
                                 .get(&(iid.module_name.clone(), iid.entity_name.clone()))
                                 .copied()
                         })
-                        .unwrap_or("unknown");
+                    })
+                    .unwrap_or("unknown");
 
-                    let event_type = classify_choice(&x.choice);
-                    let choice = x.choice.clone();
-                    entries.push(ChainAuditEntry {
-                        offset: x.offset,
-                        timestamp: tx_ts,
-                        event_type,
-                        contract_id: x.contract_id,
-                        template_id: format!("{}:{}", tid.module_name, tid.entity_name),
-                        package_id: tid.package_id.clone(),
-                        governance_type: gov_type.to_string(),
-                        action_summary: choice.clone(),
-                        choice: Some(choice),
-                        acting_parties: x.acting_parties,
-                        update_id: update_id.clone(),
-                        details: optional_value_to_json(&x.choice_argument),
-                    });
-                }
-                Event::Archived(_) => {
-                    // Under LedgerEffects we get Exercised (consuming) instead; skip.
-                }
+                let is_child_of_exercise = exercise_ranges
+                    .iter()
+                    .any(|(start, end)| c.node_id > *start && c.node_id <= *end);
+                let (event_type, action_summary) = classify_created(tid, is_child_of_exercise);
+
+                entries.push(ChainAuditEntry {
+                    offset: c.offset,
+                    timestamp: tx_ts,
+                    event_type,
+                    contract_id: c.contract_id,
+                    template_id: format!("{}:{}", tid.module_name, tid.entity_name),
+                    package_id: tid.package_id.clone(),
+                    governance_type: gov_type.to_string(),
+                    action_summary,
+                    choice: None,
+                    acting_parties: c.signatories,
+                    update_id: update_id.clone(),
+                    details: record_to_json(&c.create_arguments),
+                });
+            }
+            Event::Exercised(x) => {
+                let Some(tid) = x.template_id.as_ref() else {
+                    continue;
+                };
+                let gov_type = template_index
+                    .get(&(tid.module_name.clone(), tid.entity_name.clone()))
+                    .copied()
+                    .or_else(|| {
+                        let iid = x.interface_id.as_ref()?;
+                        template_index
+                            .get(&(iid.module_name.clone(), iid.entity_name.clone()))
+                            .copied()
+                    })
+                    .unwrap_or("unknown");
+
+                let event_type = classify_choice(&x.choice);
+                let choice = x.choice.clone();
+                entries.push(ChainAuditEntry {
+                    offset: x.offset,
+                    timestamp: tx_ts,
+                    event_type,
+                    contract_id: x.contract_id,
+                    template_id: format!("{}:{}", tid.module_name, tid.entity_name),
+                    package_id: tid.package_id.clone(),
+                    governance_type: gov_type.to_string(),
+                    action_summary: choice.clone(),
+                    choice: Some(choice),
+                    acting_parties: x.acting_parties,
+                    update_id: update_id.clone(),
+                    details: optional_value_to_json(&x.choice_argument),
+                });
+            }
+            Event::Archived(_) => {
+                // Under LedgerEffects we get Exercised (consuming) instead; skip.
             }
         }
     }
 
-    Ok(entries)
+    entries
 }
 
 /// Save chain audit entries to the cache table.

--- a/crates/decman/src/server/event_filters.rs
+++ b/crates/decman/src/server/event_filters.rs
@@ -1,0 +1,76 @@
+//! Builders for the ledger-API `EventFormat` every ACS, update and
+//! by-contract-id read carries.
+//!
+//! A read is "filter + extractor". These cover the filter half so each fetcher
+//! is left with only the part specific to it: which templates it wants and what
+//! it pulls out of the events.
+
+use std::collections::HashMap;
+
+use canton_proto_rs::com::daml::ledger::api::v2::{
+    CumulativeFilter, EventFormat, Filters, Identifier, InterfaceFilter, TemplateFilter,
+    WildcardFilter, cumulative_filter,
+};
+
+/// An `EventFormat` applying `cumulative` to a single party.
+///
+/// `verbose` asks Canton for field labels in the returned records; readers that
+/// look values up by label need it, ones that only read a contract id do not.
+pub(crate) fn party_event_format(
+    party_id: impl std::fmt::Display,
+    cumulative: Vec<CumulativeFilter>,
+    verbose: bool,
+) -> EventFormat {
+    let mut filters_by_party = HashMap::new();
+    filters_by_party.insert(party_id.to_string(), Filters { cumulative });
+
+    EventFormat {
+        filters_by_party,
+        filters_for_any_party: None,
+        verbose,
+    }
+}
+
+/// Every contract the party can see — for reads that narrow client-side because
+/// Canton can't express the filter, or that run against a test participant.
+pub(crate) fn wildcard_filter(include_created_event_blob: bool) -> CumulativeFilter {
+    CumulativeFilter {
+        identifier_filter: Some(cumulative_filter::IdentifierFilter::WildcardFilter(
+            WildcardFilter {
+                include_created_event_blob,
+            },
+        )),
+    }
+}
+
+/// One template, narrowed Canton-side.
+pub(crate) fn template_filter(
+    template_id: Identifier,
+    include_created_event_blob: bool,
+) -> CumulativeFilter {
+    CumulativeFilter {
+        identifier_filter: Some(cumulative_filter::IdentifierFilter::TemplateFilter(
+            TemplateFilter {
+                template_id: Some(template_id),
+                include_created_event_blob,
+            },
+        )),
+    }
+}
+
+/// One interface, with the computed view — the shape the token-standard
+/// registry contracts are read through.
+pub(crate) fn interface_filter(
+    interface_id: Identifier,
+    include_created_event_blob: bool,
+) -> CumulativeFilter {
+    CumulativeFilter {
+        identifier_filter: Some(cumulative_filter::IdentifierFilter::InterfaceFilter(
+            InterfaceFilter {
+                interface_id: Some(interface_id),
+                include_interface_view: true,
+                include_created_event_blob,
+            },
+        )),
+    }
+}

--- a/crates/decman/src/server/handlers/governance.rs
+++ b/crates/decman/src/server/handlers/governance.rs
@@ -1001,6 +1001,11 @@ pub async fn get_governance_chain_audit(
 ) -> impl Responder {
     let party_id = &query.party_id;
 
+    // `limit` is caller-supplied; a zero-row page needs no ledger reads.
+    if query.limit == 0 {
+        return HttpResponse::Ok().json(chain_audit_response(Vec::new(), false));
+    }
+
     if !query.refresh {
         // Return from cache. An empty result is treated as a miss rather than
         // an answer: the cache only holds the pages fetched so far, so paging

--- a/crates/decman/src/server/handlers/governance.rs
+++ b/crates/decman/src/server/handlers/governance.rs
@@ -970,13 +970,12 @@ pub async fn get_governance_audit(
 
 /// Wrap a page of audit entries, deriving the cursor for the next (older) page.
 ///
-/// A short page means the trail is exhausted, so no cursor is handed back and
-/// the UI stops asking.
-fn chain_audit_response(entries: Vec<ChainAuditEntry>, limit: usize) -> ChainAuditResponse {
+/// `has_more` is passed in rather than inferred from the row count: a page can
+/// hold more than `limit` rows (it is extended to the end of an offset group),
+/// so counting rows would hand out a cursor to a page that turns out empty.
+fn chain_audit_response(entries: Vec<ChainAuditEntry>, has_more: bool) -> ChainAuditResponse {
     let total_returned = entries.len();
-    let next_before_offset = (total_returned >= limit && limit > 0)
-        .then(|| entries.last().map(|e| e.offset))
-        .flatten();
+    let next_before_offset = has_more.then(|| entries.last().map(|e| e.offset)).flatten();
 
     ChainAuditResponse {
         entries,
@@ -1013,9 +1012,14 @@ pub async fn get_governance_chain_audit(
             .await
         {
             Ok(rows) if !rows.is_empty() => {
+                // The cache only mirrors the pages fetched so far, so it cannot
+                // prove the trail is exhausted. A full page is reported as
+                // "more" and the next request falls through to Canton — better
+                // a spare empty page than hiding entries that do exist.
+                let has_more = rows.len() >= query.limit;
                 let entries: Vec<ChainAuditEntry> =
                     rows.into_iter().map(chain_audit_entry_from_row).collect();
-                return HttpResponse::Ok().json(chain_audit_response(entries, query.limit));
+                return HttpResponse::Ok().json(chain_audit_response(entries, has_more));
             }
             Ok(_) => {}
             Err(e) => {
@@ -1039,16 +1043,16 @@ pub async fn get_governance_chain_audit(
     )
     .await
     {
-        Ok(entries) => {
+        Ok(page) => {
             // Save to cache in background
             let pool = data.db.clone();
             let pid = party_id.clone();
-            let cached = entries.clone();
+            let cached = page.entries.clone();
             tokio::spawn(async move {
                 chain_audit::save_chain_audit_cache(&pool, &pid, &cached).await;
             });
 
-            HttpResponse::Ok().json(chain_audit_response(entries, query.limit))
+            HttpResponse::Ok().json(chain_audit_response(page.entries, page.has_more))
         }
         Err(e) => {
             tracing::error!("Failed to fetch chain audit for {party_id}: {e:#}");

--- a/crates/decman/src/server/handlers/governance.rs
+++ b/crates/decman/src/server/handlers/governance.rs
@@ -968,6 +968,23 @@ pub async fn get_governance_audit(
     }
 }
 
+/// Wrap a page of audit entries, deriving the cursor for the next (older) page.
+///
+/// A short page means the trail is exhausted, so no cursor is handed back and
+/// the UI stops asking.
+fn chain_audit_response(entries: Vec<ChainAuditEntry>, limit: usize) -> ChainAuditResponse {
+    let total_returned = entries.len();
+    let next_before_offset = (total_returned >= limit && limit > 0)
+        .then(|| entries.last().map(|e| e.offset))
+        .flatten();
+
+    ChainAuditResponse {
+        entries,
+        total_returned,
+        next_before_offset,
+    }
+}
+
 /// Get on-chain governance audit entries.
 /// Returns cached data by default. Pass `refresh=true` to fetch from Canton and update cache.
 #[utoipa::path(
@@ -986,21 +1003,21 @@ pub async fn get_governance_chain_audit(
     let party_id = &query.party_id;
 
     if !query.refresh {
-        // Return from cache
+        // Return from cache. An empty result is treated as a miss rather than
+        // an answer: the cache only holds the pages fetched so far, so paging
+        // past its tail (or a cold start) has to reach Canton instead of
+        // reporting the trail as exhausted.
         match data
             .db
-            .get_chain_audit_cache(party_id, query.limit as i64)
+            .get_chain_audit_cache(party_id, query.limit as i64, query.before_offset)
             .await
         {
-            Ok(rows) => {
+            Ok(rows) if !rows.is_empty() => {
                 let entries: Vec<ChainAuditEntry> =
                     rows.into_iter().map(chain_audit_entry_from_row).collect();
-                let total_returned = entries.len();
-                return HttpResponse::Ok().json(ChainAuditResponse {
-                    entries,
-                    total_returned,
-                });
+                return HttpResponse::Ok().json(chain_audit_response(entries, query.limit));
             }
+            Ok(_) => {}
             Err(e) => {
                 tracing::warn!("Failed to read chain audit cache: {e}");
                 // Fall through to live query
@@ -1012,7 +1029,16 @@ pub async fn get_governance_chain_audit(
     let token = get_party_token(&data, party_id).await;
     let pkgs = packages();
 
-    match chain_audit::get_chain_audit(&data.config, party_id, token, &pkgs, query.limit).await {
+    match chain_audit::get_chain_audit(
+        &data.config,
+        party_id,
+        token,
+        &pkgs,
+        query.limit,
+        query.before_offset,
+    )
+    .await
+    {
         Ok(entries) => {
             // Save to cache in background
             let pool = data.db.clone();
@@ -1022,11 +1048,7 @@ pub async fn get_governance_chain_audit(
                 chain_audit::save_chain_audit_cache(&pool, &pid, &cached).await;
             });
 
-            let total_returned = entries.len();
-            HttpResponse::Ok().json(ChainAuditResponse {
-                entries,
-                total_returned,
-            })
+            HttpResponse::Ok().json(chain_audit_response(entries, query.limit))
         }
         Err(e) => {
             tracing::error!("Failed to fetch chain audit for {party_id}: {e:#}");

--- a/crates/decman/src/server/handlers/governance.rs
+++ b/crates/decman/src/server/handlers/governance.rs
@@ -21,7 +21,7 @@ use crate::{
     auth::WorkflowAuth,
     canton_id::CantonId,
     config::{NetworkConfig, NodeConfig, PackageConfig, default_package_config},
-    db::schema::SchemaRead,
+    db::{rows::ChainAuditCacheRow, schema::SchemaRead},
     error::Result,
     noise::{Message, MessageType, NoiseKeypair, parse_public_key, send_noise_message},
     server::{
@@ -984,6 +984,29 @@ fn chain_audit_response(entries: Vec<ChainAuditEntry>, has_more: bool) -> ChainA
     }
 }
 
+/// The cached answer for a page request, or `None` when the cache cannot answer
+/// it and the read has to reach Canton.
+///
+/// An empty result is a miss rather than an answer: the cache only holds the
+/// pages fetched so far, so paging past its tail (or a cold start) must not be
+/// reported as an exhausted trail.
+fn cached_chain_audit_page(
+    rows: Vec<ChainAuditCacheRow>,
+    limit: usize,
+) -> Option<ChainAuditResponse> {
+    if rows.is_empty() {
+        return None;
+    }
+
+    // The cache cannot prove the trail is exhausted either, so a full page is
+    // reported as "more" and the next request falls through to Canton — better
+    // a spare empty page than hiding entries that do exist.
+    let has_more = rows.len() >= limit;
+    let entries: Vec<ChainAuditEntry> = rows.into_iter().map(chain_audit_entry_from_row).collect();
+
+    Some(chain_audit_response(entries, has_more))
+}
+
 /// Get on-chain governance audit entries.
 /// Returns cached data by default. Pass `refresh=true` to fetch from Canton and update cache.
 #[utoipa::path(
@@ -1000,33 +1023,26 @@ pub async fn get_governance_chain_audit(
     query: web::Query<ChainAuditQuery>,
 ) -> impl Responder {
     let party_id = &query.party_id;
+    // `limit` is caller-supplied, so it is bounded here rather than trusted:
+    // one page must not be able to ask for the whole retained ledger.
+    let limit = query.clamped_limit();
 
-    // `limit` is caller-supplied; a zero-row page needs no ledger reads.
-    if query.limit == 0 {
+    // A zero-row page needs no ledger reads.
+    if limit == 0 {
         return HttpResponse::Ok().json(chain_audit_response(Vec::new(), false));
     }
 
     if !query.refresh {
-        // Return from cache. An empty result is treated as a miss rather than
-        // an answer: the cache only holds the pages fetched so far, so paging
-        // past its tail (or a cold start) has to reach Canton instead of
-        // reporting the trail as exhausted.
         match data
             .db
-            .get_chain_audit_cache(party_id, query.limit as i64, query.before_offset)
+            .get_chain_audit_cache(party_id, limit as i64, query.before_offset)
             .await
         {
-            Ok(rows) if !rows.is_empty() => {
-                // The cache only mirrors the pages fetched so far, so it cannot
-                // prove the trail is exhausted. A full page is reported as
-                // "more" and the next request falls through to Canton — better
-                // a spare empty page than hiding entries that do exist.
-                let has_more = rows.len() >= query.limit;
-                let entries: Vec<ChainAuditEntry> =
-                    rows.into_iter().map(chain_audit_entry_from_row).collect();
-                return HttpResponse::Ok().json(chain_audit_response(entries, has_more));
+            Ok(rows) => {
+                if let Some(response) = cached_chain_audit_page(rows, limit) {
+                    return HttpResponse::Ok().json(response);
+                }
             }
-            Ok(_) => {}
             Err(e) => {
                 tracing::warn!("Failed to read chain audit cache: {e}");
                 // Fall through to live query
@@ -1043,7 +1059,7 @@ pub async fn get_governance_chain_audit(
         party_id,
         token,
         &pkgs,
-        query.limit,
+        limit,
         query.before_offset,
     )
     .await
@@ -2886,5 +2902,104 @@ mod propose_guard_tests {
         assert!(!may_create_second_delegation(&setup_with_prior));
         // unrelated proposals are never blocked, and never pay for the read
         assert!(!may_create_second_delegation(&unrelated));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry_at(offset: i64) -> ChainAuditEntry {
+        ChainAuditEntry {
+            offset,
+            timestamp: 0,
+            event_type: "propose".to_string(),
+            contract_id: String::new(),
+            template_id: String::new(),
+            package_id: String::new(),
+            governance_type: "core_domain".to_string(),
+            action_summary: String::new(),
+            choice: None,
+            acting_parties: Vec::new(),
+            update_id: String::new(),
+            details: serde_json::Value::Null,
+        }
+    }
+
+    fn cache_row_at(offset: i64) -> ChainAuditCacheRow {
+        ChainAuditCacheRow {
+            party_id: "dec::1220ff".to_string(),
+            offset,
+            timestamp: 0,
+            event_type: "propose".to_string(),
+            contract_id: String::new(),
+            template_id: String::new(),
+            package_id: String::new(),
+            governance_type: "core_domain".to_string(),
+            action_summary: String::new(),
+            choice: None,
+            acting_parties: "[]".to_string(),
+            update_id: String::new(),
+            details: "null".to_string(),
+        }
+    }
+
+    /// The cursor is the oldest offset on the page, since the next request asks
+    /// for `offset < cursor`.
+    #[test]
+    fn cursor_is_the_oldest_offset_when_more_exist() {
+        let response = chain_audit_response(vec![entry_at(30), entry_at(20), entry_at(10)], true);
+        assert_eq!(response.next_before_offset, Some(10));
+        assert_eq!(response.total_returned, 3);
+    }
+
+    #[test]
+    fn no_cursor_when_nothing_older_exists() {
+        let response = chain_audit_response(vec![entry_at(30), entry_at(20)], false);
+        assert_eq!(response.next_before_offset, None);
+        assert_eq!(response.total_returned, 2);
+    }
+
+    /// A `has_more` with no rows to derive a cursor from must not hand out one:
+    /// there is no offset to page before, and inventing one would skip entries.
+    #[test]
+    fn no_cursor_from_an_empty_page() {
+        let response = chain_audit_response(Vec::new(), true);
+        assert_eq!(response.next_before_offset, None);
+        assert_eq!(response.total_returned, 0);
+    }
+
+    /// An empty cache read is a miss, not "the trail ends here" — the caller
+    /// has to fall through to Canton.
+    #[test]
+    fn empty_cache_is_a_miss() {
+        assert!(cached_chain_audit_page(Vec::new(), 2).is_none());
+    }
+
+    /// A cache page that fills `limit` is reported as having more, so the next
+    /// request reaches Canton rather than stopping at the cache's tail.
+    #[test]
+    fn full_cache_page_reports_more() {
+        let response = cached_chain_audit_page(vec![cache_row_at(30), cache_row_at(20)], 2)
+            .expect("non-empty rows are a hit");
+        assert_eq!(response.next_before_offset, Some(20));
+    }
+
+    #[test]
+    fn short_cache_page_reports_no_more() {
+        let response =
+            cached_chain_audit_page(vec![cache_row_at(30)], 2).expect("non-empty rows are a hit");
+        assert_eq!(response.next_before_offset, None);
+        assert_eq!(response.total_returned, 1);
+    }
+
+    /// An over-`limit` cache page (a whole offset group kept together) still
+    /// reports more, and its cursor is the oldest offset returned.
+    #[test]
+    fn oversized_cache_page_reports_more() {
+        let rows = vec![cache_row_at(30), cache_row_at(20), cache_row_at(20)];
+        let response = cached_chain_audit_page(rows, 2).expect("non-empty rows are a hit");
+        assert_eq!(response.total_returned, 3);
+        assert_eq!(response.next_before_offset, Some(20));
     }
 }

--- a/crates/decman/src/server/handlers/parties.rs
+++ b/crates/decman/src/server/handlers/parties.rs
@@ -866,9 +866,8 @@ pub async fn fetch_decentralized_parties(
 )]
 #[get("/packages/vetted")]
 pub async fn get_vetted_packages(data: web::Data<AppState>) -> impl Responder {
-    // Reads topology vetting state. The admin `ListPackages` this used to call
-    // lists every *uploaded* DAR, a strictly larger set — an uploaded-but-
-    // unvetted package was previously reported as vetted.
+    // Reads topology vetting state: vetting is a strict subset of the uploaded
+    // DARs, and the admin `ListPackages` reports the larger set.
     match fetch_vetted_packages(&data.config).await {
         Ok(packages) => HttpResponse::Ok().json(packages),
         Err(e) => {

--- a/crates/decman/src/server/handlers/parties.rs
+++ b/crates/decman/src/server/handlers/parties.rs
@@ -40,7 +40,7 @@ use crate::{
     server::{
         AppState,
         health::classify_health_reply,
-        ledger_paging::fetch_vetted_packages,
+        package_inventory::fetch_vetted_packages,
         queries::{get_contracts, get_party_metadata, sort_contracts},
         types::{
             ConnectionStatus, ContractInfo, DecentralizedPartiesResponse, DecentralizedParty,
@@ -866,29 +866,18 @@ pub async fn fetch_decentralized_parties(
 )]
 #[get("/packages/vetted")]
 pub async fn get_vetted_packages(data: web::Data<AppState>) -> impl Responder {
-    // Reads the participant's topology vetting state via the ledger API's
-    // paginated `ListVettedPackages`. The admin `ListPackages` this used to
-    // call lists every *uploaded* DAR, which is a strictly larger set — an
-    // uploaded-but-unvetted package was previously reported as vetted.
-    let vetted = match fetch_vetted_packages(&data.config, None).await {
-        Ok(vetted) => vetted,
+    // Reads topology vetting state. The admin `ListPackages` this used to call
+    // lists every *uploaded* DAR, a strictly larger set — an uploaded-but-
+    // unvetted package was previously reported as vetted.
+    match fetch_vetted_packages(&data.config).await {
+        Ok(packages) => HttpResponse::Ok().json(packages),
         Err(e) => {
-            return HttpResponse::InternalServerError().json(ErrorResponse {
+            tracing::error!("Failed to list vetted packages: {e:#}");
+            HttpResponse::InternalServerError().json(ErrorResponse {
                 error: format!("Failed to list vetted packages: {e}"),
-            });
+            })
         }
-    };
-
-    let packages: Vec<VettedPackageInfo> = vetted
-        .into_iter()
-        .map(|p| VettedPackageInfo {
-            package_id: p.package_id,
-            package_name: p.package_name,
-            package_version: p.package_version,
-        })
-        .collect();
-
-    HttpResponse::Ok().json(packages)
+    }
 }
 
 /// Check connectivity status of all participants

--- a/crates/decman/src/server/handlers/parties.rs
+++ b/crates/decman/src/server/handlers/parties.rs
@@ -40,6 +40,7 @@ use crate::{
     server::{
         AppState,
         health::classify_health_reply,
+        ledger_paging::fetch_vetted_packages,
         queries::{get_contracts, get_party_metadata, sort_contracts},
         types::{
             ConnectionStatus, ContractInfo, DecentralizedPartiesResponse, DecentralizedParty,
@@ -865,37 +866,25 @@ pub async fn fetch_decentralized_parties(
 )]
 #[get("/packages/vetted")]
 pub async fn get_vetted_packages(data: web::Data<AppState>) -> impl Responder {
-    let mut client = match data.config.admin_channel().await {
-        Ok(channel) => PackageServiceClient::new(channel),
+    // Reads the participant's topology vetting state via the ledger API's
+    // paginated `ListVettedPackages`. The admin `ListPackages` this used to
+    // call lists every *uploaded* DAR, which is a strictly larger set — an
+    // uploaded-but-unvetted package was previously reported as vetted.
+    let vetted = match fetch_vetted_packages(&data.config, None).await {
+        Ok(vetted) => vetted,
         Err(e) => {
             return HttpResponse::InternalServerError().json(ErrorResponse {
-                error: format!("Failed to connect to Canton: {e}"),
+                error: format!("Failed to list vetted packages: {e}"),
             });
         }
     };
 
-    let response = match client
-        .list_packages(tonic::Request::new(ListPackagesRequest {
-            limit: 0,
-            filter_name: String::new(),
-        }))
-        .await
-    {
-        Ok(r) => r.into_inner(),
-        Err(e) => {
-            return HttpResponse::InternalServerError().json(ErrorResponse {
-                error: format!("Failed to list packages: {e}"),
-            });
-        }
-    };
-
-    let packages: Vec<VettedPackageInfo> = response
-        .package_descriptions
+    let packages: Vec<VettedPackageInfo> = vetted
         .into_iter()
         .map(|p| VettedPackageInfo {
             package_id: p.package_id,
-            package_name: p.name,
-            package_version: p.version,
+            package_name: p.package_name,
+            package_version: p.package_version,
         })
         .collect();
 

--- a/crates/decman/src/server/handlers/tenant.rs
+++ b/crates/decman/src/server/handlers/tenant.rs
@@ -20,9 +20,9 @@
 use actix_web::{HttpRequest, HttpResponse, Responder, get, post, web};
 use base64::{Engine, engine::general_purpose::STANDARD};
 use canton_proto_rs::com::daml::ledger::api::v2::{
-    Command, CreateCommand, CumulativeFilter, EventFormat, Filters, GetActiveContractsRequest,
-    GetLedgerEndRequest, Identifier, List, Optional, Record, RecordField, Signature,
-    SignatureFormat, SigningAlgorithmSpec, Value, WildcardFilter, command, cumulative_filter,
+    Command, CreateCommand, GetActiveContractsRequest, GetLedgerEndRequest, Identifier, List,
+    Optional, Record, RecordField, Signature, SignatureFormat, SigningAlgorithmSpec, Value,
+    command,
     get_active_contracts_response::ContractEntry,
     interactive::{
         ExecuteSubmissionRequest, PartySignatures, PrepareSubmissionRequest, PreparedTransaction,
@@ -39,6 +39,7 @@ use crate::{
     error::Result,
     server::{
         AppState,
+        event_filters::{party_event_format, wildcard_filter},
         middleware::require_tenant_api_key,
         types::{
             ErrorResponse, TenantAcsResponse, TenantContract, TenantExecuteSubmissionRequest,
@@ -538,29 +539,15 @@ async fn fetch_party_acs(
         .into_inner()
         .offset;
 
-    let mut filters_by_party = std::collections::HashMap::new();
-    filters_by_party.insert(
-        party_id.to_string(),
-        Filters {
-            cumulative: vec![CumulativeFilter {
-                identifier_filter: Some(cumulative_filter::IdentifierFilter::WildcardFilter(
-                    WildcardFilter {
-                        include_created_event_blob: false,
-                    },
-                )),
-            }],
-        },
-    );
-
     let request = GetActiveContractsRequest {
         active_at_offset: ledger_end,
-        event_format: Some(EventFormat {
-            filters_by_party,
-            filters_for_any_party: None,
-            // Verbose so created events carry record field labels, which makes
-            // `create_arguments` render as a labelled JSON object.
-            verbose: true,
-        }),
+        // Verbose so created events carry record field labels, which makes
+        // `create_arguments` render as a labelled JSON object.
+        event_format: Some(party_event_format(
+            party_id,
+            vec![wildcard_filter(false)],
+            true,
+        )),
         stream_continuation_token: None,
     };
 

--- a/crates/decman/src/server/ledger_paging.rs
+++ b/crates/decman/src/server/ledger_paging.rs
@@ -21,7 +21,7 @@ use canton_proto_rs::com::daml::ledger::api::v2::{
 };
 
 /// Rows pulled from Canton per round trip when collecting a full result set.
-const FETCH_CHUNK: i32 = 1000;
+pub(crate) const FETCH_CHUNK: i32 = 1000;
 
 /// Did the participant reject this RPC because it predates Canton 3.5.1?
 fn is_unimplemented(status: &tonic::Status) -> bool {
@@ -296,16 +296,27 @@ pub(crate) async fn fetch_transactions_page(
                 "GetUpdatesPage unavailable (participant older than Canton 3.5.1); falling back \
                  to the streaming update read"
             );
-            let mut transactions =
+            let transactions =
                 stream_transactions(config, token, begin_exclusive, end_inclusive, update_format)
                     .await?;
-            transactions.reverse();
-            Ok(TransactionPage {
-                transactions,
-                next_page_token: None,
-            })
+            Ok(descending_page(transactions))
         }
         Err(status) => Err(status.into()),
+    }
+}
+
+/// Present an ascending stream of transactions as one descending page.
+///
+/// The pre-3.5.1 `GetUpdates` has no "newest first" option, so the reversal
+/// here is what makes the fallback meet the same contract as the paged RPC.
+/// There is no continuation token to hand back: the stream drained the whole
+/// range in one go.
+fn descending_page(mut transactions: Vec<Transaction>) -> TransactionPage {
+    transactions.reverse();
+
+    TransactionPage {
+        transactions,
+        next_page_token: None,
     }
 }
 
@@ -340,4 +351,65 @@ async fn stream_transactions(
     }
 
     Ok(transactions)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tx_at(offset: i64) -> Transaction {
+        Transaction {
+            offset,
+            update_id: format!("update-{offset}"),
+            ..Default::default()
+        }
+    }
+
+    fn offsets_of(page: &TransactionPage) -> Vec<i64> {
+        page.transactions.iter().map(|tx| tx.offset).collect()
+    }
+
+    /// The pre-3.5.1 stream arrives oldest-first; callers page newest-first, so
+    /// the fallback has to hand back the reverse of what it read.
+    #[test]
+    fn fallback_page_is_newest_first() {
+        let page = descending_page(vec![tx_at(10), tx_at(20), tx_at(30)]);
+
+        assert_eq!(offsets_of(&page), vec![30, 20, 10]);
+    }
+
+    /// The stream drained the whole range, so there is nothing to continue
+    /// from — a token here would send the caller round the same range again.
+    #[test]
+    fn fallback_page_has_no_continuation() {
+        let page = descending_page(vec![tx_at(10)]);
+        assert!(page.next_page_token.is_none());
+
+        let empty = descending_page(Vec::new());
+        assert!(empty.transactions.is_empty());
+        assert!(empty.next_page_token.is_none());
+    }
+
+    /// Only `Unimplemented` means "this participant predates the paged RPCs".
+    /// Any other status is a real error and must not be answered with a full
+    /// unpaged read.
+    #[test]
+    fn only_unimplemented_selects_the_fallback() {
+        assert!(is_unimplemented(&tonic::Status::unimplemented(
+            "GetUpdatesPage"
+        )));
+
+        for status in [
+            tonic::Status::unavailable("participant restarting"),
+            tonic::Status::permission_denied("bad token"),
+            tonic::Status::invalid_argument("bad page token"),
+            tonic::Status::deadline_exceeded("too slow"),
+        ] {
+            assert!(
+                !is_unimplemented(&status),
+                "{code:?} must not fall back",
+                code = status.code()
+            );
+        }
+    }
 }

--- a/crates/decman/src/server/ledger_paging.rs
+++ b/crates/decman/src/server/ledger_paging.rs
@@ -13,13 +13,13 @@
 //! result set anyway; sizing that at 25 would turn one stream into hundreds of
 //! round trips.
 
+use crate::{config::NodeConfig, error::Result, utils};
 use canton_proto_rs::com::daml::ledger::api::v2::{
     CreatedEvent, EventFormat, GetActiveContractsPageRequest, GetActiveContractsRequest,
     GetLedgerEndRequest, GetUpdatesPageRequest, GetUpdatesRequest, ListVettedPackagesRequest,
     Transaction, UpdateFormat, VettedPackage, get_active_contracts_response::ContractEntry,
     get_update_response, get_updates_response,
 };
-use crate::{config::NodeConfig, error::Result, utils};
 
 /// Rows pulled from Canton per round trip when collecting a full result set.
 const FETCH_CHUNK: i32 = 1000;
@@ -31,13 +31,42 @@ fn is_unimplemented(status: &tonic::Status) -> bool {
 
 /// Every `CreatedEvent` in the party's ACS matching `event_format`, read a page
 /// at a time.
-///
-/// `active_at_offset` is pinned to the ledger end for the whole walk: a page
-/// token is only valid against the offset and event format that produced it.
 pub(crate) async fn fetch_active_contracts(
     config: &NodeConfig,
     token: Option<String>,
     event_format: EventFormat,
+) -> Result<Vec<CreatedEvent>> {
+    collect_active_contracts(config, token, event_format, None).await
+}
+
+/// The first `CreatedEvent` matching `event_format`, or `None`.
+///
+/// For "does this contract exist / read its state" lookups. Stops after one
+/// page instead of walking the whole ACS to then discard all but the first
+/// row.
+pub(crate) async fn fetch_first_active_contract(
+    config: &NodeConfig,
+    token: Option<String>,
+    event_format: EventFormat,
+) -> Result<Option<CreatedEvent>> {
+    Ok(
+        collect_active_contracts(config, token, event_format, Some(1))
+            .await?
+            .into_iter()
+            .next(),
+    )
+}
+
+/// Walk the ACS a page at a time, stopping once `max_events` have been
+/// collected (or at the end of the ACS when it is `None`).
+///
+/// `active_at_offset` is pinned to the ledger end for the whole walk: a page
+/// token is only valid against the offset and event format that produced it.
+async fn collect_active_contracts(
+    config: &NodeConfig,
+    token: Option<String>,
+    event_format: EventFormat,
+    max_events: Option<usize>,
 ) -> Result<Vec<CreatedEvent>> {
     let mut client = utils::create_state_client(config, token.clone()).await?;
 
@@ -47,6 +76,13 @@ pub(crate) async fn fetch_active_contracts(
         .into_inner()
         .offset;
 
+    // Asking for fewer rows than a full chunk when the caller only wants a
+    // handful keeps the "find first" case to a single small round trip.
+    let page_size = match max_events {
+        Some(max) => FETCH_CHUNK.min(max.try_into().unwrap_or(FETCH_CHUNK)),
+        None => FETCH_CHUNK,
+    };
+
     let mut created = Vec::new();
     let mut page_token = None;
 
@@ -54,7 +90,7 @@ pub(crate) async fn fetch_active_contracts(
         let request = GetActiveContractsPageRequest {
             active_at_offset: Some(ledger_end),
             event_format: Some(event_format.clone()),
-            max_page_size: Some(FETCH_CHUNK),
+            max_page_size: Some(page_size),
             page_token,
         };
 
@@ -68,7 +104,14 @@ pub(crate) async fn fetch_active_contracts(
                     "GetActiveContractsPage unavailable (participant older than Canton 3.5.1); \
                      falling back to the streaming ACS read"
                 );
-                return stream_active_contracts(config, token, ledger_end, event_format).await;
+                return stream_active_contracts(
+                    config,
+                    token,
+                    ledger_end,
+                    event_format,
+                    max_events,
+                )
+                .await;
             }
             Err(status) => return Err(status.into()),
         };
@@ -81,6 +124,10 @@ pub(crate) async fn fetch_active_contracts(
             }
         }
 
+        if max_events.is_some_and(|max| created.len() >= max) {
+            break;
+        }
+
         match page.next_page_token {
             Some(next) if !next.is_empty() => page_token = Some(next),
             _ => break,
@@ -90,7 +137,8 @@ pub(crate) async fn fetch_active_contracts(
     Ok(created)
 }
 
-/// Pre-3.5.1 path for [`fetch_active_contracts`]: one unbounded server stream.
+/// Pre-3.5.1 path for [`collect_active_contracts`]: one server stream, stopped
+/// early once `max_events` have arrived.
 ///
 /// Builds its own client because the caller's has already been moved into the
 /// failed paged attempt.
@@ -99,6 +147,7 @@ async fn stream_active_contracts(
     token: Option<String>,
     ledger_end: i64,
     event_format: EventFormat,
+    max_events: Option<usize>,
 ) -> Result<Vec<CreatedEvent>> {
     let mut client = utils::create_state_client(config, token).await?;
 
@@ -119,6 +168,9 @@ async fn stream_active_contracts(
             && let Some(event) = active.created_event
         {
             created.push(event);
+            if max_events.is_some_and(|max| created.len() >= max) {
+                break;
+            }
         }
     }
 

--- a/crates/decman/src/server/ledger_paging.rs
+++ b/crates/decman/src/server/ledger_paging.rs
@@ -19,8 +19,6 @@ use canton_proto_rs::com::daml::ledger::api::v2::{
     Transaction, UpdateFormat, VettedPackage, get_active_contracts_response::ContractEntry,
     get_update_response, get_updates_response,
 };
-use common::api::PAGE_SIZE;
-
 use crate::{config::NodeConfig, error::Result, utils};
 
 /// Rows pulled from Canton per round trip when collecting a full result set.
@@ -222,7 +220,7 @@ pub(crate) async fn fetch_vetted_packages(
                 package_metadata_filter: None,
                 topology_state_filter: None,
                 page_token: page_token.clone(),
-                page_size: PAGE_SIZE as u32,
+                page_size: FETCH_CHUNK as u32,
             }))
             .await?
             .into_inner();

--- a/crates/decman/src/server/ledger_paging.rs
+++ b/crates/decman/src/server/ledger_paging.rs
@@ -1,0 +1,276 @@
+//! Paginated Canton ledger-API reads.
+//!
+//! Canton grew pagination for the bulk read endpoints in 3.5.1
+//! (`GetActiveContractsPage`, `GetUpdatesPage`); before that the only option
+//! was a server-side stream that ran until the whole result set had been sent.
+//! Every read in this crate goes through the helpers here so there is one
+//! place that speaks the paged protocol, and one place that falls back to the
+//! old streaming call when the participant is older than 3.5.1.
+//!
+//! Note the two different page sizes. [`common::api::PAGE_SIZE`] is the *wire*
+//! page size — what an API client or the UI gets in one response. [`FETCH_CHUNK`]
+//! is how much we pull from Canton per round trip when a caller needs the whole
+//! result set anyway; sizing that at 25 would turn one stream into hundreds of
+//! round trips.
+
+use canton_proto_rs::com::daml::ledger::api::v2::{
+    CreatedEvent, EventFormat, GetActiveContractsPageRequest, GetActiveContractsRequest,
+    GetLedgerEndRequest, GetUpdatesPageRequest, GetUpdatesRequest, ListVettedPackagesRequest,
+    Transaction, UpdateFormat, VettedPackage, get_active_contracts_response::ContractEntry,
+    get_update_response, get_updates_response,
+};
+use common::api::PAGE_SIZE;
+
+use crate::{config::NodeConfig, error::Result, utils};
+
+/// Rows pulled from Canton per round trip when collecting a full result set.
+const FETCH_CHUNK: i32 = 1000;
+
+/// Did the participant reject this RPC because it predates Canton 3.5.1?
+fn is_unimplemented(status: &tonic::Status) -> bool {
+    status.code() == tonic::Code::Unimplemented
+}
+
+/// Every `CreatedEvent` in the party's ACS matching `event_format`, read a page
+/// at a time.
+///
+/// `active_at_offset` is pinned to the ledger end for the whole walk: a page
+/// token is only valid against the offset and event format that produced it.
+pub(crate) async fn fetch_active_contracts(
+    config: &NodeConfig,
+    token: Option<String>,
+    event_format: EventFormat,
+) -> Result<Vec<CreatedEvent>> {
+    let mut client = utils::create_state_client(config, token.clone()).await?;
+
+    let ledger_end = client
+        .get_ledger_end(tonic::Request::new(GetLedgerEndRequest {}))
+        .await?
+        .into_inner()
+        .offset;
+
+    let mut created = Vec::new();
+    let mut page_token = None;
+
+    loop {
+        let request = GetActiveContractsPageRequest {
+            active_at_offset: Some(ledger_end),
+            event_format: Some(event_format.clone()),
+            max_page_size: Some(FETCH_CHUNK),
+            page_token,
+        };
+
+        let page = match client
+            .get_active_contracts_page(tonic::Request::new(request))
+            .await
+        {
+            Ok(page) => page.into_inner(),
+            Err(status) if is_unimplemented(&status) => {
+                tracing::debug!(
+                    "GetActiveContractsPage unavailable (participant older than Canton 3.5.1); \
+                     falling back to the streaming ACS read"
+                );
+                return stream_active_contracts(config, token, ledger_end, event_format).await;
+            }
+            Err(status) => return Err(status.into()),
+        };
+
+        for response in page.active_contracts {
+            if let Some(ContractEntry::ActiveContract(active)) = response.contract_entry
+                && let Some(event) = active.created_event
+            {
+                created.push(event);
+            }
+        }
+
+        match page.next_page_token {
+            Some(next) if !next.is_empty() => page_token = Some(next),
+            _ => break,
+        }
+    }
+
+    Ok(created)
+}
+
+/// Pre-3.5.1 path for [`fetch_active_contracts`]: one unbounded server stream.
+///
+/// Builds its own client because the caller's has already been moved into the
+/// failed paged attempt.
+async fn stream_active_contracts(
+    config: &NodeConfig,
+    token: Option<String>,
+    ledger_end: i64,
+    event_format: EventFormat,
+) -> Result<Vec<CreatedEvent>> {
+    let mut client = utils::create_state_client(config, token).await?;
+
+    let request = GetActiveContractsRequest {
+        active_at_offset: ledger_end,
+        event_format: Some(event_format),
+        stream_continuation_token: None,
+    };
+
+    let mut stream = client
+        .get_active_contracts(tonic::Request::new(request))
+        .await?
+        .into_inner();
+
+    let mut created = Vec::new();
+    while let Some(response) = stream.message().await? {
+        if let Some(ContractEntry::ActiveContract(active)) = response.contract_entry
+            && let Some(event) = active.created_event
+        {
+            created.push(event);
+        }
+    }
+
+    Ok(created)
+}
+
+/// One page of transactions, newest first, plus the token for the page after
+/// it.
+///
+/// The paged and streaming RPCs return different `update` oneofs
+/// (`GetUpdateResponse` vs `GetUpdatesResponse` — the latter also carries
+/// offset checkpoints), so both paths are narrowed to transactions here and
+/// callers see one shape.
+pub(crate) struct TransactionPage {
+    pub transactions: Vec<Transaction>,
+    pub next_page_token: Option<Vec<u8>>,
+}
+
+/// Read updates in `(begin_exclusive, end_inclusive]` newest-first, one page at
+/// a time, so a caller that only wants the most recent N can stop early instead
+/// of draining the whole ledger.
+///
+/// On a pre-3.5.1 participant there is no way to ask for "newest first" — the
+/// fallback drains the range in ascending order and reverses, which is exactly
+/// the behaviour this replaces.
+pub(crate) async fn fetch_transactions_page(
+    config: &NodeConfig,
+    token: Option<String>,
+    begin_exclusive: i64,
+    end_inclusive: i64,
+    update_format: UpdateFormat,
+    page_token: Option<Vec<u8>>,
+) -> Result<TransactionPage> {
+    let mut client = utils::create_update_client(config, token.clone()).await?;
+
+    let request = GetUpdatesPageRequest {
+        begin_offset_exclusive: Some(begin_exclusive),
+        end_offset_inclusive: Some(end_inclusive),
+        max_page_size: Some(FETCH_CHUNK),
+        update_format: Some(update_format.clone()),
+        descending_order: true,
+        page_token,
+    };
+
+    match client.get_updates_page(tonic::Request::new(request)).await {
+        Ok(page) => {
+            let page = page.into_inner();
+            let transactions = page
+                .updates
+                .into_iter()
+                .filter_map(|response| match response.update? {
+                    get_update_response::Update::Transaction(tx) => Some(tx),
+                    _ => None,
+                })
+                .collect();
+            Ok(TransactionPage {
+                transactions,
+                next_page_token: page.next_page_token.filter(|t| !t.is_empty()),
+            })
+        }
+        Err(status) if is_unimplemented(&status) => {
+            tracing::debug!(
+                "GetUpdatesPage unavailable (participant older than Canton 3.5.1); falling back \
+                 to the streaming update read"
+            );
+            let mut transactions =
+                stream_transactions(config, token, begin_exclusive, end_inclusive, update_format)
+                    .await?;
+            transactions.reverse();
+            Ok(TransactionPage {
+                transactions,
+                next_page_token: None,
+            })
+        }
+        Err(status) => Err(status.into()),
+    }
+}
+
+/// Every package currently vetted by this participant, deduplicated by package
+/// id.
+///
+/// `ListVettedPackages` landed in Canton 3.4.10 and is paginated from the
+/// outset. It reports the participant's *topology* vetting state, one entry per
+/// (participant, synchronizer) pair, so the same package id can appear more
+/// than once when a participant is connected to several synchronizers.
+pub(crate) async fn fetch_vetted_packages(
+    config: &NodeConfig,
+    token: Option<String>,
+) -> Result<Vec<VettedPackage>> {
+    let mut client = utils::create_package_client(config, token).await?;
+
+    let mut seen = std::collections::HashSet::new();
+    let mut vetted = Vec::new();
+    let mut page_token = String::new();
+
+    loop {
+        let response = client
+            .list_vetted_packages(tonic::Request::new(ListVettedPackagesRequest {
+                package_metadata_filter: None,
+                topology_state_filter: None,
+                page_token: page_token.clone(),
+                page_size: PAGE_SIZE as u32,
+            }))
+            .await?
+            .into_inner();
+
+        for entry in response.vetted_packages {
+            for package in entry.packages {
+                if seen.insert(package.package_id.clone()) {
+                    vetted.push(package);
+                }
+            }
+        }
+
+        if response.next_page_token.is_empty() {
+            return Ok(vetted);
+        }
+        page_token = response.next_page_token;
+    }
+}
+
+/// Pre-3.5.1 path for [`fetch_transactions_page`]: drain the range as one
+/// stream.
+async fn stream_transactions(
+    config: &NodeConfig,
+    token: Option<String>,
+    begin_exclusive: i64,
+    end_inclusive: i64,
+    update_format: UpdateFormat,
+) -> Result<Vec<Transaction>> {
+    let mut client = utils::create_update_client(config, token).await?;
+
+    let request = GetUpdatesRequest {
+        begin_exclusive,
+        end_inclusive: Some(end_inclusive),
+        update_format: Some(update_format),
+        descending_order: false,
+    };
+
+    let mut stream = client
+        .get_updates(tonic::Request::new(request))
+        .await?
+        .into_inner();
+
+    let mut transactions = Vec::new();
+    while let Some(response) = stream.message().await? {
+        if let Some(get_updates_response::Update::Transaction(tx)) = response.update {
+            transactions.push(tx);
+        }
+    }
+
+    Ok(transactions)
+}

--- a/crates/decman/src/server/ledger_paging.rs
+++ b/crates/decman/src/server/ledger_paging.rs
@@ -29,14 +29,64 @@ fn is_unimplemented(status: &tonic::Status) -> bool {
     status.code() == tonic::Code::Unimplemented
 }
 
-/// Every `CreatedEvent` in the party's ACS matching `event_format`, read a page
-/// at a time.
-pub(crate) async fn fetch_active_contracts(
+/// Like [`fetch_active_contracts`], but applies `extract` to each event as its
+/// page arrives and keeps only what it returns.
+///
+/// For callers that discard most of what they read — a wildcard query narrowed
+/// client-side, or a filter Canton can't express. Collecting every event first
+/// and filtering afterwards would hold the whole matching ACS in memory, which
+/// is worse than the streaming read this replaced.
+pub(crate) async fn fetch_active_contracts_filtered<T, F>(
     config: &NodeConfig,
     token: Option<String>,
     event_format: EventFormat,
-) -> Result<Vec<CreatedEvent>> {
-    collect_active_contracts(config, token, event_format, None).await
+    extract: F,
+) -> Result<Vec<T>>
+where
+    F: FnMut(CreatedEvent) -> Option<T>,
+{
+    collect_active_contracts(config, token, event_format, None, extract).await
+}
+
+/// Run `f` over every matching `CreatedEvent` as its page arrives, keeping
+/// nothing.
+///
+/// For callers that fold results into state they already own (a caller-supplied
+/// accumulator, a map keyed by contract id) rather than building a list.
+pub(crate) async fn for_each_active_contract<F>(
+    config: &NodeConfig,
+    token: Option<String>,
+    event_format: EventFormat,
+    mut f: F,
+) -> Result<()>
+where
+    F: FnMut(CreatedEvent),
+{
+    collect_active_contracts(config, token, event_format, None, |created| {
+        f(created);
+        None::<()>
+    })
+    .await?;
+    Ok(())
+}
+
+/// The first event `extract` accepts, or `None` — stopping at the first match
+/// rather than walking the rest of the ACS.
+pub(crate) async fn fetch_first_matching<T, F>(
+    config: &NodeConfig,
+    token: Option<String>,
+    event_format: EventFormat,
+    extract: F,
+) -> Result<Option<T>>
+where
+    F: FnMut(CreatedEvent) -> Option<T>,
+{
+    Ok(
+        collect_active_contracts(config, token, event_format, Some(1), extract)
+            .await?
+            .into_iter()
+            .next(),
+    )
 }
 
 /// The first `CreatedEvent` matching `event_format`, or `None`.
@@ -50,7 +100,7 @@ pub(crate) async fn fetch_first_active_contract(
     event_format: EventFormat,
 ) -> Result<Option<CreatedEvent>> {
     Ok(
-        collect_active_contracts(config, token, event_format, Some(1))
+        collect_active_contracts(config, token, event_format, Some(1), Some)
             .await?
             .into_iter()
             .next(),
@@ -62,12 +112,16 @@ pub(crate) async fn fetch_first_active_contract(
 ///
 /// `active_at_offset` is pinned to the ledger end for the whole walk: a page
 /// token is only valid against the offset and event format that produced it.
-async fn collect_active_contracts(
+async fn collect_active_contracts<T, F>(
     config: &NodeConfig,
     token: Option<String>,
     event_format: EventFormat,
     max_events: Option<usize>,
-) -> Result<Vec<CreatedEvent>> {
+    mut extract: F,
+) -> Result<Vec<T>>
+where
+    F: FnMut(CreatedEvent) -> Option<T>,
+{
     let mut client = utils::create_state_client(config, token.clone()).await?;
 
     let ledger_end = client
@@ -110,6 +164,7 @@ async fn collect_active_contracts(
                     ledger_end,
                     event_format,
                     max_events,
+                    extract,
                 )
                 .await;
             }
@@ -119,8 +174,9 @@ async fn collect_active_contracts(
         for response in page.active_contracts {
             if let Some(ContractEntry::ActiveContract(active)) = response.contract_entry
                 && let Some(event) = active.created_event
+                && let Some(kept) = extract(event)
             {
-                created.push(event);
+                created.push(kept);
             }
         }
 
@@ -142,13 +198,17 @@ async fn collect_active_contracts(
 ///
 /// Builds its own client because the caller's has already been moved into the
 /// failed paged attempt.
-async fn stream_active_contracts(
+async fn stream_active_contracts<T, F>(
     config: &NodeConfig,
     token: Option<String>,
     ledger_end: i64,
     event_format: EventFormat,
     max_events: Option<usize>,
-) -> Result<Vec<CreatedEvent>> {
+    mut extract: F,
+) -> Result<Vec<T>>
+where
+    F: FnMut(CreatedEvent) -> Option<T>,
+{
     let mut client = utils::create_state_client(config, token).await?;
 
     let request = GetActiveContractsRequest {
@@ -166,8 +226,9 @@ async fn stream_active_contracts(
     while let Some(response) = stream.message().await? {
         if let Some(ContractEntry::ActiveContract(active)) = response.contract_entry
             && let Some(event) = active.created_event
+            && let Some(kept) = extract(event)
         {
-            created.push(event);
+            created.push(kept);
             if max_events.is_some_and(|max| created.len() >= max) {
                 break;
             }

--- a/crates/decman/src/server/ledger_paging.rs
+++ b/crates/decman/src/server/ledger_paging.rs
@@ -16,9 +16,8 @@
 use crate::{config::NodeConfig, error::Result, utils};
 use canton_proto_rs::com::daml::ledger::api::v2::{
     CreatedEvent, EventFormat, GetActiveContractsPageRequest, GetActiveContractsRequest,
-    GetLedgerEndRequest, GetUpdatesPageRequest, GetUpdatesRequest, ListVettedPackagesRequest,
-    Transaction, UpdateFormat, VettedPackage, get_active_contracts_response::ContractEntry,
-    get_update_response, get_updates_response,
+    GetLedgerEndRequest, GetUpdatesPageRequest, GetUpdatesRequest, Transaction, UpdateFormat,
+    get_active_contracts_response::ContractEntry, get_update_response, get_updates_response,
 };
 
 /// Rows pulled from Canton per round trip when collecting a full result set.
@@ -307,49 +306,6 @@ pub(crate) async fn fetch_transactions_page(
             })
         }
         Err(status) => Err(status.into()),
-    }
-}
-
-/// Every package currently vetted by this participant, deduplicated by package
-/// id.
-///
-/// `ListVettedPackages` landed in Canton 3.4.10 and is paginated from the
-/// outset. It reports the participant's *topology* vetting state, one entry per
-/// (participant, synchronizer) pair, so the same package id can appear more
-/// than once when a participant is connected to several synchronizers.
-pub(crate) async fn fetch_vetted_packages(
-    config: &NodeConfig,
-    token: Option<String>,
-) -> Result<Vec<VettedPackage>> {
-    let mut client = utils::create_package_client(config, token).await?;
-
-    let mut seen = std::collections::HashSet::new();
-    let mut vetted = Vec::new();
-    let mut page_token = String::new();
-
-    loop {
-        let response = client
-            .list_vetted_packages(tonic::Request::new(ListVettedPackagesRequest {
-                package_metadata_filter: None,
-                topology_state_filter: None,
-                page_token: page_token.clone(),
-                page_size: FETCH_CHUNK as u32,
-            }))
-            .await?
-            .into_inner();
-
-        for entry in response.vetted_packages {
-            for package in entry.packages {
-                if seen.insert(package.package_id.clone()) {
-                    vetted.push(package);
-                }
-            }
-        }
-
-        if response.next_page_token.is_empty() {
-            return Ok(vetted);
-        }
-        page_token = response.next_page_token;
     }
 }
 

--- a/crates/decman/src/server/mod.rs
+++ b/crates/decman/src/server/mod.rs
@@ -12,6 +12,7 @@ mod assets;
 mod audit;
 mod chain_audit;
 mod handlers;
+mod ledger_paging;
 mod middleware;
 mod package_inventory;
 mod queries;

--- a/crates/decman/src/server/mod.rs
+++ b/crates/decman/src/server/mod.rs
@@ -11,6 +11,7 @@ mod action_serializer;
 mod assets;
 mod audit;
 mod chain_audit;
+mod event_filters;
 mod handlers;
 mod ledger_paging;
 mod middleware;

--- a/crates/decman/src/server/package_inventory.rs
+++ b/crates/decman/src/server/package_inventory.rs
@@ -1,13 +1,17 @@
 use std::collections::{BTreeSet, HashMap};
 
 use anyhow::{Context, Result};
-use canton_proto_rs::com::digitalasset::canton::admin::participant::v30::{
-    ListPackagesRequest, package_service_client::PackageServiceClient,
+use canton_proto_rs::com::digitalasset::canton::{
+    admin::participant::v30::{ListPackagesRequest, package_service_client::PackageServiceClient},
+    topology::admin::v30::{
+        BaseQuery, ListVettedPackagesRequest, StoreId, base_query, store_id,
+        topology_manager_read_service_client::TopologyManagerReadServiceClient,
+    },
 };
 
-use crate::config::NodeConfig;
+use crate::{config::NodeConfig, utils};
 
-use super::queries::compare_versions;
+use super::{queries::compare_versions, types::VettedPackageInfo};
 
 /// Derive the stable package-name prefix from a package reference by
 /// stripping the leading `#` and any trailing version segments, e.g.
@@ -113,6 +117,93 @@ pub(crate) async fn fetch_package_id_to_name(
         .package_descriptions
         .into_iter()
         .map(|p| (p.package_id, p.name))
+        .collect())
+}
+
+/// Packages this participant has actually vetted, with name and version.
+///
+/// Reads topology vetting state — which is a strictly smaller set than the
+/// uploaded DARs `fetch_package_names` reports, since a DAR can be uploaded
+/// without being vetted. The topology entries carry only package ids, so
+/// name/version are joined in from the Admin PackageService.
+///
+/// Deliberately on the admin channel: the Ledger API has a paginated
+/// `ListVettedPackages`, but it needs a bearer token and tokens here are
+/// per-party — a participant-level endpoint has no party to borrow one from.
+pub(crate) async fn fetch_vetted_packages(config: &NodeConfig) -> Result<Vec<VettedPackageInfo>> {
+    let channel = config
+        .admin_channel()
+        .await
+        .context("Failed to connect to participant Admin API")?;
+    let mut client = TopologyManagerReadServiceClient::new(channel)
+        .max_decoding_message_size(utils::MAX_GRPC_MESSAGE_SIZE);
+
+    let response = client
+        .list_vetted_packages(tonic::Request::new(ListVettedPackagesRequest {
+            base_query: Some(BaseQuery {
+                store: Some(StoreId {
+                    store: Some(store_id::Store::Authorized(store_id::Authorized {})),
+                }),
+                proposals: false,
+                operation: 0,
+                time_query: Some(base_query::TimeQuery::HeadState(())),
+                filter_signed_key: String::new(),
+                protocol_version: None,
+                client_version: None,
+            }),
+            filter_participant: config.participant_id().to_string(),
+        }))
+        .await
+        .context("Failed to list vetted packages")?
+        .into_inner();
+
+    let descriptions = fetch_package_descriptions(config).await?;
+
+    let mut seen = std::collections::HashSet::new();
+    let mut vetted = Vec::new();
+    for result in response.results {
+        let Some(item) = result.item else { continue };
+        for package in item.packages {
+            if !seen.insert(package.package_id.clone()) {
+                continue;
+            }
+            let (name, version) = descriptions
+                .get(&package.package_id)
+                .cloned()
+                .unwrap_or_default();
+            vetted.push(VettedPackageInfo {
+                package_id: package.package_id,
+                package_name: name,
+                package_version: version,
+            });
+        }
+    }
+
+    Ok(vetted)
+}
+
+/// Load `(package_id → (name, version))` from the Admin PackageService.
+async fn fetch_package_descriptions(
+    config: &NodeConfig,
+) -> Result<HashMap<String, (String, String)>> {
+    let mut client = PackageServiceClient::new(
+        config
+            .admin_channel()
+            .await
+            .context("Failed to connect to participant Admin API")?,
+    );
+    let response = client
+        .list_packages(tonic::Request::new(ListPackagesRequest {
+            limit: 0,
+            filter_name: String::new(),
+        }))
+        .await
+        .context("Failed to list participant packages")?
+        .into_inner();
+    Ok(response
+        .package_descriptions
+        .into_iter()
+        .map(|p| (p.package_id, (p.name, p.version)))
         .collect())
 }
 

--- a/crates/decman/src/server/queries.rs
+++ b/crates/decman/src/server/queries.rs
@@ -32,7 +32,10 @@ use crate::{
 
 use super::{
     action_serializer,
-    ledger_paging::{fetch_active_contracts, fetch_first_active_contract},
+    ledger_paging::{
+        fetch_active_contracts_filtered, fetch_first_active_contract, fetch_first_matching,
+        for_each_active_contract,
+    },
     package_inventory::{
         fetch_package_id_to_name, fetch_package_names, newest_matching_names, package_name_prefix,
     },
@@ -479,20 +482,20 @@ async fn fetch_contracts_with_wildcard(
         verbose: false,
     };
 
-    for created in fetch_active_contracts(config, token, event_format).await? {
-        // Filter in-memory for contract templates
+    for_each_active_contract(config, token, event_format, |created| {
+        // Test mode reads the ACS wildcard, so the template narrowing happens
+        // here rather than Canton-side.
         let is_wanted = created
             .template_id
             .as_ref()
             .map(|t| is_contract_template(&t.module_name, &t.entity_name))
             .unwrap_or(false);
 
-        if !is_wanted {
-            continue;
+        if is_wanted {
+            contracts.push(render_contract_info(&created, package_versions));
         }
-
-        contracts.push(render_contract_info(&created, package_versions));
-    }
+    })
+    .await?;
 
     Ok(())
 }
@@ -531,9 +534,10 @@ async fn fetch_contracts_for_template(
         verbose: false,
     };
 
-    for created in fetch_active_contracts(config, token, event_format).await? {
+    for_each_active_contract(config, token, event_format, |created| {
         contracts.push(render_contract_info(&created, package_versions));
-    }
+    })
+    .await?;
 
     Ok(())
 }
@@ -818,9 +822,9 @@ async fn fetch_governance_with_wildcard(
         verbose: true,
     };
 
-    for created in fetch_active_contracts(config, token, event_format).await? {
+    for_each_active_contract(config, token, event_format, |created| {
         let Some(ref template_id) = created.template_id else {
-            continue;
+            return;
         };
 
         if is_governance_template(&template_id.module_name, &template_id.entity_name) {
@@ -835,7 +839,8 @@ async fn fetch_governance_with_wildcard(
             // Capture proposal info from GovernableAction contracts
             extract_proposal_info(&created, proposal_infos);
         }
-    }
+    })
+    .await?;
 
     Ok(())
 }
@@ -874,7 +879,7 @@ async fn fetch_governance_for_template(
         verbose: true,
     };
 
-    for created in fetch_active_contracts(config, token, event_format).await? {
+    for_each_active_contract(config, token, event_format, |created| {
         if created.template_id.as_ref().is_some_and(|t| {
             t.module_name == "Governance.Confirmation" && t.entity_name == "GovernanceConfirmation"
         }) {
@@ -882,7 +887,8 @@ async fn fetch_governance_for_template(
         } else {
             extract_and_add_confirmation(&created, confirmations_by_hash);
         }
-    }
+    })
+    .await?;
 
     Ok(())
 }
@@ -1364,9 +1370,10 @@ async fn fetch_proposal_infos(
         verbose: true,
     };
 
-    for created in fetch_active_contracts(config, token.clone(), event_format).await? {
+    for_each_active_contract(config, token.clone(), event_format, |created| {
         extract_proposal_info(&created, proposal_infos);
-    }
+    })
+    .await?;
 
     // Resolve the linked `TransferInstruction` for any
     // `AcceptTransferProposal`s we just captured so the notification card has
@@ -1519,19 +1526,19 @@ async fn fetch_governance_state_with_wildcard(
         verbose: true,
     };
 
-    for created in fetch_active_contracts(config, token, event_format).await? {
-        // Check if this is a governance rules template (vault or core)
-        if let Some(ref template_id) = created.template_id
-            && ((template_id.module_name == "BitsafeVault.VaultGovernance"
-                && template_id.entity_name == "VaultGovernanceRules")
-                || (template_id.module_name == "Governance.Rules"
-                    && template_id.entity_name == "GovernanceRules"))
-        {
-            return Ok(extract_governance_state(&created));
-        }
-    }
-
-    Ok(None)
+    // Test mode reads the ACS wildcard, so the governance-rules templates are
+    // matched here; stops at the first one rather than draining the ACS.
+    fetch_first_matching(config, token, event_format, |created| {
+        let template_id = created.template_id.as_ref()?;
+        let is_rules = (template_id.module_name == "BitsafeVault.VaultGovernance"
+            && template_id.entity_name == "VaultGovernanceRules")
+            || (template_id.module_name == "Governance.Rules"
+                && template_id.entity_name == "GovernanceRules");
+        is_rules
+            .then(|| extract_governance_state(&created))
+            .flatten()
+    })
+    .await
 }
 
 /// Fetch governance state for a specific template
@@ -1838,7 +1845,7 @@ async fn fetch_vaults_with_wildcard(
     };
 
     let mut vaults = Vec::new();
-    for created in fetch_active_contracts(config, token, event_format).await? {
+    for_each_active_contract(config, token, event_format, |created| {
         if let Some(template_id) = &created.template_id
             && template_id.module_name == "BitsafeVault.Vault"
             && template_id.entity_name == "Vault"
@@ -1846,7 +1853,8 @@ async fn fetch_vaults_with_wildcard(
         {
             vaults.push(vault_info);
         }
-    }
+    })
+    .await?;
 
     Ok(vaults)
 }
@@ -1883,16 +1891,10 @@ async fn fetch_vaults_for_template(
         verbose: true,
     };
 
-    let active_contracts = fetch_active_contracts(config, token, event_format).await?;
-
-    let mut vaults = Vec::new();
-    for created in active_contracts {
-        if let Some(vault_info) = extract_vault_info(&created) {
-            vaults.push(vault_info);
-        }
-    }
-
-    Ok(vaults)
+    fetch_active_contracts_filtered(config, token, event_format, |created| {
+        extract_vault_info(&created)
+    })
+    .await
 }
 
 /// Extract VaultInfo from a Vault created event
@@ -2020,20 +2022,16 @@ async fn fetch_provider_services_with_wildcard(
         verbose: true,
     };
 
-    let active_contracts = fetch_active_contracts(config, token, event_format).await?;
-
-    let mut services = Vec::new();
-    for created in active_contracts {
-        if let Some(template_id) = &created.template_id
-            && template_id.module_name == "Utility.Registry.App.V0.Service.Provider"
-            && template_id.entity_name == "ProviderService"
-            && let Some(info) = extract_provider_service_info(&created)
+    fetch_active_contracts_filtered(config, token, event_format, |created| {
+        let template_id = created.template_id.as_ref()?;
+        if template_id.module_name != "Utility.Registry.App.V0.Service.Provider"
+            || template_id.entity_name != "ProviderService"
         {
-            services.push(info);
+            return None;
         }
-    }
-
-    Ok(services)
+        extract_provider_service_info(&created)
+    })
+    .await
 }
 
 /// Fetch provider services using TemplateFilter
@@ -2068,16 +2066,10 @@ async fn fetch_provider_services_for_template(
         verbose: true,
     };
 
-    let active_contracts = fetch_active_contracts(config, token, event_format).await?;
-
-    let mut services = Vec::new();
-    for created in active_contracts {
-        if let Some(info) = extract_provider_service_info(&created) {
-            services.push(info);
-        }
-    }
-
-    Ok(services)
+    fetch_active_contracts_filtered(config, token, event_format, |created| {
+        extract_provider_service_info(&created)
+    })
+    .await
 }
 
 /// Extract ProviderServiceInfo from a ProviderService created event
@@ -2157,20 +2149,16 @@ async fn fetch_user_services_with_wildcard(
         verbose: true,
     };
 
-    let active_contracts = fetch_active_contracts(config, token, event_format).await?;
-
-    let mut services = Vec::new();
-    for created in active_contracts {
-        if let Some(template_id) = &created.template_id
-            && template_id.module_name == "Utility.Credential.App.V0.Service.User"
-            && template_id.entity_name == "UserService"
-            && let Some(info) = extract_user_service_info(&created)
+    fetch_active_contracts_filtered(config, token, event_format, |created| {
+        let template_id = created.template_id.as_ref()?;
+        if template_id.module_name != "Utility.Credential.App.V0.Service.User"
+            || template_id.entity_name != "UserService"
         {
-            services.push(info);
+            return None;
         }
-    }
-
-    Ok(services)
+        extract_user_service_info(&created)
+    })
+    .await
 }
 
 /// Fetch user services using TemplateFilter
@@ -2205,16 +2193,10 @@ async fn fetch_user_services_for_template(
         verbose: true,
     };
 
-    let active_contracts = fetch_active_contracts(config, token, event_format).await?;
-
-    let mut services = Vec::new();
-    for created in active_contracts {
-        if let Some(info) = extract_user_service_info(&created) {
-            services.push(info);
-        }
-    }
-
-    Ok(services)
+    fetch_active_contracts_filtered(config, token, event_format, |created| {
+        extract_user_service_info(&created)
+    })
+    .await
 }
 
 /// Extract UserServiceInfo from a UserService created event
@@ -2300,20 +2282,16 @@ async fn fetch_credential_offers_with_wildcard(
         verbose: true,
     };
 
-    let active_contracts = fetch_active_contracts(config, token, event_format).await?;
-
-    let mut offers = Vec::new();
-    for created in active_contracts {
-        if let Some(template_id) = &created.template_id
-            && template_id.module_name == "Utility.Credential.App.V0.Model.Offer"
-            && template_id.entity_name == "CredentialOffer"
-            && let Some(info) = extract_credential_offer_info(&created)
+    fetch_active_contracts_filtered(config, token, event_format, |created| {
+        let template_id = created.template_id.as_ref()?;
+        if template_id.module_name != "Utility.Credential.App.V0.Model.Offer"
+            || template_id.entity_name != "CredentialOffer"
         {
-            offers.push(info);
+            return None;
         }
-    }
-
-    Ok(offers)
+        extract_credential_offer_info(&created)
+    })
+    .await
 }
 
 /// Fetch credential offers using TemplateFilter
@@ -2348,16 +2326,10 @@ async fn fetch_credential_offers_for_template(
         verbose: true,
     };
 
-    let active_contracts = fetch_active_contracts(config, token, event_format).await?;
-
-    let mut offers = Vec::new();
-    for created in active_contracts {
-        if let Some(info) = extract_credential_offer_info(&created) {
-            offers.push(info);
-        }
-    }
-
-    Ok(offers)
+    fetch_active_contracts_filtered(config, token, event_format, |created| {
+        extract_credential_offer_info(&created)
+    })
+    .await
 }
 
 /// Extract CredentialOfferInfo from a CredentialOffer created event. An offer
@@ -2443,20 +2415,16 @@ async fn fetch_registrar_services_with_wildcard(
         verbose: true,
     };
 
-    let active_contracts = fetch_active_contracts(config, token, event_format).await?;
-
-    let mut services = Vec::new();
-    for created in active_contracts {
-        if let Some(template_id) = &created.template_id
-            && template_id.module_name == "Utility.Registry.App.V0.Service.Registrar"
-            && template_id.entity_name == "RegistrarService"
-            && let Some(info) = extract_registrar_service_info(&created)
+    fetch_active_contracts_filtered(config, token, event_format, |created| {
+        let template_id = created.template_id.as_ref()?;
+        if template_id.module_name != "Utility.Registry.App.V0.Service.Registrar"
+            || template_id.entity_name != "RegistrarService"
         {
-            services.push(info);
+            return None;
         }
-    }
-
-    Ok(services)
+        extract_registrar_service_info(&created)
+    })
+    .await
 }
 
 /// Fetch registrar services using TemplateFilter
@@ -2491,16 +2459,10 @@ async fn fetch_registrar_services_for_template(
         verbose: true,
     };
 
-    let active_contracts = fetch_active_contracts(config, token, event_format).await?;
-
-    let mut services = Vec::new();
-    for created in active_contracts {
-        if let Some(info) = extract_registrar_service_info(&created) {
-            services.push(info);
-        }
-    }
-
-    Ok(services)
+    fetch_active_contracts_filtered(config, token, event_format, |created| {
+        extract_registrar_service_info(&created)
+    })
+    .await
 }
 
 /// Extract RegistrarServiceInfo from a RegistrarService created event
@@ -2596,20 +2558,16 @@ async fn fetch_instruments_with_wildcard(
         verbose: true,
     };
 
-    let active_contracts = fetch_active_contracts(config, token, event_format).await?;
-
-    let mut instruments = Vec::new();
-    for created in active_contracts {
-        if let Some(template_id) = &created.template_id
-            && template_id.module_name == "Utility.Registry.V0.Configuration.Instrument"
-            && template_id.entity_name == "InstrumentConfiguration"
-            && let Some(info) = extract_instrument_info(&created)
+    fetch_active_contracts_filtered(config, token, event_format, |created| {
+        let template_id = created.template_id.as_ref()?;
+        if template_id.module_name != "Utility.Registry.V0.Configuration.Instrument"
+            || template_id.entity_name != "InstrumentConfiguration"
         {
-            instruments.push(info);
+            return None;
         }
-    }
-
-    Ok(instruments)
+        extract_instrument_info(&created)
+    })
+    .await
 }
 
 async fn fetch_instruments_for_template(
@@ -2643,16 +2601,10 @@ async fn fetch_instruments_for_template(
         verbose: true,
     };
 
-    let active_contracts = fetch_active_contracts(config, token, event_format).await?;
-
-    let mut instruments = Vec::new();
-    for created in active_contracts {
-        if let Some(info) = extract_instrument_info(&created) {
-            instruments.push(info);
-        }
-    }
-
-    Ok(instruments)
+    fetch_active_contracts_filtered(config, token, event_format, |created| {
+        extract_instrument_info(&created)
+    })
+    .await
 }
 
 /// Extract InstrumentInfo from an InstrumentConfiguration created event.
@@ -2766,36 +2718,32 @@ pub async fn query_contracts_by_template(
         verbose: true,
     };
 
-    let active_contracts = fetch_active_contracts(config, token, event_format).await?;
-
-    let mut contracts = Vec::new();
-    for created in active_contracts {
-        let matches = if test_mode {
-            created.template_id.as_ref().is_some_and(|t| {
+    fetch_active_contracts_filtered(config, token, event_format, |created| {
+        // Test mode reads the ACS wildcard, so the template narrowing Canton
+        // would otherwise have done has to happen here.
+        if test_mode
+            && !created.template_id.as_ref().is_some_and(|t| {
                 t.module_name == params.module_name && t.entity_name == params.entity_name
             })
-        } else {
-            true
-        };
-
-        if matches {
-            // QA flagged the Accept Mint Request dropdown for surfacing
-            // contracts whose `executeBefore` has already passed —
-            // accepting them would fail at interpretation with
-            // deadline-exceeded. Drop them here when the caller opts in.
-            if params.active_only && is_execute_before_expired(&created) {
-                continue;
-            }
-            let blob =
-                base64::engine::general_purpose::STANDARD.encode(&created.created_event_blob);
-            contracts.push(ContractWithBlob {
-                contract_id: created.contract_id,
-                blob,
-            });
+        {
+            return None;
         }
-    }
 
-    Ok(contracts)
+        // QA flagged the Accept Mint Request dropdown for surfacing contracts
+        // whose `executeBefore` has already passed — accepting them would fail
+        // at interpretation with deadline-exceeded. Drop them here when the
+        // caller opts in.
+        if params.active_only && is_execute_before_expired(&created) {
+            return None;
+        }
+
+        let blob = base64::engine::general_purpose::STANDARD.encode(&created.created_event_blob);
+        Some(ContractWithBlob {
+            contract_id: created.contract_id,
+            blob,
+        })
+    })
+    .await
 }
 
 // ============================================================================
@@ -2846,23 +2794,17 @@ pub async fn get_open_transfer_instructions(
         verbose: true,
     };
 
-    let active_contracts = fetch_active_contracts(config, token, event_format).await?;
-
     let receiver_str = party_id.to_string();
-    let mut instructions = Vec::new();
-    for created in active_contracts {
-        // The InterfaceFilter only enforces party visibility — this party can
-        // see the contract as sender, receiver, or an instrument-admin
-        // stakeholder. Keep only the ones where it's the *receiver*, since
-        // those are the only ones it can Accept.
-        if let Some(info) = extract_transfer_instruction_info(&created)
-            && info.receiver.to_string() == receiver_str
-        {
-            instructions.push(info);
-        }
-    }
 
-    Ok(instructions)
+    // The InterfaceFilter only enforces party visibility — this party can see
+    // the contract as sender, receiver, or an instrument-admin stakeholder.
+    // Keep only the ones where it's the *receiver*, since those are the only
+    // ones it can Accept.
+    fetch_active_contracts_filtered(config, token, event_format, |created| {
+        extract_transfer_instruction_info(&created)
+            .filter(|info| info.receiver.to_string() == receiver_str)
+    })
+    .await
 }
 
 /// Pull sender / receiver / amount / instrument out of a `TransferInstruction`
@@ -3043,18 +2985,13 @@ async fn fetch_token_requests_for_template(
         verbose: true,
     };
 
-    let active_contracts = fetch_active_contracts(config, token, event_format).await?;
-
-    let mut requests = Vec::new();
-    for created in active_contracts {
-        if !is_execute_before_expired_in_payload(&created, payload_field)
-            && let Some(info) = extract_token_request_info(&created, payload_field)
-        {
-            requests.push(info);
+    fetch_active_contracts_filtered(config, token, event_format, |created| {
+        if is_execute_before_expired_in_payload(&created, payload_field) {
+            return None;
         }
-    }
-
-    Ok(requests)
+        extract_token_request_info(&created, payload_field)
+    })
+    .await
 }
 
 /// Extract `{holder, amount, instrumentId.{admin,id}, executeBefore}` from a
@@ -3272,15 +3209,10 @@ pub async fn get_transfer_factories(
         verbose: true,
     };
 
-    let active_contracts = fetch_active_contracts(config, token, event_format).await?;
-
-    let mut factories = Vec::new();
-    for created in active_contracts {
-        if let Some(info) = extract_transfer_factory_info(&created) {
-            factories.push(info);
-        }
-    }
-    Ok(factories)
+    fetch_active_contracts_filtered(config, token, event_format, |created| {
+        extract_transfer_factory_info(&created)
+    })
+    .await
 }
 
 /// Pull `admin` (the instrument admin / expected admin) out of the
@@ -3433,18 +3365,12 @@ async fn fetch_holding_views(
         verbose: true,
     };
 
-    let active_contracts = fetch_active_contracts(config, token, event_format).await?;
-
     let owner_str = party_id.to_string();
-    let mut holdings = Vec::new();
-    for created in active_contracts {
-        if let Some(view) = extract_holding_view(&created)
-            && view.owner == owner_str
-        {
-            holdings.push(view);
-        }
-    }
-    Ok(holdings)
+
+    fetch_active_contracts_filtered(config, token, event_format, |created| {
+        extract_holding_view(&created).filter(|view| view.owner == owner_str)
+    })
+    .await
 }
 
 /// Intermediate parse result. `owner` lets `fetch_holding_views` drop holdings
@@ -3634,17 +3560,15 @@ async fn fetch_utility_preapproval_instruments(
         verbose: true,
     };
 
-    let active_contracts = fetch_active_contracts(config, token, event_format).await?;
+    let entries = fetch_active_contracts_filtered(config, token, event_format, |created| {
+        created
+            .create_arguments
+            .as_ref()
+            .map(extract_preapproval_entries)
+    })
+    .await?;
 
-    let mut set = std::collections::HashSet::new();
-    for created in active_contracts {
-        if let Some(args) = created.create_arguments {
-            for entry in extract_preapproval_entries(&args) {
-                set.insert(entry);
-            }
-        }
-    }
-    Ok(set)
+    Ok(entries.into_iter().flatten().collect())
 }
 
 /// Sentinel `instrument_id` for a preapproval whose `instrumentAllowances` is

--- a/crates/decman/src/server/queries.rs
+++ b/crates/decman/src/server/queries.rs
@@ -7,21 +7,21 @@
 use std::{
     cmp::Reverse,
     collections::HashMap,
+    future::Future,
     time::{SystemTime, UNIX_EPOCH},
 };
 
 use canton_common::decimal::DamlDecimal;
 use canton_proto_rs::com::{
     daml::ledger::api::v2::{
-        CreatedEvent, CumulativeFilter, EventFormat, Filters, GetEventsByContractIdRequest,
-        Identifier, InterfaceFilter, Record, TemplateFilter, Value, WildcardFilter,
-        admin::ListKnownPartiesRequest, cumulative_filter, value,
+        CreatedEvent, GetEventsByContractIdRequest, Identifier, Record, Value,
+        admin::{ListKnownPartiesRequest, ListKnownPartiesResponse},
+        value,
     },
     digitalasset::canton::admin::participant::v30::{
         ListPackagesRequest, package_service_client::PackageServiceClient,
     },
 };
-use common::api::PAGE_SIZE;
 
 use crate::{
     canton_id::CantonId,
@@ -32,9 +32,10 @@ use crate::{
 
 use super::{
     action_serializer,
+    event_filters::{interface_filter, party_event_format, template_filter, wildcard_filter},
     ledger_paging::{
-        fetch_active_contracts_filtered, fetch_first_active_contract, fetch_first_matching,
-        for_each_active_contract,
+        FETCH_CHUNK, fetch_active_contracts_filtered, fetch_first_active_contract,
+        fetch_first_matching, for_each_active_contract,
     },
     package_inventory::{
         fetch_package_id_to_name, fetch_package_names, newest_matching_names, package_name_prefix,
@@ -462,25 +463,7 @@ async fn fetch_contracts_with_wildcard(
     package_versions: &HashMap<String, String>,
     contracts: &mut Vec<ContractInfo>,
 ) -> Result {
-    let mut filters_by_party = HashMap::new();
-    filters_by_party.insert(
-        party_id.to_string(),
-        Filters {
-            cumulative: vec![CumulativeFilter {
-                identifier_filter: Some(cumulative_filter::IdentifierFilter::WildcardFilter(
-                    WildcardFilter {
-                        include_created_event_blob: false,
-                    },
-                )),
-            }],
-        },
-    );
-
-    let event_format = EventFormat {
-        filters_by_party,
-        filters_for_any_party: None,
-        verbose: false,
-    };
+    let event_format = party_event_format(party_id, vec![wildcard_filter(false)], false);
 
     for_each_active_contract(config, token, event_format, |created| {
         // Test mode reads the ACS wildcard, so the template narrowing happens
@@ -509,30 +492,18 @@ async fn fetch_contracts_for_template(
     package_versions: &HashMap<String, String>,
     contracts: &mut Vec<ContractInfo>,
 ) -> Result {
-    let mut filters_by_party = HashMap::new();
-    filters_by_party.insert(
-        party_id.to_string(),
-        Filters {
-            cumulative: vec![CumulativeFilter {
-                identifier_filter: Some(cumulative_filter::IdentifierFilter::TemplateFilter(
-                    TemplateFilter {
-                        template_id: Some(Identifier {
-                            package_id: template.package_id.to_string(),
-                            module_name: template.module_name.to_string(),
-                            entity_name: template.entity_name.to_string(),
-                        }),
-                        include_created_event_blob: false,
-                    },
-                )),
-            }],
-        },
+    let event_format = party_event_format(
+        party_id,
+        vec![template_filter(
+            Identifier {
+                package_id: template.package_id.to_string(),
+                module_name: template.module_name.to_string(),
+                entity_name: template.entity_name.to_string(),
+            },
+            false,
+        )],
+        false,
     );
-
-    let event_format = EventFormat {
-        filters_by_party,
-        filters_for_any_party: None,
-        verbose: false,
-    };
 
     for_each_active_contract(config, token, event_format, |created| {
         contracts.push(render_contract_info(&created, package_versions));
@@ -548,30 +519,54 @@ pub async fn get_party_metadata(
     party_id: &CantonId,
     token: Option<String>,
 ) -> Result<Option<PartyMetadata>> {
-    let mut client = utils::create_party_client(config, token).await?;
+    let client = utils::create_party_client(config, token).await?;
     let party_id_str = party_id.to_string();
 
     // `filter_party` is a server-side prefix match, so a full party id narrows
     // this to the one party we want. Paging is still walked because the prefix
     // can in principle match more than one id, and a participant hosting more
     // parties than one page holds would otherwise silently report no metadata.
-    let mut page_token = String::new();
-    loop {
-        let response = client
-            .list_known_parties(tonic::Request::new(ListKnownPartiesRequest {
-                identity_provider_id: String::new(),
-                page_token: page_token.clone(),
-                page_size: PAGE_SIZE,
-                filter_party: party_id_str.clone(),
-            }))
-            .await?
-            .into_inner();
+    //
+    // `FETCH_CHUNK` rather than the wire `PAGE_SIZE`: this is an internal
+    // full-collection read, and on a participant that ignores `filter_party`
+    // the wire size would turn the walk into a round trip per 25 parties.
+    find_party_annotations(&party_id_str, |page_token| {
+        let request = ListKnownPartiesRequest {
+            identity_provider_id: String::new(),
+            page_token,
+            page_size: FETCH_CHUNK,
+            filter_party: party_id_str.clone(),
+        };
+        let mut client = client.clone();
 
-        if let Some(details) = response
-            .party_details
-            .iter()
-            .find(|p| p.party == party_id_str)
-        {
+        async move {
+            Ok(client
+                .list_known_parties(tonic::Request::new(request))
+                .await?
+                .into_inner())
+        }
+    })
+    .await
+}
+
+/// Walk `ListKnownParties` pages for `party_id`, returning its annotations.
+///
+/// `fetch_page` takes the token of the page to read and is a parameter so the
+/// walk can be tested; production passes the Ledger API call.
+async fn find_party_annotations<F, Fut>(
+    party_id: &str,
+    mut fetch_page: F,
+) -> Result<Option<PartyMetadata>>
+where
+    F: FnMut(String) -> Fut,
+    Fut: Future<Output = Result<ListKnownPartiesResponse>>,
+{
+    let mut page_token = String::new();
+
+    loop {
+        let response = fetch_page(page_token.clone()).await?;
+
+        if let Some(details) = response.party_details.iter().find(|p| p.party == party_id) {
             let annotations = details
                 .local_metadata
                 .as_ref()
@@ -585,7 +580,9 @@ pub async fn get_party_metadata(
             };
         }
 
-        if response.next_page_token.is_empty() {
+        // A repeated token means the server is not advancing; treating it as the
+        // end keeps a misbehaving participant from walking forever.
+        if response.next_page_token.is_empty() || response.next_page_token == page_token {
             return Ok(None);
         }
         page_token = response.next_page_token;
@@ -802,25 +799,7 @@ async fn fetch_governance_with_wildcard(
     domain_confirmations: &mut HashMap<String, (String, Vec<GovernanceConfirmation>)>,
     proposal_infos: &mut HashMap<String, ProposalInfo>,
 ) -> Result {
-    let mut filters_by_party = HashMap::new();
-    filters_by_party.insert(
-        party_id.to_string(),
-        Filters {
-            cumulative: vec![CumulativeFilter {
-                identifier_filter: Some(cumulative_filter::IdentifierFilter::WildcardFilter(
-                    WildcardFilter {
-                        include_created_event_blob: false,
-                    },
-                )),
-            }],
-        },
-    );
-
-    let event_format = EventFormat {
-        filters_by_party,
-        filters_for_any_party: None,
-        verbose: true,
-    };
+    let event_format = party_event_format(party_id, vec![wildcard_filter(false)], true);
 
     for_each_active_contract(config, token, event_format, |created| {
         let Some(ref template_id) = created.template_id else {
@@ -854,30 +833,18 @@ async fn fetch_governance_for_template(
     confirmations_by_hash: &mut HashMap<String, (ActionType, Vec<GovernanceConfirmation>)>,
     domain_confirmations: &mut HashMap<String, (String, Vec<GovernanceConfirmation>)>,
 ) -> Result {
-    let mut filters_by_party = HashMap::new();
-    filters_by_party.insert(
-        party_id.to_string(),
-        Filters {
-            cumulative: vec![CumulativeFilter {
-                identifier_filter: Some(cumulative_filter::IdentifierFilter::TemplateFilter(
-                    TemplateFilter {
-                        template_id: Some(Identifier {
-                            package_id: template.package_id.to_string(),
-                            module_name: template.module_name.to_string(),
-                            entity_name: template.entity_name.to_string(),
-                        }),
-                        include_created_event_blob: false,
-                    },
-                )),
-            }],
-        },
+    let event_format = party_event_format(
+        party_id,
+        vec![template_filter(
+            Identifier {
+                package_id: template.package_id.to_string(),
+                module_name: template.module_name.to_string(),
+                entity_name: template.entity_name.to_string(),
+            },
+            false,
+        )],
+        true,
     );
-
-    let event_format = EventFormat {
-        filters_by_party,
-        filters_for_any_party: None,
-        verbose: true,
-    };
 
     for_each_active_contract(config, token, event_format, |created| {
         if created.template_id.as_ref().is_some_and(|t| {
@@ -1221,32 +1188,20 @@ async fn resolve_accept_transfer_details(
     let mut client = utils::create_event_query_client(config, token).await?;
 
     for (proposal_cid, instruction_cid) in pending {
-        let mut filters_by_party = HashMap::new();
-        filters_by_party.insert(
-            party_id.to_string(),
-            Filters {
-                cumulative: vec![CumulativeFilter {
-                    identifier_filter: Some(cumulative_filter::IdentifierFilter::InterfaceFilter(
-                        InterfaceFilter {
-                            interface_id: Some(Identifier {
-                                package_id: "#splice-api-token-transfer-instruction-v1".to_string(),
-                                module_name: "Splice.Api.Token.TransferInstructionV1".to_string(),
-                                entity_name: "TransferInstruction".to_string(),
-                            }),
-                            include_interface_view: true,
-                            include_created_event_blob: false,
-                        },
-                    )),
-                }],
-            },
-        );
         let request = GetEventsByContractIdRequest {
             contract_id: instruction_cid.clone(),
-            event_format: Some(EventFormat {
-                filters_by_party,
-                filters_for_any_party: None,
-                verbose: true,
-            }),
+            event_format: Some(party_event_format(
+                party_id,
+                vec![interface_filter(
+                    Identifier {
+                        package_id: "#splice-api-token-transfer-instruction-v1".to_string(),
+                        module_name: "Splice.Api.Token.TransferInstructionV1".to_string(),
+                        entity_name: "TransferInstruction".to_string(),
+                    },
+                    false,
+                )],
+                true,
+            )),
         };
         let created_event = match client
             .get_events_by_contract_id(tonic::Request::new(request))
@@ -1344,31 +1299,18 @@ async fn fetch_proposal_infos(
         return Ok(());
     };
 
-    let mut filters_by_party = HashMap::new();
-    filters_by_party.insert(
-        party_id.to_string(),
-        Filters {
-            cumulative: vec![CumulativeFilter {
-                identifier_filter: Some(cumulative_filter::IdentifierFilter::InterfaceFilter(
-                    InterfaceFilter {
-                        interface_id: Some(Identifier {
-                            package_id: pkg.clone(),
-                            module_name: "Governance.Action".to_string(),
-                            entity_name: "GovernableAction".to_string(),
-                        }),
-                        include_created_event_blob: false,
-                        include_interface_view: true,
-                    },
-                )),
-            }],
-        },
+    let event_format = party_event_format(
+        party_id,
+        vec![interface_filter(
+            Identifier {
+                package_id: pkg.clone(),
+                module_name: "Governance.Action".to_string(),
+                entity_name: "GovernableAction".to_string(),
+            },
+            false,
+        )],
+        true,
     );
-
-    let event_format = EventFormat {
-        filters_by_party,
-        filters_for_any_party: None,
-        verbose: true,
-    };
 
     for_each_active_contract(config, token.clone(), event_format, |created| {
         extract_proposal_info(&created, proposal_infos);
@@ -1506,25 +1448,7 @@ async fn fetch_governance_state_with_wildcard(
     party_id: &CantonId,
     token: Option<String>,
 ) -> Result<Option<GovernanceState>> {
-    let mut filters_by_party = HashMap::new();
-    filters_by_party.insert(
-        party_id.to_string(),
-        Filters {
-            cumulative: vec![CumulativeFilter {
-                identifier_filter: Some(cumulative_filter::IdentifierFilter::WildcardFilter(
-                    WildcardFilter {
-                        include_created_event_blob: false,
-                    },
-                )),
-            }],
-        },
-    );
-
-    let event_format = EventFormat {
-        filters_by_party,
-        filters_for_any_party: None,
-        verbose: true,
-    };
+    let event_format = party_event_format(party_id, vec![wildcard_filter(false)], true);
 
     // Test mode reads the ACS wildcard, so the governance-rules templates are
     // matched here; stops at the first one rather than draining the ACS.
@@ -1548,30 +1472,18 @@ async fn fetch_governance_state_for_template(
     token: Option<String>,
     template: &TemplateId,
 ) -> Result<Option<GovernanceState>> {
-    let mut filters_by_party = HashMap::new();
-    filters_by_party.insert(
-        party_id.to_string(),
-        Filters {
-            cumulative: vec![CumulativeFilter {
-                identifier_filter: Some(cumulative_filter::IdentifierFilter::TemplateFilter(
-                    TemplateFilter {
-                        template_id: Some(Identifier {
-                            package_id: template.package_id.clone(),
-                            module_name: template.module_name.to_string(),
-                            entity_name: template.entity_name.to_string(),
-                        }),
-                        include_created_event_blob: false,
-                    },
-                )),
-            }],
-        },
+    let event_format = party_event_format(
+        party_id,
+        vec![template_filter(
+            Identifier {
+                package_id: template.package_id.clone(),
+                module_name: template.module_name.to_string(),
+                entity_name: template.entity_name.to_string(),
+            },
+            false,
+        )],
+        true,
     );
-
-    let event_format = EventFormat {
-        filters_by_party,
-        filters_for_any_party: None,
-        verbose: true,
-    };
 
     Ok(fetch_first_active_contract(config, token, event_format)
         .await?
@@ -1678,26 +1590,13 @@ async fn fetch_contract_package_ref(
 ) -> Result<Option<String>> {
     let mut client = utils::create_event_query_client(config, token).await?;
 
-    let mut filters_by_party = HashMap::new();
-    filters_by_party.insert(
-        party_id.to_string(),
-        Filters {
-            cumulative: vec![CumulativeFilter {
-                identifier_filter: Some(cumulative_filter::IdentifierFilter::WildcardFilter(
-                    WildcardFilter {
-                        include_created_event_blob: false,
-                    },
-                )),
-            }],
-        },
-    );
     let request = GetEventsByContractIdRequest {
         contract_id: contract_id.to_string(),
-        event_format: Some(EventFormat {
-            filters_by_party,
-            filters_for_any_party: None,
-            verbose: false,
-        }),
+        event_format: Some(party_event_format(
+            party_id,
+            vec![wildcard_filter(false)],
+            false,
+        )),
     };
 
     let package_id = client
@@ -1824,25 +1723,7 @@ async fn fetch_vaults_with_wildcard(
     party_id: &CantonId,
     token: Option<String>,
 ) -> Result<Vec<VaultInfo>> {
-    let mut filters_by_party = HashMap::new();
-    filters_by_party.insert(
-        party_id.to_string(),
-        Filters {
-            cumulative: vec![CumulativeFilter {
-                identifier_filter: Some(cumulative_filter::IdentifierFilter::WildcardFilter(
-                    WildcardFilter {
-                        include_created_event_blob: false,
-                    },
-                )),
-            }],
-        },
-    );
-
-    let event_format = EventFormat {
-        filters_by_party,
-        filters_for_any_party: None,
-        verbose: true,
-    };
+    let event_format = party_event_format(party_id, vec![wildcard_filter(false)], true);
 
     let mut vaults = Vec::new();
     for_each_active_contract(config, token, event_format, |created| {
@@ -1866,30 +1747,18 @@ async fn fetch_vaults_for_template(
     token: Option<String>,
     template: &TemplateId,
 ) -> Result<Vec<VaultInfo>> {
-    let mut filters_by_party = HashMap::new();
-    filters_by_party.insert(
-        party_id.to_string(),
-        Filters {
-            cumulative: vec![CumulativeFilter {
-                identifier_filter: Some(cumulative_filter::IdentifierFilter::TemplateFilter(
-                    TemplateFilter {
-                        template_id: Some(Identifier {
-                            package_id: template.package_id.clone(),
-                            module_name: template.module_name.to_string(),
-                            entity_name: template.entity_name.to_string(),
-                        }),
-                        include_created_event_blob: false,
-                    },
-                )),
-            }],
-        },
+    let event_format = party_event_format(
+        party_id,
+        vec![template_filter(
+            Identifier {
+                package_id: template.package_id.clone(),
+                module_name: template.module_name.to_string(),
+                entity_name: template.entity_name.to_string(),
+            },
+            false,
+        )],
+        true,
     );
-
-    let event_format = EventFormat {
-        filters_by_party,
-        filters_for_any_party: None,
-        verbose: true,
-    };
 
     fetch_active_contracts_filtered(config, token, event_format, |created| {
         extract_vault_info(&created)
@@ -2002,25 +1871,7 @@ async fn fetch_provider_services_with_wildcard(
     party_id: &CantonId,
     token: Option<String>,
 ) -> Result<Vec<ProviderServiceInfo>> {
-    let mut filters_by_party = HashMap::new();
-    filters_by_party.insert(
-        party_id.to_string(),
-        Filters {
-            cumulative: vec![CumulativeFilter {
-                identifier_filter: Some(cumulative_filter::IdentifierFilter::WildcardFilter(
-                    WildcardFilter {
-                        include_created_event_blob: false,
-                    },
-                )),
-            }],
-        },
-    );
-
-    let event_format = EventFormat {
-        filters_by_party,
-        filters_for_any_party: None,
-        verbose: true,
-    };
+    let event_format = party_event_format(party_id, vec![wildcard_filter(false)], true);
 
     fetch_active_contracts_filtered(config, token, event_format, |created| {
         let template_id = created.template_id.as_ref()?;
@@ -2041,30 +1892,18 @@ async fn fetch_provider_services_for_template(
     token: Option<String>,
     template: &TemplateId,
 ) -> Result<Vec<ProviderServiceInfo>> {
-    let mut filters_by_party = HashMap::new();
-    filters_by_party.insert(
-        party_id.to_string(),
-        Filters {
-            cumulative: vec![CumulativeFilter {
-                identifier_filter: Some(cumulative_filter::IdentifierFilter::TemplateFilter(
-                    TemplateFilter {
-                        template_id: Some(Identifier {
-                            package_id: template.package_id.clone(),
-                            module_name: template.module_name.to_string(),
-                            entity_name: template.entity_name.to_string(),
-                        }),
-                        include_created_event_blob: false,
-                    },
-                )),
-            }],
-        },
+    let event_format = party_event_format(
+        party_id,
+        vec![template_filter(
+            Identifier {
+                package_id: template.package_id.clone(),
+                module_name: template.module_name.to_string(),
+                entity_name: template.entity_name.to_string(),
+            },
+            false,
+        )],
+        true,
     );
-
-    let event_format = EventFormat {
-        filters_by_party,
-        filters_for_any_party: None,
-        verbose: true,
-    };
 
     fetch_active_contracts_filtered(config, token, event_format, |created| {
         extract_provider_service_info(&created)
@@ -2129,25 +1968,7 @@ async fn fetch_user_services_with_wildcard(
     party_id: &CantonId,
     token: Option<String>,
 ) -> Result<Vec<UserServiceInfo>> {
-    let mut filters_by_party = HashMap::new();
-    filters_by_party.insert(
-        party_id.to_string(),
-        Filters {
-            cumulative: vec![CumulativeFilter {
-                identifier_filter: Some(cumulative_filter::IdentifierFilter::WildcardFilter(
-                    WildcardFilter {
-                        include_created_event_blob: false,
-                    },
-                )),
-            }],
-        },
-    );
-
-    let event_format = EventFormat {
-        filters_by_party,
-        filters_for_any_party: None,
-        verbose: true,
-    };
+    let event_format = party_event_format(party_id, vec![wildcard_filter(false)], true);
 
     fetch_active_contracts_filtered(config, token, event_format, |created| {
         let template_id = created.template_id.as_ref()?;
@@ -2168,30 +1989,18 @@ async fn fetch_user_services_for_template(
     token: Option<String>,
     template: &TemplateId,
 ) -> Result<Vec<UserServiceInfo>> {
-    let mut filters_by_party = HashMap::new();
-    filters_by_party.insert(
-        party_id.to_string(),
-        Filters {
-            cumulative: vec![CumulativeFilter {
-                identifier_filter: Some(cumulative_filter::IdentifierFilter::TemplateFilter(
-                    TemplateFilter {
-                        template_id: Some(Identifier {
-                            package_id: template.package_id.clone(),
-                            module_name: template.module_name.to_string(),
-                            entity_name: template.entity_name.to_string(),
-                        }),
-                        include_created_event_blob: false,
-                    },
-                )),
-            }],
-        },
+    let event_format = party_event_format(
+        party_id,
+        vec![template_filter(
+            Identifier {
+                package_id: template.package_id.clone(),
+                module_name: template.module_name.to_string(),
+                entity_name: template.entity_name.to_string(),
+            },
+            false,
+        )],
+        true,
     );
-
-    let event_format = EventFormat {
-        filters_by_party,
-        filters_for_any_party: None,
-        verbose: true,
-    };
 
     fetch_active_contracts_filtered(config, token, event_format, |created| {
         extract_user_service_info(&created)
@@ -2262,25 +2071,7 @@ async fn fetch_credential_offers_with_wildcard(
     party_id: &CantonId,
     token: Option<String>,
 ) -> Result<Vec<CredentialOfferInfo>> {
-    let mut filters_by_party = HashMap::new();
-    filters_by_party.insert(
-        party_id.to_string(),
-        Filters {
-            cumulative: vec![CumulativeFilter {
-                identifier_filter: Some(cumulative_filter::IdentifierFilter::WildcardFilter(
-                    WildcardFilter {
-                        include_created_event_blob: false,
-                    },
-                )),
-            }],
-        },
-    );
-
-    let event_format = EventFormat {
-        filters_by_party,
-        filters_for_any_party: None,
-        verbose: true,
-    };
+    let event_format = party_event_format(party_id, vec![wildcard_filter(false)], true);
 
     fetch_active_contracts_filtered(config, token, event_format, |created| {
         let template_id = created.template_id.as_ref()?;
@@ -2301,30 +2092,18 @@ async fn fetch_credential_offers_for_template(
     token: Option<String>,
     template: &TemplateId,
 ) -> Result<Vec<CredentialOfferInfo>> {
-    let mut filters_by_party = HashMap::new();
-    filters_by_party.insert(
-        party_id.to_string(),
-        Filters {
-            cumulative: vec![CumulativeFilter {
-                identifier_filter: Some(cumulative_filter::IdentifierFilter::TemplateFilter(
-                    TemplateFilter {
-                        template_id: Some(Identifier {
-                            package_id: template.package_id.clone(),
-                            module_name: template.module_name.to_string(),
-                            entity_name: template.entity_name.to_string(),
-                        }),
-                        include_created_event_blob: false,
-                    },
-                )),
-            }],
-        },
+    let event_format = party_event_format(
+        party_id,
+        vec![template_filter(
+            Identifier {
+                package_id: template.package_id.clone(),
+                module_name: template.module_name.to_string(),
+                entity_name: template.entity_name.to_string(),
+            },
+            false,
+        )],
+        true,
     );
-
-    let event_format = EventFormat {
-        filters_by_party,
-        filters_for_any_party: None,
-        verbose: true,
-    };
 
     fetch_active_contracts_filtered(config, token, event_format, |created| {
         extract_credential_offer_info(&created)
@@ -2395,25 +2174,7 @@ async fn fetch_registrar_services_with_wildcard(
     party_id: &CantonId,
     token: Option<String>,
 ) -> Result<Vec<RegistrarServiceInfo>> {
-    let mut filters_by_party = HashMap::new();
-    filters_by_party.insert(
-        party_id.to_string(),
-        Filters {
-            cumulative: vec![CumulativeFilter {
-                identifier_filter: Some(cumulative_filter::IdentifierFilter::WildcardFilter(
-                    WildcardFilter {
-                        include_created_event_blob: false,
-                    },
-                )),
-            }],
-        },
-    );
-
-    let event_format = EventFormat {
-        filters_by_party,
-        filters_for_any_party: None,
-        verbose: true,
-    };
+    let event_format = party_event_format(party_id, vec![wildcard_filter(false)], true);
 
     fetch_active_contracts_filtered(config, token, event_format, |created| {
         let template_id = created.template_id.as_ref()?;
@@ -2434,30 +2195,18 @@ async fn fetch_registrar_services_for_template(
     token: Option<String>,
     template: &TemplateId,
 ) -> Result<Vec<RegistrarServiceInfo>> {
-    let mut filters_by_party = HashMap::new();
-    filters_by_party.insert(
-        party_id.to_string(),
-        Filters {
-            cumulative: vec![CumulativeFilter {
-                identifier_filter: Some(cumulative_filter::IdentifierFilter::TemplateFilter(
-                    TemplateFilter {
-                        template_id: Some(Identifier {
-                            package_id: template.package_id.clone(),
-                            module_name: template.module_name.to_string(),
-                            entity_name: template.entity_name.to_string(),
-                        }),
-                        include_created_event_blob: false,
-                    },
-                )),
-            }],
-        },
+    let event_format = party_event_format(
+        party_id,
+        vec![template_filter(
+            Identifier {
+                package_id: template.package_id.clone(),
+                module_name: template.module_name.to_string(),
+                entity_name: template.entity_name.to_string(),
+            },
+            false,
+        )],
+        true,
     );
-
-    let event_format = EventFormat {
-        filters_by_party,
-        filters_for_any_party: None,
-        verbose: true,
-    };
 
     fetch_active_contracts_filtered(config, token, event_format, |created| {
         extract_registrar_service_info(&created)
@@ -2538,25 +2287,7 @@ async fn fetch_instruments_with_wildcard(
     party_id: &CantonId,
     token: Option<String>,
 ) -> Result<Vec<InstrumentInfo>> {
-    let mut filters_by_party = HashMap::new();
-    filters_by_party.insert(
-        party_id.to_string(),
-        Filters {
-            cumulative: vec![CumulativeFilter {
-                identifier_filter: Some(cumulative_filter::IdentifierFilter::WildcardFilter(
-                    WildcardFilter {
-                        include_created_event_blob: false,
-                    },
-                )),
-            }],
-        },
-    );
-
-    let event_format = EventFormat {
-        filters_by_party,
-        filters_for_any_party: None,
-        verbose: true,
-    };
+    let event_format = party_event_format(party_id, vec![wildcard_filter(false)], true);
 
     fetch_active_contracts_filtered(config, token, event_format, |created| {
         let template_id = created.template_id.as_ref()?;
@@ -2576,30 +2307,18 @@ async fn fetch_instruments_for_template(
     token: Option<String>,
     template: &TemplateId,
 ) -> Result<Vec<InstrumentInfo>> {
-    let mut filters_by_party = HashMap::new();
-    filters_by_party.insert(
-        party_id.to_string(),
-        Filters {
-            cumulative: vec![CumulativeFilter {
-                identifier_filter: Some(cumulative_filter::IdentifierFilter::TemplateFilter(
-                    TemplateFilter {
-                        template_id: Some(Identifier {
-                            package_id: template.package_id.clone(),
-                            module_name: template.module_name.to_string(),
-                            entity_name: template.entity_name.to_string(),
-                        }),
-                        include_created_event_blob: false,
-                    },
-                )),
-            }],
-        },
+    let event_format = party_event_format(
+        party_id,
+        vec![template_filter(
+            Identifier {
+                package_id: template.package_id.clone(),
+                module_name: template.module_name.to_string(),
+                entity_name: template.entity_name.to_string(),
+            },
+            false,
+        )],
+        true,
     );
-
-    let event_format = EventFormat {
-        filters_by_party,
-        filters_for_any_party: None,
-        verbose: true,
-    };
 
     fetch_active_contracts_filtered(config, token, event_format, |created| {
         extract_instrument_info(&created)
@@ -2685,38 +2404,15 @@ pub async fn query_contracts_by_template(
         entity_name: params.entity_name.clone(),
     };
 
-    let identifier_filter = if test_mode {
-        cumulative_filter::IdentifierFilter::WildcardFilter(WildcardFilter {
-            include_created_event_blob: true,
-        })
+    let filter = if test_mode {
+        wildcard_filter(true)
     } else if params.use_interface_filter {
-        cumulative_filter::IdentifierFilter::InterfaceFilter(InterfaceFilter {
-            interface_id: Some(identifier),
-            include_interface_view: true,
-            include_created_event_blob: true,
-        })
+        interface_filter(identifier, true)
     } else {
-        cumulative_filter::IdentifierFilter::TemplateFilter(TemplateFilter {
-            template_id: Some(identifier),
-            include_created_event_blob: true,
-        })
+        template_filter(identifier, true)
     };
 
-    let mut filters_by_party = HashMap::new();
-    filters_by_party.insert(
-        party_id.to_string(),
-        Filters {
-            cumulative: vec![CumulativeFilter {
-                identifier_filter: Some(identifier_filter),
-            }],
-        },
-    );
-
-    let event_format = EventFormat {
-        filters_by_party,
-        filters_for_any_party: None,
-        verbose: true,
-    };
+    let event_format = party_event_format(party_id, vec![filter], true);
 
     fetch_active_contracts_filtered(config, token, event_format, |created| {
         // Test mode reads the ACS wildcard, so the template narrowing Canton
@@ -2768,31 +2464,18 @@ pub async fn get_open_transfer_instructions(
     party_id: &CantonId,
     token: Option<String>,
 ) -> Result<Vec<TransferInstructionInfo>> {
-    let mut filters_by_party = HashMap::new();
-    filters_by_party.insert(
-        party_id.to_string(),
-        Filters {
-            cumulative: vec![CumulativeFilter {
-                identifier_filter: Some(cumulative_filter::IdentifierFilter::InterfaceFilter(
-                    InterfaceFilter {
-                        interface_id: Some(Identifier {
-                            package_id: "#splice-api-token-transfer-instruction-v1".to_string(),
-                            module_name: "Splice.Api.Token.TransferInstructionV1".to_string(),
-                            entity_name: "TransferInstruction".to_string(),
-                        }),
-                        include_interface_view: true,
-                        include_created_event_blob: false,
-                    },
-                )),
-            }],
-        },
+    let event_format = party_event_format(
+        party_id,
+        vec![interface_filter(
+            Identifier {
+                package_id: "#splice-api-token-transfer-instruction-v1".to_string(),
+                module_name: "Splice.Api.Token.TransferInstructionV1".to_string(),
+                entity_name: "TransferInstruction".to_string(),
+            },
+            false,
+        )],
+        true,
     );
-
-    let event_format = EventFormat {
-        filters_by_party,
-        filters_for_any_party: None,
-        verbose: true,
-    };
 
     let receiver_str = party_id.to_string();
 
@@ -2960,30 +2643,18 @@ async fn fetch_token_requests_for_template(
     template: &TemplateId,
     payload_field: &str,
 ) -> Result<Vec<TokenRequestInfo>> {
-    let mut filters_by_party = HashMap::new();
-    filters_by_party.insert(
-        party_id.to_string(),
-        Filters {
-            cumulative: vec![CumulativeFilter {
-                identifier_filter: Some(cumulative_filter::IdentifierFilter::TemplateFilter(
-                    TemplateFilter {
-                        template_id: Some(Identifier {
-                            package_id: template.package_id.clone(),
-                            module_name: template.module_name.to_string(),
-                            entity_name: template.entity_name.to_string(),
-                        }),
-                        include_created_event_blob: false,
-                    },
-                )),
-            }],
-        },
+    let event_format = party_event_format(
+        party_id,
+        vec![template_filter(
+            Identifier {
+                package_id: template.package_id.clone(),
+                module_name: template.module_name.to_string(),
+                entity_name: template.entity_name.to_string(),
+            },
+            false,
+        )],
+        true,
     );
-
-    let event_format = EventFormat {
-        filters_by_party,
-        filters_for_any_party: None,
-        verbose: true,
-    };
 
     fetch_active_contracts_filtered(config, token, event_format, |created| {
         if is_execute_before_expired_in_payload(&created, payload_field) {
@@ -3183,31 +2854,18 @@ pub async fn get_transfer_factories(
     party_id: &CantonId,
     token: Option<String>,
 ) -> Result<Vec<TransferFactoryInfo>> {
-    let mut filters_by_party = HashMap::new();
-    filters_by_party.insert(
-        party_id.to_string(),
-        Filters {
-            cumulative: vec![CumulativeFilter {
-                identifier_filter: Some(cumulative_filter::IdentifierFilter::InterfaceFilter(
-                    InterfaceFilter {
-                        interface_id: Some(Identifier {
-                            package_id: "#splice-api-token-transfer-instruction-v1".to_string(),
-                            module_name: "Splice.Api.Token.TransferInstructionV1".to_string(),
-                            entity_name: "TransferFactory".to_string(),
-                        }),
-                        include_interface_view: true,
-                        include_created_event_blob: false,
-                    },
-                )),
-            }],
-        },
+    let event_format = party_event_format(
+        party_id,
+        vec![interface_filter(
+            Identifier {
+                package_id: "#splice-api-token-transfer-instruction-v1".to_string(),
+                module_name: "Splice.Api.Token.TransferInstructionV1".to_string(),
+                entity_name: "TransferFactory".to_string(),
+            },
+            false,
+        )],
+        true,
     );
-
-    let event_format = EventFormat {
-        filters_by_party,
-        filters_for_any_party: None,
-        verbose: true,
-    };
 
     fetch_active_contracts_filtered(config, token, event_format, |created| {
         extract_transfer_factory_info(&created)
@@ -3339,31 +2997,18 @@ async fn fetch_holding_views(
     party_id: &CantonId,
     token: Option<String>,
 ) -> Result<Vec<HoldingView>> {
-    let mut filters_by_party = HashMap::new();
-    filters_by_party.insert(
-        party_id.to_string(),
-        Filters {
-            cumulative: vec![CumulativeFilter {
-                identifier_filter: Some(cumulative_filter::IdentifierFilter::InterfaceFilter(
-                    InterfaceFilter {
-                        interface_id: Some(Identifier {
-                            package_id: "#splice-api-token-holding-v1".to_string(),
-                            module_name: "Splice.Api.Token.HoldingV1".to_string(),
-                            entity_name: "Holding".to_string(),
-                        }),
-                        include_interface_view: true,
-                        include_created_event_blob: false,
-                    },
-                )),
-            }],
-        },
+    let event_format = party_event_format(
+        party_id,
+        vec![interface_filter(
+            Identifier {
+                package_id: "#splice-api-token-holding-v1".to_string(),
+                module_name: "Splice.Api.Token.HoldingV1".to_string(),
+                entity_name: "Holding".to_string(),
+            },
+            false,
+        )],
+        true,
     );
-
-    let event_format = EventFormat {
-        filters_by_party,
-        filters_for_any_party: None,
-        verbose: true,
-    };
 
     let owner_str = party_id.to_string();
 
@@ -3534,31 +3179,18 @@ async fn fetch_utility_preapproval_instruments(
     party_id: &CantonId,
     token: Option<String>,
 ) -> Result<std::collections::HashSet<(String, String)>> {
-    let mut filters_by_party = HashMap::new();
-    filters_by_party.insert(
-        party_id.to_string(),
-        Filters {
-            cumulative: vec![CumulativeFilter {
-                identifier_filter: Some(cumulative_filter::IdentifierFilter::TemplateFilter(
-                    TemplateFilter {
-                        template_id: Some(Identifier {
-                            package_id: "#utility-registry-app-v0".to_string(),
-                            module_name: "Utility.Registry.App.V0.Model.TransferPreapproval"
-                                .to_string(),
-                            entity_name: "TransferPreapproval".to_string(),
-                        }),
-                        include_created_event_blob: false,
-                    },
-                )),
-            }],
-        },
+    let event_format = party_event_format(
+        party_id,
+        vec![template_filter(
+            Identifier {
+                package_id: "#utility-registry-app-v0".to_string(),
+                module_name: "Utility.Registry.App.V0.Model.TransferPreapproval".to_string(),
+                entity_name: "TransferPreapproval".to_string(),
+            },
+            false,
+        )],
+        true,
     );
-
-    let event_format = EventFormat {
-        filters_by_party,
-        filters_for_any_party: None,
-        verbose: true,
-    };
 
     let entries = fetch_active_contracts_filtered(config, token, event_format, |created| {
         created
@@ -3614,6 +3246,8 @@ fn extract_preapproval_entries(args: &Record) -> Vec<(String, String)> {
 
 #[cfg(test)]
 mod tests {
+    use canton_proto_rs::com::daml::ledger::api::v2::admin::{ObjectMeta, PartyDetails};
+
     use super::*;
 
     fn ci(name: &str, version: &str, created_at: &str, contract_id: &str) -> ContractInfo {
@@ -4093,5 +3727,106 @@ mod tests {
             record.fields.retain(|f| f.label != "holder");
         }
         assert!(extract_credential_offer_info(&event).is_none());
+    }
+
+    // ====================================================================
+    // Party metadata page walk
+    // ====================================================================
+
+    fn party_page(parties: &[(&str, &[(&str, &str)])], next: &str) -> ListKnownPartiesResponse {
+        ListKnownPartiesResponse {
+            party_details: parties
+                .iter()
+                .map(|(party, annotations)| PartyDetails {
+                    party: (*party).to_string(),
+                    is_local: true,
+                    local_metadata: Some(ObjectMeta {
+                        resource_version: String::new(),
+                        annotations: annotations
+                            .iter()
+                            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+                            .collect(),
+                    }),
+                    identity_provider_id: String::new(),
+                })
+                .collect(),
+            next_page_token: next.to_string(),
+        }
+    }
+
+    /// Walk `pages` in order. Asking past the script is an error, so a test that
+    /// over-reads fails instead of quietly passing.
+    async fn walk_parties(
+        party_id: &str,
+        pages: Vec<ListKnownPartiesResponse>,
+    ) -> Result<Option<PartyMetadata>> {
+        let mut remaining = std::collections::VecDeque::from(pages);
+
+        find_party_annotations(party_id, |_page_token| {
+            let page = remaining.pop_front();
+            async move { page.ok_or_else(|| anyhow::anyhow!("asked for a page beyond the script")) }
+        })
+        .await
+    }
+
+    /// `filter_party` is only a prefix match, so the wanted party can sit behind
+    /// a page of others — the walk has to follow the token to find it.
+    #[tokio::test]
+    async fn party_walk_finds_the_party_on_a_later_page() -> Result {
+        let pages = vec![
+            party_page(&[("other::1220aa", &[("k", "v")])], "page-2"),
+            party_page(&[("wanted::1220bb", &[("owner", "alice")])], ""),
+        ];
+
+        let metadata = walk_parties("wanted::1220bb", pages).await?;
+
+        assert_eq!(
+            metadata.map(|m| m.annotations),
+            Some([("owner".to_string(), "alice".to_string())].into())
+        );
+
+        Ok(())
+    }
+
+    /// An exhausted token list means the party is not hosted here.
+    #[tokio::test]
+    async fn party_walk_reports_nothing_when_the_tokens_run_out() -> Result {
+        let pages = vec![
+            party_page(&[("other::1220aa", &[])], "page-2"),
+            party_page(&[("another::1220cc", &[])], ""),
+        ];
+
+        assert!(walk_parties("wanted::1220bb", pages).await?.is_none());
+
+        Ok(())
+    }
+
+    /// A participant that keeps handing back the same token would otherwise walk
+    /// forever; the walk treats a repeat as the end. The script holds two pages,
+    /// so a third read would error rather than return `None`.
+    #[tokio::test]
+    async fn party_walk_stops_on_a_repeated_page_token() -> Result {
+        let pages = vec![
+            party_page(&[("other::1220aa", &[])], "stuck"),
+            party_page(&[("other::1220aa", &[])], "stuck"),
+        ];
+
+        assert!(walk_parties("wanted::1220bb", pages).await?.is_none());
+
+        Ok(())
+    }
+
+    /// Found, but carrying no annotations — there is no metadata to report, and
+    /// the walk must not keep looking for a better match.
+    #[tokio::test]
+    async fn party_walk_reports_nothing_for_a_party_without_annotations() -> Result {
+        let pages = vec![
+            party_page(&[("wanted::1220bb", &[])], "page-2"),
+            party_page(&[("wanted::1220bb", &[("owner", "alice")])], ""),
+        ];
+
+        assert!(walk_parties("wanted::1220bb", pages).await?.is_none());
+
+        Ok(())
     }
 }

--- a/crates/decman/src/server/queries.rs
+++ b/crates/decman/src/server/queries.rs
@@ -13,15 +13,15 @@ use std::{
 use canton_common::decimal::DamlDecimal;
 use canton_proto_rs::com::{
     daml::ledger::api::v2::{
-        CreatedEvent, CumulativeFilter, EventFormat, Filters, GetActiveContractsRequest,
-        GetEventsByContractIdRequest, GetLedgerEndRequest, Identifier, InterfaceFilter, Record,
-        TemplateFilter, Value, WildcardFilter, admin::ListKnownPartiesRequest, cumulative_filter,
-        get_active_contracts_response::ContractEntry, value,
+        CreatedEvent, CumulativeFilter, EventFormat, Filters, GetEventsByContractIdRequest,
+        Identifier, InterfaceFilter, Record, TemplateFilter, Value, WildcardFilter,
+        admin::ListKnownPartiesRequest, cumulative_filter, value,
     },
     digitalasset::canton::admin::participant::v30::{
         ListPackagesRequest, package_service_client::PackageServiceClient,
     },
 };
+use common::api::PAGE_SIZE;
 
 use crate::{
     canton_id::CantonId,
@@ -32,6 +32,7 @@ use crate::{
 
 use super::{
     action_serializer,
+    ledger_paging::fetch_active_contracts,
     package_inventory::{
         fetch_package_id_to_name, fetch_package_names, newest_matching_names, package_name_prefix,
     },
@@ -458,14 +459,6 @@ async fn fetch_contracts_with_wildcard(
     package_versions: &HashMap<String, String>,
     contracts: &mut Vec<ContractInfo>,
 ) -> Result {
-    let mut state_client = utils::create_state_client(config, token).await?;
-
-    let ledger_end = state_client
-        .get_ledger_end(tonic::Request::new(GetLedgerEndRequest {}))
-        .await?
-        .into_inner()
-        .offset;
-
     let mut filters_by_party = HashMap::new();
     filters_by_party.insert(
         party_id.to_string(),
@@ -480,38 +473,25 @@ async fn fetch_contracts_with_wildcard(
         },
     );
 
-    let acs_request = GetActiveContractsRequest {
-        active_at_offset: ledger_end,
-        event_format: Some(EventFormat {
-            filters_by_party,
-            filters_for_any_party: None,
-            verbose: false,
-        }),
-        stream_continuation_token: None,
+    let event_format = EventFormat {
+        filters_by_party,
+        filters_for_any_party: None,
+        verbose: false,
     };
 
-    let mut stream = state_client
-        .get_active_contracts(tonic::Request::new(acs_request))
-        .await?
-        .into_inner();
+    for created in fetch_active_contracts(config, token, event_format).await? {
+        // Filter in-memory for contract templates
+        let is_wanted = created
+            .template_id
+            .as_ref()
+            .map(|t| is_contract_template(&t.module_name, &t.entity_name))
+            .unwrap_or(false);
 
-    while let Some(response) = stream.message().await? {
-        if let Some(ContractEntry::ActiveContract(active)) = response.contract_entry
-            && let Some(created) = active.created_event
-        {
-            // Filter in-memory for contract templates
-            let is_wanted = created
-                .template_id
-                .as_ref()
-                .map(|t| is_contract_template(&t.module_name, &t.entity_name))
-                .unwrap_or(false);
-
-            if !is_wanted {
-                continue;
-            }
-
-            contracts.push(render_contract_info(&created, package_versions));
+        if !is_wanted {
+            continue;
         }
+
+        contracts.push(render_contract_info(&created, package_versions));
     }
 
     Ok(())
@@ -526,14 +506,6 @@ async fn fetch_contracts_for_template(
     package_versions: &HashMap<String, String>,
     contracts: &mut Vec<ContractInfo>,
 ) -> Result {
-    let mut state_client = utils::create_state_client(config, token).await?;
-
-    let ledger_end = state_client
-        .get_ledger_end(tonic::Request::new(GetLedgerEndRequest {}))
-        .await?
-        .into_inner()
-        .offset;
-
     let mut filters_by_party = HashMap::new();
     filters_by_party.insert(
         party_id.to_string(),
@@ -553,27 +525,14 @@ async fn fetch_contracts_for_template(
         },
     );
 
-    let acs_request = GetActiveContractsRequest {
-        active_at_offset: ledger_end,
-        event_format: Some(EventFormat {
-            filters_by_party,
-            filters_for_any_party: None,
-            verbose: false,
-        }),
-        stream_continuation_token: None,
+    let event_format = EventFormat {
+        filters_by_party,
+        filters_for_any_party: None,
+        verbose: false,
     };
 
-    let mut stream = state_client
-        .get_active_contracts(tonic::Request::new(acs_request))
-        .await?
-        .into_inner();
-
-    while let Some(response) = stream.message().await? {
-        if let Some(ContractEntry::ActiveContract(active)) = response.contract_entry
-            && let Some(created) = active.created_event
-        {
-            contracts.push(render_contract_info(&created, package_versions));
-        }
+    for created in fetch_active_contracts(config, token, event_format).await? {
+        contracts.push(render_contract_info(&created, package_versions));
     }
 
     Ok(())
@@ -586,32 +545,46 @@ pub async fn get_party_metadata(
     token: Option<String>,
 ) -> Result<Option<PartyMetadata>> {
     let mut client = utils::create_party_client(config, token).await?;
-
-    let response = client
-        .list_known_parties(tonic::Request::new(ListKnownPartiesRequest {
-            identity_provider_id: String::new(),
-            page_token: String::new(),
-            page_size: 1000,
-            filter_party: String::new(),
-        }))
-        .await?
-        .into_inner();
-
     let party_id_str = party_id.to_string();
-    let party_details = response
-        .party_details
-        .iter()
-        .find(|p| p.party == party_id_str);
 
-    let annotations = party_details
-        .and_then(|d| d.local_metadata.as_ref())
-        .map(|m| m.annotations.clone())
-        .unwrap_or_default();
+    // `filter_party` is a server-side prefix match, so a full party id narrows
+    // this to the one party we want. Paging is still walked because the prefix
+    // can in principle match more than one id, and a participant hosting more
+    // parties than one page holds would otherwise silently report no metadata.
+    let mut page_token = String::new();
+    loop {
+        let response = client
+            .list_known_parties(tonic::Request::new(ListKnownPartiesRequest {
+                identity_provider_id: String::new(),
+                page_token: page_token.clone(),
+                page_size: PAGE_SIZE,
+                filter_party: party_id_str.clone(),
+            }))
+            .await?
+            .into_inner();
 
-    if annotations.is_empty() {
-        Ok(None)
-    } else {
-        Ok(Some(PartyMetadata { annotations }))
+        if let Some(details) = response
+            .party_details
+            .iter()
+            .find(|p| p.party == party_id_str)
+        {
+            let annotations = details
+                .local_metadata
+                .as_ref()
+                .map(|m| m.annotations.clone())
+                .unwrap_or_default();
+
+            return if annotations.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(PartyMetadata { annotations }))
+            };
+        }
+
+        if response.next_page_token.is_empty() {
+            return Ok(None);
+        }
+        page_token = response.next_page_token;
     }
 }
 
@@ -825,14 +798,6 @@ async fn fetch_governance_with_wildcard(
     domain_confirmations: &mut HashMap<String, (String, Vec<GovernanceConfirmation>)>,
     proposal_infos: &mut HashMap<String, ProposalInfo>,
 ) -> Result {
-    let mut state_client = utils::create_state_client(config, token).await?;
-
-    let ledger_end = state_client
-        .get_ledger_end(tonic::Request::new(GetLedgerEndRequest {}))
-        .await?
-        .into_inner()
-        .offset;
-
     let mut filters_by_party = HashMap::new();
     filters_by_party.insert(
         party_id.to_string(),
@@ -847,38 +812,28 @@ async fn fetch_governance_with_wildcard(
         },
     );
 
-    let acs_request = GetActiveContractsRequest {
-        active_at_offset: ledger_end,
-        event_format: Some(EventFormat {
-            filters_by_party,
-            filters_for_any_party: None,
-            verbose: true,
-        }),
-        stream_continuation_token: None,
+    let event_format = EventFormat {
+        filters_by_party,
+        filters_for_any_party: None,
+        verbose: true,
     };
 
-    let mut stream = state_client
-        .get_active_contracts(tonic::Request::new(acs_request))
-        .await?
-        .into_inner();
+    for created in fetch_active_contracts(config, token, event_format).await? {
+        let Some(ref template_id) = created.template_id else {
+            continue;
+        };
 
-    while let Some(response) = stream.message().await? {
-        if let Some(ContractEntry::ActiveContract(active)) = response.contract_entry
-            && let Some(created) = active.created_event
-            && let Some(ref template_id) = created.template_id
-        {
-            if is_governance_template(&template_id.module_name, &template_id.entity_name) {
-                if template_id.module_name == "Governance.Confirmation"
-                    && template_id.entity_name == "GovernanceConfirmation"
-                {
-                    extract_and_add_domain_confirmation(&created, domain_confirmations);
-                } else {
-                    extract_and_add_confirmation(&created, confirmations_by_hash);
-                }
+        if is_governance_template(&template_id.module_name, &template_id.entity_name) {
+            if template_id.module_name == "Governance.Confirmation"
+                && template_id.entity_name == "GovernanceConfirmation"
+            {
+                extract_and_add_domain_confirmation(&created, domain_confirmations);
             } else {
-                // Capture proposal info from GovernableAction contracts
-                extract_proposal_info(&created, proposal_infos);
+                extract_and_add_confirmation(&created, confirmations_by_hash);
             }
+        } else {
+            // Capture proposal info from GovernableAction contracts
+            extract_proposal_info(&created, proposal_infos);
         }
     }
 
@@ -894,14 +849,6 @@ async fn fetch_governance_for_template(
     confirmations_by_hash: &mut HashMap<String, (ActionType, Vec<GovernanceConfirmation>)>,
     domain_confirmations: &mut HashMap<String, (String, Vec<GovernanceConfirmation>)>,
 ) -> Result {
-    let mut state_client = utils::create_state_client(config, token).await?;
-
-    let ledger_end = state_client
-        .get_ledger_end(tonic::Request::new(GetLedgerEndRequest {}))
-        .await?
-        .into_inner()
-        .offset;
-
     let mut filters_by_party = HashMap::new();
     filters_by_party.insert(
         party_id.to_string(),
@@ -921,33 +868,19 @@ async fn fetch_governance_for_template(
         },
     );
 
-    let acs_request = GetActiveContractsRequest {
-        active_at_offset: ledger_end,
-        event_format: Some(EventFormat {
-            filters_by_party,
-            filters_for_any_party: None,
-            verbose: true,
-        }),
-        stream_continuation_token: None,
+    let event_format = EventFormat {
+        filters_by_party,
+        filters_for_any_party: None,
+        verbose: true,
     };
 
-    let mut stream = state_client
-        .get_active_contracts(tonic::Request::new(acs_request))
-        .await?
-        .into_inner();
-
-    while let Some(response) = stream.message().await? {
-        if let Some(ContractEntry::ActiveContract(active)) = response.contract_entry
-            && let Some(created) = active.created_event
-        {
-            if created.template_id.as_ref().is_some_and(|t| {
-                t.module_name == "Governance.Confirmation"
-                    && t.entity_name == "GovernanceConfirmation"
-            }) {
-                extract_and_add_domain_confirmation(&created, domain_confirmations);
-            } else {
-                extract_and_add_confirmation(&created, confirmations_by_hash);
-            }
+    for created in fetch_active_contracts(config, token, event_format).await? {
+        if created.template_id.as_ref().is_some_and(|t| {
+            t.module_name == "Governance.Confirmation" && t.entity_name == "GovernanceConfirmation"
+        }) {
+            extract_and_add_domain_confirmation(&created, domain_confirmations);
+        } else {
+            extract_and_add_confirmation(&created, confirmations_by_hash);
         }
     }
 
@@ -1405,14 +1338,6 @@ async fn fetch_proposal_infos(
         return Ok(());
     };
 
-    let mut state_client = utils::create_state_client(config, token.clone()).await?;
-
-    let ledger_end = state_client
-        .get_ledger_end(tonic::Request::new(GetLedgerEndRequest {}))
-        .await?
-        .into_inner()
-        .offset;
-
     let mut filters_by_party = HashMap::new();
     filters_by_party.insert(
         party_id.to_string(),
@@ -1433,27 +1358,14 @@ async fn fetch_proposal_infos(
         },
     );
 
-    let acs_request = GetActiveContractsRequest {
-        active_at_offset: ledger_end,
-        event_format: Some(EventFormat {
-            filters_by_party,
-            filters_for_any_party: None,
-            verbose: true,
-        }),
-        stream_continuation_token: None,
+    let event_format = EventFormat {
+        filters_by_party,
+        filters_for_any_party: None,
+        verbose: true,
     };
 
-    let mut stream = state_client
-        .get_active_contracts(tonic::Request::new(acs_request))
-        .await?
-        .into_inner();
-
-    while let Some(response) = stream.message().await? {
-        if let Some(ContractEntry::ActiveContract(active)) = response.contract_entry
-            && let Some(created) = active.created_event
-        {
-            extract_proposal_info(&created, proposal_infos);
-        }
+    for created in fetch_active_contracts(config, token.clone(), event_format).await? {
+        extract_proposal_info(&created, proposal_infos);
     }
 
     // Resolve the linked `TransferInstruction` for any
@@ -1587,14 +1499,6 @@ async fn fetch_governance_state_with_wildcard(
     party_id: &CantonId,
     token: Option<String>,
 ) -> Result<Option<GovernanceState>> {
-    let mut state_client = utils::create_state_client(config, token).await?;
-
-    let ledger_end = state_client
-        .get_ledger_end(tonic::Request::new(GetLedgerEndRequest {}))
-        .await?
-        .into_inner()
-        .offset;
-
     let mut filters_by_party = HashMap::new();
     filters_by_party.insert(
         party_id.to_string(),
@@ -1609,34 +1513,21 @@ async fn fetch_governance_state_with_wildcard(
         },
     );
 
-    let acs_request = GetActiveContractsRequest {
-        active_at_offset: ledger_end,
-        event_format: Some(EventFormat {
-            filters_by_party,
-            filters_for_any_party: None,
-            verbose: true,
-        }),
-        stream_continuation_token: None,
+    let event_format = EventFormat {
+        filters_by_party,
+        filters_for_any_party: None,
+        verbose: true,
     };
 
-    let mut stream = state_client
-        .get_active_contracts(tonic::Request::new(acs_request))
-        .await?
-        .into_inner();
-
-    while let Some(response) = stream.message().await? {
-        if let Some(ContractEntry::ActiveContract(active)) = response.contract_entry
-            && let Some(created) = active.created_event
+    for created in fetch_active_contracts(config, token, event_format).await? {
+        // Check if this is a governance rules template (vault or core)
+        if let Some(ref template_id) = created.template_id
+            && ((template_id.module_name == "BitsafeVault.VaultGovernance"
+                && template_id.entity_name == "VaultGovernanceRules")
+                || (template_id.module_name == "Governance.Rules"
+                    && template_id.entity_name == "GovernanceRules"))
         {
-            // Check if this is a governance rules template (vault or core)
-            if let Some(ref template_id) = created.template_id
-                && ((template_id.module_name == "BitsafeVault.VaultGovernance"
-                    && template_id.entity_name == "VaultGovernanceRules")
-                    || (template_id.module_name == "Governance.Rules"
-                        && template_id.entity_name == "GovernanceRules"))
-            {
-                return Ok(extract_governance_state(&created));
-            }
+            return Ok(extract_governance_state(&created));
         }
     }
 
@@ -1650,14 +1541,6 @@ async fn fetch_governance_state_for_template(
     token: Option<String>,
     template: &TemplateId,
 ) -> Result<Option<GovernanceState>> {
-    let mut state_client = utils::create_state_client(config, token).await?;
-
-    let ledger_end = state_client
-        .get_ledger_end(tonic::Request::new(GetLedgerEndRequest {}))
-        .await?
-        .into_inner()
-        .offset;
-
     let mut filters_by_party = HashMap::new();
     filters_by_party.insert(
         party_id.to_string(),
@@ -1677,30 +1560,16 @@ async fn fetch_governance_state_for_template(
         },
     );
 
-    let acs_request = GetActiveContractsRequest {
-        active_at_offset: ledger_end,
-        event_format: Some(EventFormat {
-            filters_by_party,
-            filters_for_any_party: None,
-            verbose: true,
-        }),
-        stream_continuation_token: None,
+    let event_format = EventFormat {
+        filters_by_party,
+        filters_for_any_party: None,
+        verbose: true,
     };
 
-    let mut stream = state_client
-        .get_active_contracts(tonic::Request::new(acs_request))
+    Ok(fetch_active_contracts(config, token, event_format)
         .await?
-        .into_inner();
-
-    while let Some(response) = stream.message().await? {
-        if let Some(ContractEntry::ActiveContract(active)) = response.contract_entry
-            && let Some(created) = active.created_event
-        {
-            return Ok(extract_governance_state(&created));
-        }
-    }
-
-    Ok(None)
+        .first()
+        .and_then(extract_governance_state))
 }
 
 /// Extract governance state from a VaultGovernanceRules or GovernanceRules created event
@@ -1948,14 +1817,6 @@ async fn fetch_vaults_with_wildcard(
     party_id: &CantonId,
     token: Option<String>,
 ) -> Result<Vec<VaultInfo>> {
-    let mut state_client = utils::create_state_client(config, token).await?;
-
-    let ledger_end = state_client
-        .get_ledger_end(tonic::Request::new(GetLedgerEndRequest {}))
-        .await?
-        .into_inner()
-        .offset;
-
     let mut filters_by_party = HashMap::new();
     filters_by_party.insert(
         party_id.to_string(),
@@ -1970,26 +1831,15 @@ async fn fetch_vaults_with_wildcard(
         },
     );
 
-    let acs_request = GetActiveContractsRequest {
-        active_at_offset: ledger_end,
-        event_format: Some(EventFormat {
-            filters_by_party,
-            filters_for_any_party: None,
-            verbose: true,
-        }),
-        stream_continuation_token: None,
+    let event_format = EventFormat {
+        filters_by_party,
+        filters_for_any_party: None,
+        verbose: true,
     };
 
-    let mut stream = state_client
-        .get_active_contracts(acs_request)
-        .await?
-        .into_inner();
-
     let mut vaults = Vec::new();
-    while let Some(response) = stream.message().await? {
-        if let Some(ContractEntry::ActiveContract(active)) = response.contract_entry
-            && let Some(created) = active.created_event
-            && let Some(template_id) = &created.template_id
+    for created in fetch_active_contracts(config, token, event_format).await? {
+        if let Some(template_id) = &created.template_id
             && template_id.module_name == "BitsafeVault.Vault"
             && template_id.entity_name == "Vault"
             && let Some(vault_info) = extract_vault_info(&created)
@@ -2008,14 +1858,6 @@ async fn fetch_vaults_for_template(
     token: Option<String>,
     template: &TemplateId,
 ) -> Result<Vec<VaultInfo>> {
-    let mut state_client = utils::create_state_client(config, token).await?;
-
-    let ledger_end = state_client
-        .get_ledger_end(tonic::Request::new(GetLedgerEndRequest {}))
-        .await?
-        .into_inner()
-        .offset;
-
     let mut filters_by_party = HashMap::new();
     filters_by_party.insert(
         party_id.to_string(),
@@ -2035,27 +1877,17 @@ async fn fetch_vaults_for_template(
         },
     );
 
-    let acs_request = GetActiveContractsRequest {
-        active_at_offset: ledger_end,
-        event_format: Some(EventFormat {
-            filters_by_party,
-            filters_for_any_party: None,
-            verbose: true,
-        }),
-        stream_continuation_token: None,
+    let event_format = EventFormat {
+        filters_by_party,
+        filters_for_any_party: None,
+        verbose: true,
     };
 
-    let mut stream = state_client
-        .get_active_contracts(acs_request)
-        .await?
-        .into_inner();
+    let active_contracts = fetch_active_contracts(config, token, event_format).await?;
 
     let mut vaults = Vec::new();
-    while let Some(response) = stream.message().await? {
-        if let Some(ContractEntry::ActiveContract(active)) = response.contract_entry
-            && let Some(created) = active.created_event
-            && let Some(vault_info) = extract_vault_info(&created)
-        {
+    for created in active_contracts {
+        if let Some(vault_info) = extract_vault_info(&created) {
             vaults.push(vault_info);
         }
     }
@@ -2168,14 +2000,6 @@ async fn fetch_provider_services_with_wildcard(
     party_id: &CantonId,
     token: Option<String>,
 ) -> Result<Vec<ProviderServiceInfo>> {
-    let mut state_client = utils::create_state_client(config, token).await?;
-
-    let ledger_end = state_client
-        .get_ledger_end(tonic::Request::new(GetLedgerEndRequest {}))
-        .await?
-        .into_inner()
-        .offset;
-
     let mut filters_by_party = HashMap::new();
     filters_by_party.insert(
         party_id.to_string(),
@@ -2190,26 +2014,17 @@ async fn fetch_provider_services_with_wildcard(
         },
     );
 
-    let acs_request = GetActiveContractsRequest {
-        active_at_offset: ledger_end,
-        event_format: Some(EventFormat {
-            filters_by_party,
-            filters_for_any_party: None,
-            verbose: true,
-        }),
-        stream_continuation_token: None,
+    let event_format = EventFormat {
+        filters_by_party,
+        filters_for_any_party: None,
+        verbose: true,
     };
 
-    let mut stream = state_client
-        .get_active_contracts(acs_request)
-        .await?
-        .into_inner();
+    let active_contracts = fetch_active_contracts(config, token, event_format).await?;
 
     let mut services = Vec::new();
-    while let Some(response) = stream.message().await? {
-        if let Some(ContractEntry::ActiveContract(active)) = response.contract_entry
-            && let Some(created) = active.created_event
-            && let Some(template_id) = &created.template_id
+    for created in active_contracts {
+        if let Some(template_id) = &created.template_id
             && template_id.module_name == "Utility.Registry.App.V0.Service.Provider"
             && template_id.entity_name == "ProviderService"
             && let Some(info) = extract_provider_service_info(&created)
@@ -2228,14 +2043,6 @@ async fn fetch_provider_services_for_template(
     token: Option<String>,
     template: &TemplateId,
 ) -> Result<Vec<ProviderServiceInfo>> {
-    let mut state_client = utils::create_state_client(config, token).await?;
-
-    let ledger_end = state_client
-        .get_ledger_end(tonic::Request::new(GetLedgerEndRequest {}))
-        .await?
-        .into_inner()
-        .offset;
-
     let mut filters_by_party = HashMap::new();
     filters_by_party.insert(
         party_id.to_string(),
@@ -2255,27 +2062,17 @@ async fn fetch_provider_services_for_template(
         },
     );
 
-    let acs_request = GetActiveContractsRequest {
-        active_at_offset: ledger_end,
-        event_format: Some(EventFormat {
-            filters_by_party,
-            filters_for_any_party: None,
-            verbose: true,
-        }),
-        stream_continuation_token: None,
+    let event_format = EventFormat {
+        filters_by_party,
+        filters_for_any_party: None,
+        verbose: true,
     };
 
-    let mut stream = state_client
-        .get_active_contracts(acs_request)
-        .await?
-        .into_inner();
+    let active_contracts = fetch_active_contracts(config, token, event_format).await?;
 
     let mut services = Vec::new();
-    while let Some(response) = stream.message().await? {
-        if let Some(ContractEntry::ActiveContract(active)) = response.contract_entry
-            && let Some(created) = active.created_event
-            && let Some(info) = extract_provider_service_info(&created)
-        {
+    for created in active_contracts {
+        if let Some(info) = extract_provider_service_info(&created) {
             services.push(info);
         }
     }
@@ -2340,14 +2137,6 @@ async fn fetch_user_services_with_wildcard(
     party_id: &CantonId,
     token: Option<String>,
 ) -> Result<Vec<UserServiceInfo>> {
-    let mut state_client = utils::create_state_client(config, token).await?;
-
-    let ledger_end = state_client
-        .get_ledger_end(tonic::Request::new(GetLedgerEndRequest {}))
-        .await?
-        .into_inner()
-        .offset;
-
     let mut filters_by_party = HashMap::new();
     filters_by_party.insert(
         party_id.to_string(),
@@ -2362,26 +2151,17 @@ async fn fetch_user_services_with_wildcard(
         },
     );
 
-    let acs_request = GetActiveContractsRequest {
-        active_at_offset: ledger_end,
-        event_format: Some(EventFormat {
-            filters_by_party,
-            filters_for_any_party: None,
-            verbose: true,
-        }),
-        stream_continuation_token: None,
+    let event_format = EventFormat {
+        filters_by_party,
+        filters_for_any_party: None,
+        verbose: true,
     };
 
-    let mut stream = state_client
-        .get_active_contracts(acs_request)
-        .await?
-        .into_inner();
+    let active_contracts = fetch_active_contracts(config, token, event_format).await?;
 
     let mut services = Vec::new();
-    while let Some(response) = stream.message().await? {
-        if let Some(ContractEntry::ActiveContract(active)) = response.contract_entry
-            && let Some(created) = active.created_event
-            && let Some(template_id) = &created.template_id
+    for created in active_contracts {
+        if let Some(template_id) = &created.template_id
             && template_id.module_name == "Utility.Credential.App.V0.Service.User"
             && template_id.entity_name == "UserService"
             && let Some(info) = extract_user_service_info(&created)
@@ -2400,14 +2180,6 @@ async fn fetch_user_services_for_template(
     token: Option<String>,
     template: &TemplateId,
 ) -> Result<Vec<UserServiceInfo>> {
-    let mut state_client = utils::create_state_client(config, token).await?;
-
-    let ledger_end = state_client
-        .get_ledger_end(tonic::Request::new(GetLedgerEndRequest {}))
-        .await?
-        .into_inner()
-        .offset;
-
     let mut filters_by_party = HashMap::new();
     filters_by_party.insert(
         party_id.to_string(),
@@ -2427,27 +2199,17 @@ async fn fetch_user_services_for_template(
         },
     );
 
-    let acs_request = GetActiveContractsRequest {
-        active_at_offset: ledger_end,
-        event_format: Some(EventFormat {
-            filters_by_party,
-            filters_for_any_party: None,
-            verbose: true,
-        }),
-        stream_continuation_token: None,
+    let event_format = EventFormat {
+        filters_by_party,
+        filters_for_any_party: None,
+        verbose: true,
     };
 
-    let mut stream = state_client
-        .get_active_contracts(acs_request)
-        .await?
-        .into_inner();
+    let active_contracts = fetch_active_contracts(config, token, event_format).await?;
 
     let mut services = Vec::new();
-    while let Some(response) = stream.message().await? {
-        if let Some(ContractEntry::ActiveContract(active)) = response.contract_entry
-            && let Some(created) = active.created_event
-            && let Some(info) = extract_user_service_info(&created)
-        {
+    for created in active_contracts {
+        if let Some(info) = extract_user_service_info(&created) {
             services.push(info);
         }
     }
@@ -2518,14 +2280,6 @@ async fn fetch_credential_offers_with_wildcard(
     party_id: &CantonId,
     token: Option<String>,
 ) -> Result<Vec<CredentialOfferInfo>> {
-    let mut state_client = utils::create_state_client(config, token).await?;
-
-    let ledger_end = state_client
-        .get_ledger_end(tonic::Request::new(GetLedgerEndRequest {}))
-        .await?
-        .into_inner()
-        .offset;
-
     let mut filters_by_party = HashMap::new();
     filters_by_party.insert(
         party_id.to_string(),
@@ -2540,26 +2294,17 @@ async fn fetch_credential_offers_with_wildcard(
         },
     );
 
-    let acs_request = GetActiveContractsRequest {
-        active_at_offset: ledger_end,
-        event_format: Some(EventFormat {
-            filters_by_party,
-            filters_for_any_party: None,
-            verbose: true,
-        }),
-        stream_continuation_token: None,
+    let event_format = EventFormat {
+        filters_by_party,
+        filters_for_any_party: None,
+        verbose: true,
     };
 
-    let mut stream = state_client
-        .get_active_contracts(acs_request)
-        .await?
-        .into_inner();
+    let active_contracts = fetch_active_contracts(config, token, event_format).await?;
 
     let mut offers = Vec::new();
-    while let Some(response) = stream.message().await? {
-        if let Some(ContractEntry::ActiveContract(active)) = response.contract_entry
-            && let Some(created) = active.created_event
-            && let Some(template_id) = &created.template_id
+    for created in active_contracts {
+        if let Some(template_id) = &created.template_id
             && template_id.module_name == "Utility.Credential.App.V0.Model.Offer"
             && template_id.entity_name == "CredentialOffer"
             && let Some(info) = extract_credential_offer_info(&created)
@@ -2578,14 +2323,6 @@ async fn fetch_credential_offers_for_template(
     token: Option<String>,
     template: &TemplateId,
 ) -> Result<Vec<CredentialOfferInfo>> {
-    let mut state_client = utils::create_state_client(config, token).await?;
-
-    let ledger_end = state_client
-        .get_ledger_end(tonic::Request::new(GetLedgerEndRequest {}))
-        .await?
-        .into_inner()
-        .offset;
-
     let mut filters_by_party = HashMap::new();
     filters_by_party.insert(
         party_id.to_string(),
@@ -2605,27 +2342,17 @@ async fn fetch_credential_offers_for_template(
         },
     );
 
-    let acs_request = GetActiveContractsRequest {
-        active_at_offset: ledger_end,
-        event_format: Some(EventFormat {
-            filters_by_party,
-            filters_for_any_party: None,
-            verbose: true,
-        }),
-        stream_continuation_token: None,
+    let event_format = EventFormat {
+        filters_by_party,
+        filters_for_any_party: None,
+        verbose: true,
     };
 
-    let mut stream = state_client
-        .get_active_contracts(acs_request)
-        .await?
-        .into_inner();
+    let active_contracts = fetch_active_contracts(config, token, event_format).await?;
 
     let mut offers = Vec::new();
-    while let Some(response) = stream.message().await? {
-        if let Some(ContractEntry::ActiveContract(active)) = response.contract_entry
-            && let Some(created) = active.created_event
-            && let Some(info) = extract_credential_offer_info(&created)
-        {
+    for created in active_contracts {
+        if let Some(info) = extract_credential_offer_info(&created) {
             offers.push(info);
         }
     }
@@ -2696,14 +2423,6 @@ async fn fetch_registrar_services_with_wildcard(
     party_id: &CantonId,
     token: Option<String>,
 ) -> Result<Vec<RegistrarServiceInfo>> {
-    let mut state_client = utils::create_state_client(config, token).await?;
-
-    let ledger_end = state_client
-        .get_ledger_end(tonic::Request::new(GetLedgerEndRequest {}))
-        .await?
-        .into_inner()
-        .offset;
-
     let mut filters_by_party = HashMap::new();
     filters_by_party.insert(
         party_id.to_string(),
@@ -2718,26 +2437,17 @@ async fn fetch_registrar_services_with_wildcard(
         },
     );
 
-    let acs_request = GetActiveContractsRequest {
-        active_at_offset: ledger_end,
-        event_format: Some(EventFormat {
-            filters_by_party,
-            filters_for_any_party: None,
-            verbose: true,
-        }),
-        stream_continuation_token: None,
+    let event_format = EventFormat {
+        filters_by_party,
+        filters_for_any_party: None,
+        verbose: true,
     };
 
-    let mut stream = state_client
-        .get_active_contracts(acs_request)
-        .await?
-        .into_inner();
+    let active_contracts = fetch_active_contracts(config, token, event_format).await?;
 
     let mut services = Vec::new();
-    while let Some(response) = stream.message().await? {
-        if let Some(ContractEntry::ActiveContract(active)) = response.contract_entry
-            && let Some(created) = active.created_event
-            && let Some(template_id) = &created.template_id
+    for created in active_contracts {
+        if let Some(template_id) = &created.template_id
             && template_id.module_name == "Utility.Registry.App.V0.Service.Registrar"
             && template_id.entity_name == "RegistrarService"
             && let Some(info) = extract_registrar_service_info(&created)
@@ -2756,14 +2466,6 @@ async fn fetch_registrar_services_for_template(
     token: Option<String>,
     template: &TemplateId,
 ) -> Result<Vec<RegistrarServiceInfo>> {
-    let mut state_client = utils::create_state_client(config, token).await?;
-
-    let ledger_end = state_client
-        .get_ledger_end(tonic::Request::new(GetLedgerEndRequest {}))
-        .await?
-        .into_inner()
-        .offset;
-
     let mut filters_by_party = HashMap::new();
     filters_by_party.insert(
         party_id.to_string(),
@@ -2783,27 +2485,17 @@ async fn fetch_registrar_services_for_template(
         },
     );
 
-    let acs_request = GetActiveContractsRequest {
-        active_at_offset: ledger_end,
-        event_format: Some(EventFormat {
-            filters_by_party,
-            filters_for_any_party: None,
-            verbose: true,
-        }),
-        stream_continuation_token: None,
+    let event_format = EventFormat {
+        filters_by_party,
+        filters_for_any_party: None,
+        verbose: true,
     };
 
-    let mut stream = state_client
-        .get_active_contracts(acs_request)
-        .await?
-        .into_inner();
+    let active_contracts = fetch_active_contracts(config, token, event_format).await?;
 
     let mut services = Vec::new();
-    while let Some(response) = stream.message().await? {
-        if let Some(ContractEntry::ActiveContract(active)) = response.contract_entry
-            && let Some(created) = active.created_event
-            && let Some(info) = extract_registrar_service_info(&created)
-        {
+    for created in active_contracts {
+        if let Some(info) = extract_registrar_service_info(&created) {
             services.push(info);
         }
     }
@@ -2884,14 +2576,6 @@ async fn fetch_instruments_with_wildcard(
     party_id: &CantonId,
     token: Option<String>,
 ) -> Result<Vec<InstrumentInfo>> {
-    let mut state_client = utils::create_state_client(config, token).await?;
-
-    let ledger_end = state_client
-        .get_ledger_end(tonic::Request::new(GetLedgerEndRequest {}))
-        .await?
-        .into_inner()
-        .offset;
-
     let mut filters_by_party = HashMap::new();
     filters_by_party.insert(
         party_id.to_string(),
@@ -2906,26 +2590,17 @@ async fn fetch_instruments_with_wildcard(
         },
     );
 
-    let acs_request = GetActiveContractsRequest {
-        active_at_offset: ledger_end,
-        event_format: Some(EventFormat {
-            filters_by_party,
-            filters_for_any_party: None,
-            verbose: true,
-        }),
-        stream_continuation_token: None,
+    let event_format = EventFormat {
+        filters_by_party,
+        filters_for_any_party: None,
+        verbose: true,
     };
 
-    let mut stream = state_client
-        .get_active_contracts(acs_request)
-        .await?
-        .into_inner();
+    let active_contracts = fetch_active_contracts(config, token, event_format).await?;
 
     let mut instruments = Vec::new();
-    while let Some(response) = stream.message().await? {
-        if let Some(ContractEntry::ActiveContract(active)) = response.contract_entry
-            && let Some(created) = active.created_event
-            && let Some(template_id) = &created.template_id
+    for created in active_contracts {
+        if let Some(template_id) = &created.template_id
             && template_id.module_name == "Utility.Registry.V0.Configuration.Instrument"
             && template_id.entity_name == "InstrumentConfiguration"
             && let Some(info) = extract_instrument_info(&created)
@@ -2943,14 +2618,6 @@ async fn fetch_instruments_for_template(
     token: Option<String>,
     template: &TemplateId,
 ) -> Result<Vec<InstrumentInfo>> {
-    let mut state_client = utils::create_state_client(config, token).await?;
-
-    let ledger_end = state_client
-        .get_ledger_end(tonic::Request::new(GetLedgerEndRequest {}))
-        .await?
-        .into_inner()
-        .offset;
-
     let mut filters_by_party = HashMap::new();
     filters_by_party.insert(
         party_id.to_string(),
@@ -2970,27 +2637,17 @@ async fn fetch_instruments_for_template(
         },
     );
 
-    let acs_request = GetActiveContractsRequest {
-        active_at_offset: ledger_end,
-        event_format: Some(EventFormat {
-            filters_by_party,
-            filters_for_any_party: None,
-            verbose: true,
-        }),
-        stream_continuation_token: None,
+    let event_format = EventFormat {
+        filters_by_party,
+        filters_for_any_party: None,
+        verbose: true,
     };
 
-    let mut stream = state_client
-        .get_active_contracts(acs_request)
-        .await?
-        .into_inner();
+    let active_contracts = fetch_active_contracts(config, token, event_format).await?;
 
     let mut instruments = Vec::new();
-    while let Some(response) = stream.message().await? {
-        if let Some(ContractEntry::ActiveContract(active)) = response.contract_entry
-            && let Some(created) = active.created_event
-            && let Some(info) = extract_instrument_info(&created)
-        {
+    for created in active_contracts {
+        if let Some(info) = extract_instrument_info(&created) {
             instruments.push(info);
         }
     }
@@ -3070,14 +2727,6 @@ pub async fn query_contracts_by_template(
 ) -> Result<Vec<ContractWithBlob>> {
     use base64::Engine;
 
-    let mut state_client = utils::create_state_client(config, token).await?;
-
-    let ledger_end = state_client
-        .get_ledger_end(tonic::Request::new(GetLedgerEndRequest {}))
-        .await?
-        .into_inner()
-        .offset;
-
     let identifier = Identifier {
         package_id: params.package_id.clone(),
         module_name: params.module_name.clone(),
@@ -3111,49 +2760,38 @@ pub async fn query_contracts_by_template(
         },
     );
 
-    let acs_request = GetActiveContractsRequest {
-        active_at_offset: ledger_end,
-        event_format: Some(EventFormat {
-            filters_by_party,
-            filters_for_any_party: None,
-            verbose: true,
-        }),
-        stream_continuation_token: None,
+    let event_format = EventFormat {
+        filters_by_party,
+        filters_for_any_party: None,
+        verbose: true,
     };
 
-    let mut stream = state_client
-        .get_active_contracts(acs_request)
-        .await?
-        .into_inner();
+    let active_contracts = fetch_active_contracts(config, token, event_format).await?;
 
     let mut contracts = Vec::new();
-    while let Some(response) = stream.message().await? {
-        if let Some(ContractEntry::ActiveContract(active)) = response.contract_entry
-            && let Some(created) = active.created_event
-        {
-            let matches = if test_mode {
-                created.template_id.as_ref().is_some_and(|t| {
-                    t.module_name == params.module_name && t.entity_name == params.entity_name
-                })
-            } else {
-                true
-            };
+    for created in active_contracts {
+        let matches = if test_mode {
+            created.template_id.as_ref().is_some_and(|t| {
+                t.module_name == params.module_name && t.entity_name == params.entity_name
+            })
+        } else {
+            true
+        };
 
-            if matches {
-                // QA flagged the Accept Mint Request dropdown for surfacing
-                // contracts whose `executeBefore` has already passed —
-                // accepting them would fail at interpretation with
-                // deadline-exceeded. Drop them here when the caller opts in.
-                if params.active_only && is_execute_before_expired(&created) {
-                    continue;
-                }
-                let blob =
-                    base64::engine::general_purpose::STANDARD.encode(&created.created_event_blob);
-                contracts.push(ContractWithBlob {
-                    contract_id: created.contract_id,
-                    blob,
-                });
+        if matches {
+            // QA flagged the Accept Mint Request dropdown for surfacing
+            // contracts whose `executeBefore` has already passed —
+            // accepting them would fail at interpretation with
+            // deadline-exceeded. Drop them here when the caller opts in.
+            if params.active_only && is_execute_before_expired(&created) {
+                continue;
             }
+            let blob =
+                base64::engine::general_purpose::STANDARD.encode(&created.created_event_blob);
+            contracts.push(ContractWithBlob {
+                contract_id: created.contract_id,
+                blob,
+            });
         }
     }
 
@@ -3182,14 +2820,6 @@ pub async fn get_open_transfer_instructions(
     party_id: &CantonId,
     token: Option<String>,
 ) -> Result<Vec<TransferInstructionInfo>> {
-    let mut state_client = utils::create_state_client(config, token).await?;
-
-    let ledger_end = state_client
-        .get_ledger_end(tonic::Request::new(GetLedgerEndRequest {}))
-        .await?
-        .into_inner()
-        .offset;
-
     let mut filters_by_party = HashMap::new();
     filters_by_party.insert(
         party_id.to_string(),
@@ -3210,31 +2840,22 @@ pub async fn get_open_transfer_instructions(
         },
     );
 
-    let acs_request = GetActiveContractsRequest {
-        active_at_offset: ledger_end,
-        event_format: Some(EventFormat {
-            filters_by_party,
-            filters_for_any_party: None,
-            verbose: true,
-        }),
-        stream_continuation_token: None,
+    let event_format = EventFormat {
+        filters_by_party,
+        filters_for_any_party: None,
+        verbose: true,
     };
 
-    let mut stream = state_client
-        .get_active_contracts(tonic::Request::new(acs_request))
-        .await?
-        .into_inner();
+    let active_contracts = fetch_active_contracts(config, token, event_format).await?;
 
     let receiver_str = party_id.to_string();
     let mut instructions = Vec::new();
-    while let Some(response) = stream.message().await? {
+    for created in active_contracts {
         // The InterfaceFilter only enforces party visibility — this party can
         // see the contract as sender, receiver, or an instrument-admin
         // stakeholder. Keep only the ones where it's the *receiver*, since
         // those are the only ones it can Accept.
-        if let Some(ContractEntry::ActiveContract(active)) = response.contract_entry
-            && let Some(created) = active.created_event
-            && let Some(info) = extract_transfer_instruction_info(&created)
+        if let Some(info) = extract_transfer_instruction_info(&created)
             && info.receiver.to_string() == receiver_str
         {
             instructions.push(info);
@@ -3397,14 +3018,6 @@ async fn fetch_token_requests_for_template(
     template: &TemplateId,
     payload_field: &str,
 ) -> Result<Vec<TokenRequestInfo>> {
-    let mut state_client = utils::create_state_client(config, token).await?;
-
-    let ledger_end = state_client
-        .get_ledger_end(tonic::Request::new(GetLedgerEndRequest {}))
-        .await?
-        .into_inner()
-        .offset;
-
     let mut filters_by_party = HashMap::new();
     filters_by_party.insert(
         party_id.to_string(),
@@ -3424,26 +3037,17 @@ async fn fetch_token_requests_for_template(
         },
     );
 
-    let acs_request = GetActiveContractsRequest {
-        active_at_offset: ledger_end,
-        event_format: Some(EventFormat {
-            filters_by_party,
-            filters_for_any_party: None,
-            verbose: true,
-        }),
-        stream_continuation_token: None,
+    let event_format = EventFormat {
+        filters_by_party,
+        filters_for_any_party: None,
+        verbose: true,
     };
 
-    let mut stream = state_client
-        .get_active_contracts(tonic::Request::new(acs_request))
-        .await?
-        .into_inner();
+    let active_contracts = fetch_active_contracts(config, token, event_format).await?;
 
     let mut requests = Vec::new();
-    while let Some(response) = stream.message().await? {
-        if let Some(ContractEntry::ActiveContract(active)) = response.contract_entry
-            && let Some(created) = active.created_event
-            && !is_execute_before_expired_in_payload(&created, payload_field)
+    for created in active_contracts {
+        if !is_execute_before_expired_in_payload(&created, payload_field)
             && let Some(info) = extract_token_request_info(&created, payload_field)
         {
             requests.push(info);
@@ -3642,14 +3246,6 @@ pub async fn get_transfer_factories(
     party_id: &CantonId,
     token: Option<String>,
 ) -> Result<Vec<TransferFactoryInfo>> {
-    let mut state_client = utils::create_state_client(config, token).await?;
-
-    let ledger_end = state_client
-        .get_ledger_end(tonic::Request::new(GetLedgerEndRequest {}))
-        .await?
-        .into_inner()
-        .offset;
-
     let mut filters_by_party = HashMap::new();
     filters_by_party.insert(
         party_id.to_string(),
@@ -3670,27 +3266,17 @@ pub async fn get_transfer_factories(
         },
     );
 
-    let acs_request = GetActiveContractsRequest {
-        active_at_offset: ledger_end,
-        event_format: Some(EventFormat {
-            filters_by_party,
-            filters_for_any_party: None,
-            verbose: true,
-        }),
-        stream_continuation_token: None,
+    let event_format = EventFormat {
+        filters_by_party,
+        filters_for_any_party: None,
+        verbose: true,
     };
 
-    let mut stream = state_client
-        .get_active_contracts(tonic::Request::new(acs_request))
-        .await?
-        .into_inner();
+    let active_contracts = fetch_active_contracts(config, token, event_format).await?;
 
     let mut factories = Vec::new();
-    while let Some(response) = stream.message().await? {
-        if let Some(ContractEntry::ActiveContract(active)) = response.contract_entry
-            && let Some(created) = active.created_event
-            && let Some(info) = extract_transfer_factory_info(&created)
-        {
+    for created in active_contracts {
+        if let Some(info) = extract_transfer_factory_info(&created) {
             factories.push(info);
         }
     }
@@ -3821,14 +3407,6 @@ async fn fetch_holding_views(
     party_id: &CantonId,
     token: Option<String>,
 ) -> Result<Vec<HoldingView>> {
-    let mut state_client = utils::create_state_client(config, token).await?;
-
-    let ledger_end = state_client
-        .get_ledger_end(tonic::Request::new(GetLedgerEndRequest {}))
-        .await?
-        .into_inner()
-        .offset;
-
     let mut filters_by_party = HashMap::new();
     filters_by_party.insert(
         party_id.to_string(),
@@ -3849,27 +3427,18 @@ async fn fetch_holding_views(
         },
     );
 
-    let acs_request = GetActiveContractsRequest {
-        active_at_offset: ledger_end,
-        event_format: Some(EventFormat {
-            filters_by_party,
-            filters_for_any_party: None,
-            verbose: true,
-        }),
-        stream_continuation_token: None,
+    let event_format = EventFormat {
+        filters_by_party,
+        filters_for_any_party: None,
+        verbose: true,
     };
 
-    let mut stream = state_client
-        .get_active_contracts(tonic::Request::new(acs_request))
-        .await?
-        .into_inner();
+    let active_contracts = fetch_active_contracts(config, token, event_format).await?;
 
     let owner_str = party_id.to_string();
     let mut holdings = Vec::new();
-    while let Some(response) = stream.message().await? {
-        if let Some(ContractEntry::ActiveContract(active)) = response.contract_entry
-            && let Some(created) = active.created_event
-            && let Some(view) = extract_holding_view(&created)
+    for created in active_contracts {
+        if let Some(view) = extract_holding_view(&created)
             && view.owner == owner_str
         {
             holdings.push(view);
@@ -4039,13 +3608,6 @@ async fn fetch_utility_preapproval_instruments(
     party_id: &CantonId,
     token: Option<String>,
 ) -> Result<std::collections::HashSet<(String, String)>> {
-    let mut state_client = utils::create_state_client(config, token).await?;
-    let ledger_end = state_client
-        .get_ledger_end(tonic::Request::new(GetLedgerEndRequest {}))
-        .await?
-        .into_inner()
-        .offset;
-
     let mut filters_by_party = HashMap::new();
     filters_by_party.insert(
         party_id.to_string(),
@@ -4066,27 +3628,17 @@ async fn fetch_utility_preapproval_instruments(
         },
     );
 
-    let acs_request = GetActiveContractsRequest {
-        active_at_offset: ledger_end,
-        event_format: Some(EventFormat {
-            filters_by_party,
-            filters_for_any_party: None,
-            verbose: true,
-        }),
-        stream_continuation_token: None,
+    let event_format = EventFormat {
+        filters_by_party,
+        filters_for_any_party: None,
+        verbose: true,
     };
 
-    let mut stream = state_client
-        .get_active_contracts(tonic::Request::new(acs_request))
-        .await?
-        .into_inner();
+    let active_contracts = fetch_active_contracts(config, token, event_format).await?;
 
     let mut set = std::collections::HashSet::new();
-    while let Some(response) = stream.message().await? {
-        if let Some(ContractEntry::ActiveContract(active)) = response.contract_entry
-            && let Some(created) = active.created_event
-            && let Some(args) = created.create_arguments
-        {
+    for created in active_contracts {
+        if let Some(args) = created.create_arguments {
             for entry in extract_preapproval_entries(&args) {
                 set.insert(entry);
             }

--- a/crates/decman/src/server/queries.rs
+++ b/crates/decman/src/server/queries.rs
@@ -32,7 +32,7 @@ use crate::{
 
 use super::{
     action_serializer,
-    ledger_paging::fetch_active_contracts,
+    ledger_paging::{fetch_active_contracts, fetch_first_active_contract},
     package_inventory::{
         fetch_package_id_to_name, fetch_package_names, newest_matching_names, package_name_prefix,
     },
@@ -1566,9 +1566,9 @@ async fn fetch_governance_state_for_template(
         verbose: true,
     };
 
-    Ok(fetch_active_contracts(config, token, event_format)
+    Ok(fetch_first_active_contract(config, token, event_format)
         .await?
-        .first()
+        .as_ref()
         .and_then(extract_governance_state))
 }
 

--- a/crates/decman/src/server/reward_automation.rs
+++ b/crates/decman/src/server/reward_automation.rs
@@ -31,15 +31,11 @@
 //! [`chunk_size`]) are unit-tested here; the gRPC reads and command submission
 //! are exercised by the localnet and devnet integration tests.
 
-use std::collections::HashMap;
-
 use anyhow::{Context, anyhow};
 use canton_common::decimal::DamlDecimal;
 use canton_proto_rs::com::daml::ledger::api::v2::{
-    Command, Commands, CumulativeFilter, EventFormat, ExerciseCommand, Filters,
-    GetActiveContractsRequest, GetLedgerEndRequest, Identifier, InterfaceFilter, Record,
-    SubmitAndWaitRequest, TemplateFilter, Value, WildcardFilter, command,
-    command_service_client::CommandServiceClient, cumulative_filter,
+    Command, Commands, ExerciseCommand, GetActiveContractsRequest, GetLedgerEndRequest, Identifier,
+    Record, SubmitAndWaitRequest, Value, command, command_service_client::CommandServiceClient,
     get_active_contracts_response::ContractEntry, value,
 };
 use chrono::{DateTime, Utc};
@@ -55,6 +51,9 @@ use std::time::Duration;
 use super::AppState;
 use super::action_serializer::{
     field, make_contract_id, make_extra_args, make_list, make_party, make_text_map,
+};
+use super::event_filters::{
+    interface_filter, party_event_format, template_filter, wildcard_filter,
 };
 use super::handlers::{get_party_credentials, packages};
 use super::queries::resolve_contract_package_ref;
@@ -160,48 +159,22 @@ pub(crate) async fn active_created_records(
         .into_inner()
         .offset;
 
-    let identifier_filter = if interface_view {
-        cumulative_filter::IdentifierFilter::InterfaceFilter(InterfaceFilter {
-            interface_id: Some(Identifier {
-                package_id: package_id.to_string(),
-                module_name: module.to_string(),
-                entity_name: entity.to_string(),
-            }),
-            include_interface_view: true,
-            include_created_event_blob: false,
-        })
-    } else if test_mode {
-        cumulative_filter::IdentifierFilter::WildcardFilter(WildcardFilter {
-            include_created_event_blob: false,
-        })
-    } else {
-        cumulative_filter::IdentifierFilter::TemplateFilter(TemplateFilter {
-            template_id: Some(Identifier {
-                package_id: package_id.to_string(),
-                module_name: module.to_string(),
-                entity_name: entity.to_string(),
-            }),
-            include_created_event_blob: false,
-        })
+    let identifier = || Identifier {
+        package_id: package_id.to_string(),
+        module_name: module.to_string(),
+        entity_name: entity.to_string(),
     };
-
-    let mut filters_by_party = HashMap::new();
-    filters_by_party.insert(
-        party_id.to_string(),
-        Filters {
-            cumulative: vec![CumulativeFilter {
-                identifier_filter: Some(identifier_filter),
-            }],
-        },
-    );
+    let filter = if interface_view {
+        interface_filter(identifier(), false)
+    } else if test_mode {
+        wildcard_filter(false)
+    } else {
+        template_filter(identifier(), false)
+    };
 
     let acs_request = GetActiveContractsRequest {
         active_at_offset: ledger_end,
-        event_format: Some(EventFormat {
-            filters_by_party,
-            filters_for_any_party: None,
-            verbose: true,
-        }),
+        event_format: Some(party_event_format(party_id, vec![filter], true)),
         stream_continuation_token: None,
     };
 

--- a/crates/decman/src/server/transfer_context.rs
+++ b/crates/decman/src/server/transfer_context.rs
@@ -23,8 +23,7 @@ use canton_common::{
     },
 };
 use canton_proto_rs::com::daml::ledger::api::v2::{
-    CumulativeFilter, DisclosedContract, EventFormat, Filters, GetEventsByContractIdRequest,
-    Identifier, InterfaceFilter, Record, WildcardFilter, cumulative_filter, value,
+    DisclosedContract, GetEventsByContractIdRequest, Identifier, Record, value,
 };
 use chrono::DateTime;
 
@@ -32,6 +31,7 @@ use crate::{
     canton_id::CantonId,
     config::{Network, NodeConfig},
     error::Result,
+    server::event_filters::{interface_filter, party_event_format, wildcard_filter},
     utils,
 };
 
@@ -228,33 +228,20 @@ async fn fetch_instruction_registrar(
 ) -> Result<CantonId> {
     let mut client = utils::create_event_query_client(config, token).await?;
 
-    let mut filters_by_party = HashMap::new();
-    filters_by_party.insert(
-        party_id.to_string(),
-        Filters {
-            cumulative: vec![CumulativeFilter {
-                identifier_filter: Some(cumulative_filter::IdentifierFilter::InterfaceFilter(
-                    InterfaceFilter {
-                        interface_id: Some(Identifier {
-                            package_id: "#splice-api-token-transfer-instruction-v1".to_string(),
-                            module_name: "Splice.Api.Token.TransferInstructionV1".to_string(),
-                            entity_name: "TransferInstruction".to_string(),
-                        }),
-                        include_interface_view: true,
-                        include_created_event_blob: false,
-                    },
-                )),
-            }],
-        },
-    );
-
     let request = GetEventsByContractIdRequest {
         contract_id: transfer_instruction_cid.to_string(),
-        event_format: Some(EventFormat {
-            filters_by_party,
-            filters_for_any_party: None,
-            verbose: true,
-        }),
+        event_format: Some(party_event_format(
+            party_id,
+            vec![interface_filter(
+                Identifier {
+                    package_id: "#splice-api-token-transfer-instruction-v1".to_string(),
+                    module_name: "Splice.Api.Token.TransferInstructionV1".to_string(),
+                    entity_name: "TransferInstruction".to_string(),
+                },
+                false,
+            )],
+            true,
+        )),
     };
 
     let created_event = client
@@ -335,27 +322,14 @@ pub async fn maybe_fetch_for_proposal(
     // `GetEventsByContractId` filters by party-visibility so the requester
     // must be authorized to read the proposal. Use the party that's executing
     // the action — they're a stakeholder on the governance proposal.
-    let mut filters_by_party = HashMap::new();
-    filters_by_party.insert(
-        party_id.to_string(),
-        Filters {
-            cumulative: vec![CumulativeFilter {
-                identifier_filter: Some(cumulative_filter::IdentifierFilter::WildcardFilter(
-                    WildcardFilter {
-                        include_created_event_blob: false,
-                    },
-                )),
-            }],
-        },
-    );
 
     let request = GetEventsByContractIdRequest {
         contract_id: proposal_cid.to_string(),
-        event_format: Some(EventFormat {
-            filters_by_party,
-            filters_for_any_party: None,
-            verbose: true,
-        }),
+        event_format: Some(party_event_format(
+            party_id,
+            vec![wildcard_filter(false)],
+            true,
+        )),
     };
 
     let response = client

--- a/crates/decman/src/server/types.rs
+++ b/crates/decman/src/server/types.rs
@@ -1248,7 +1248,8 @@ fn default_audit_limit() -> i64 {
 pub struct ChainAuditQuery {
     /// Decentralized party ID to query chain events for
     pub party_id: CantonId,
-    /// Maximum number of entries to return (default [`PAGE_SIZE`])
+    /// Maximum number of entries to return (default [`PAGE_SIZE`], capped at
+    /// [`MAX_CHAIN_AUDIT_LIMIT`])
     #[serde(default = "default_chain_audit_limit")]
     pub limit: usize,
     /// Cursor: return only entries strictly older than this ledger offset.
@@ -1262,6 +1263,21 @@ pub struct ChainAuditQuery {
 
 fn default_chain_audit_limit() -> usize {
     PAGE_SIZE as usize
+}
+
+/// Ceiling on a chain-audit page size.
+///
+/// `limit` arrives on the query string, so it is untrusted: left unbounded it
+/// would drain the whole retained ledger into one response, and a value above
+/// `i64::MAX` wraps negative when cast for SQLite — which reads a negative
+/// `LIMIT` as no limit at all.
+pub const MAX_CHAIN_AUDIT_LIMIT: usize = 1_000;
+
+impl ChainAuditQuery {
+    /// The requested page size, bounded by [`MAX_CHAIN_AUDIT_LIMIT`].
+    pub fn clamped_limit(&self) -> usize {
+        self.limit.min(MAX_CHAIN_AUDIT_LIMIT)
+    }
 }
 
 /// Build a [`ChainAuditEntry`] wire DTO from a cached DB row.

--- a/crates/decman/src/server/types.rs
+++ b/crates/decman/src/server/types.rs
@@ -13,6 +13,7 @@ use tokio::sync::RwLock;
 // `crate::server::types::X` (and the glob `pub use types::*` in `server/mod.rs`)
 // keep resolving unchanged. `common::api` holds the HTTP request/response DTOs
 // the frontend's TypeScript is generated from (see `decman/build.rs`).
+pub use common::api::PAGE_SIZE;
 pub use common::api::{
     ActiveCouponReassignmentDelegation, AddPartyInvitePayload, AddPartyRequest, AuditLogResponse,
     AuthStatus, AuthStatusResponse, AuthTestResponse, AuthTestResult, CancelConfirmationRequest,
@@ -1247,16 +1248,20 @@ fn default_audit_limit() -> i64 {
 pub struct ChainAuditQuery {
     /// Decentralized party ID to query chain events for
     pub party_id: CantonId,
-    /// Maximum number of entries to return (default 100)
+    /// Maximum number of entries to return (default [`PAGE_SIZE`])
     #[serde(default = "default_chain_audit_limit")]
     pub limit: usize,
+    /// Cursor: return only entries strictly older than this ledger offset.
+    /// Pass the previous response's `next_before_offset` to get the next page.
+    #[serde(default)]
+    pub before_offset: Option<i64>,
     /// When true, fetches fresh data from Canton and updates cache
     #[serde(default)]
     pub refresh: bool,
 }
 
 fn default_chain_audit_limit() -> usize {
-    100
+    PAGE_SIZE as usize
 }
 
 /// Build a [`ChainAuditEntry`] wire DTO from a cached DB row.

--- a/crates/decman/src/utils.rs
+++ b/crates/decman/src/utils.rs
@@ -13,7 +13,6 @@ use canton_proto_rs::com::{
         },
         event_query_service_client::EventQueryServiceClient,
         interactive::interactive_submission_service_client::InteractiveSubmissionServiceClient,
-        package_service_client::PackageServiceClient,
         state_service_client::StateServiceClient,
         update_service_client::UpdateServiceClient,
     },
@@ -486,7 +485,6 @@ define_client_creator!(create_submission_client, InteractiveSubmissionServiceCli
 define_client_creator!(create_state_client, StateServiceClient);
 define_client_creator!(create_update_client, UpdateServiceClient);
 define_client_creator!(create_event_query_client, EventQueryServiceClient);
-define_client_creator!(create_package_client, PackageServiceClient);
 
 /// Create a directory with context for error messages
 pub async fn create_directory(path: &Path) -> Result {

--- a/crates/decman/src/utils.rs
+++ b/crates/decman/src/utils.rs
@@ -13,6 +13,7 @@ use canton_proto_rs::com::{
         },
         event_query_service_client::EventQueryServiceClient,
         interactive::interactive_submission_service_client::InteractiveSubmissionServiceClient,
+        package_service_client::PackageServiceClient,
         state_service_client::StateServiceClient,
         update_service_client::UpdateServiceClient,
     },
@@ -485,6 +486,7 @@ define_client_creator!(create_submission_client, InteractiveSubmissionServiceCli
 define_client_creator!(create_state_client, StateServiceClient);
 define_client_creator!(create_update_client, UpdateServiceClient);
 define_client_creator!(create_event_query_client, EventQueryServiceClient);
+define_client_creator!(create_package_client, PackageServiceClient);
 
 /// Create a directory with context for error messages
 pub async fn create_directory(path: &Path) -> Result {


### PR DESCRIPTION
Canton added pagination to the bulk read endpoints in 3.5.1 (`GetActiveContractsPage`, `GetUpdatesPage`) and 3.4.10 (`ListVettedPackages`). We're on 3.5.11 protos and were using none of it.

## What changed

**`server/ledger_paging.rs`** — one place that speaks the paged protocol, with a fallback to the old streaming calls when the participant returns `UNIMPLEMENTED` (below 3.5.1). Three helpers: `fetch_active_contracts`, `fetch_transactions_page`, `fetch_vetted_packages`.

**All 25 ACS reads in `queries.rs`** now go through it. The helper absorbs the client setup, `GetLedgerEnd`, request construction and the stream loop, so `queries.rs` drops ~590 net lines.

**Chain audit** was streaming the whole retained ledger from the pruned offset, materialising every match, sorting, then truncating to `limit` — O(entire ledger) to return 25 rows, growing without bound as the ledger ages. It now pages newest-first (`descending_order`) and stops as soon as it has enough. `before_offset` / `next_before_offset` carry a cursor through the endpoint into the UI.

**`get_party_metadata` bug** — `page_size` was hardcoded to 1000 and `next_page_token` was never read, so on a participant hosting more than 1000 parties the lookup fell off page 1, `find()` returned `None`, and the caller got `Ok(None)`: indistinguishable from "this party has no annotations". Now filters server-side via `filter_party` (a prefix match, so a full id narrows to one row) and walks pages as a backstop.

**Frontend** — `usePagination` hook + `PaginationControls` / `CursorPagination`. Applied to the audit trail (server cursor), party list, external parties, holdings, party-detail contracts, both packages tables, and the notifications feed.

**`PAGE_SIZE = 25`** lives in `common::api` and is emitted into `types.generated.ts` by `gen-types`, so the wire page size and the UI page size are the same number and can't drift.

## Behaviour change to be aware of

`/packages/vetted` was calling the admin `ListPackages`, which lists every *uploaded* DAR — a strictly larger set than the vetted ones. It now reads real topology vetting state via `ListVettedPackages`. Packages that are uploaded but not vetted will disappear from that panel. That's the endpoint finally doing what its name says, but it is user-visible.

## Limits

- **Multi-template endpoints page internally, not end-to-end.** The `_for_template` fan-out concatenates N template queries into one list and a single Canton page token can't address that. They read Canton a page at a time (bounded memory per round trip) but still return the full list, and the UI pages it at 25. True server-side paging there needs a composite cursor — not attempted here.
- **`FETCH_CHUNK` is 1000, not 25.** `PAGE_SIZE` is the wire/UI page size; using 25 as the Canton chunk when collecting a full result set would turn one stream into hundreds of round trips.
- `tenant.rs` (`/v0/tenant/*/acs`) is deliberately untouched — changing that response shape is a separate call.
- `ContractsDialog` is not paginated: it's an index-keyed editable form, not a data list.

## Compatibility

Paginated RPCs need Canton >= 3.5.1 on the participant. Devnet localnet is 3.5.8 and testnet is PV35; mainnet's version I could not verify from the repo, which is why the fallback exists rather than a hard switch.

## Two edge cases worth a look in review

- A transaction can emit several audit entries sharing one offset, and the cursor is an offset — so a page cut mid-offset would make the next page (`offset < cursor`) skip the remainder. Both the live path and the cache SQL now return whole offset groups, overshooting `limit` by at most one transaction's tail.
- The chain-audit cache only holds pages fetched so far, so an empty cache result is treated as a miss and falls through to Canton rather than reporting the trail as exhausted.

## Verification

`cargo clippy --all-targets --workspace` clean, `cargo fmt --check` clean, `tsc --noEmit` clean, `vite build` succeeds. ESLint adds no new errors (the repo has 63 pre-existing; the two in files I touched are identical on `main`).

No tests were run. The chain-audit cursor edge cases above are reasoned about and verified by inspection only.
