### PR TITLE
Log JSON so SigNoz can index the fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6109,6 +6109,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6118,12 +6128,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ tonic = { version = "0.14.2", features = [
 ] }
 tonic-prost = { version = "0.14.2" }
 tracing = { version = "0.1" }
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 ts-rs = { version = "12", features = ["no-serde-warnings"] }
 utoipa = { version = "5" }
 utoipa-actix-web = { version = "0.1" }

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ The database file path can be overridden with the `--db` CLI flag.
 | `DECPM_DB_ENCRYPTION_KEY` | Encryption key for secrets stored in the database | _(none)_ |
 | `DECPM_ADMIN_ROLE` | Role name that gates sensitive endpoints (unset skips the role check) | _(none)_ |
 | `DECPM_ALLOWED_ORIGIN` | Origin permitted by CORS (e.g. `https://decman.example.com`) | _(none, same-origin only)_ |
+| `DECPM_LOG_FORMAT` | Log format. `text` gives the readable console format for local work; any other value gives one JSON object per line | `json` |
 | `DECPM_LISTEN_ADDRESS` | Address to listen on for Noise protocol connections | `0.0.0.0` |
 | `DECPM_NOISE_PORT` | Port for Noise protocol connections | `9000` |
 | `DECPM_PUBLIC_ADDRESS` | Public address that peers use to connect to this node | _(falls back to listen address)_ |

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -45,6 +45,7 @@ All configuration is supplied via `DECPM_*` environment variables. The key ones:
 |----------|-------------|---------|
 | `DECPM_PORT` | Port for the HTTP / web UI server | `8080` |
 | `DECPM_NOISE_PORT` | Port for the Noise P2P transport | `9000` |
+| `DECPM_LOG_FORMAT` | Log format. Set `text` for the readable console format while working locally | `json` |
 | `DECPM_CANTON_ADMIN_HOST` | Canton Admin API host | `127.0.0.1` |
 | `DECPM_CANTON_ADMIN_PORT` | Canton Admin API port | `5002` |
 | `DECPM_CANTON_LEDGER_HOST` | Canton Ledger API host | `127.0.0.1` |

--- a/crates/decman/src/main.rs
+++ b/crates/decman/src/main.rs
@@ -1,6 +1,6 @@
 mod cli;
 
-use std::path::PathBuf;
+use std::{path::PathBuf, process::ExitCode};
 
 use dec_party_manager::{
     config::{Auth0Config, CantonTlsConfig, KeycloakConfig, NodeConfig},
@@ -70,7 +70,21 @@ fn json_logs_enabled(format: Option<&str>) -> bool {
 }
 
 #[tokio::main]
-async fn main() -> Result {
+async fn main() -> ExitCode {
+    match run().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            // Returning the error from `main` prints it through `Termination`,
+            // as plain text no pipeline parses. The error-rate alert counts
+            // parsed `level` values, so the fatal has to leave through
+            // `tracing` to be counted at all.
+            tracing::error!(%error, "dec-party-manager exited with an error");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn run() -> Result {
     // Load .env from the root directory before clap parses,
     // so DECPM_* env vars are available for clap's env feature
     let dir = find_dir_arg();
@@ -97,6 +111,14 @@ async fn main() -> Result {
             .with(tracing_subscriber::fmt::layer().with_filter(filter))
             .init();
     }
+
+    // A panic prints to stderr as plain text, which the pipeline leaves
+    // unparsed, so log it before the default hook prints the backtrace.
+    let default_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        tracing::error!(panic = %info, "dec-party-manager panicked");
+        default_hook(info);
+    }));
 
     let args = Cli::parse();
 

--- a/crates/decman/src/main.rs
+++ b/crates/decman/src/main.rs
@@ -69,6 +69,21 @@ fn json_logs_enabled(format: Option<&str>) -> bool {
     !format.is_some_and(|f| f.trim().eq_ignore_ascii_case("text"))
 }
 
+/// The layer whose output the SigNoz log pipeline parses. `severity_parser`
+/// reads `level` and `timestamp`, so both stay at the top level, and the event's
+/// own fields nest under `fields`. `with_ansi(false)` drops the colouring, which
+/// the layer applies even when stdout is not a terminal.
+fn json_layer<S, W>(writer: W) -> impl tracing_subscriber::Layer<S>
+where
+    S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+    W: for<'a> tracing_subscriber::fmt::MakeWriter<'a> + 'static,
+{
+    tracing_subscriber::fmt::layer()
+        .json()
+        .with_ansi(false)
+        .with_writer(writer)
+}
+
 #[tokio::main]
 async fn main() -> ExitCode {
     match run().await {
@@ -99,12 +114,7 @@ async fn run() -> Result {
 
     if json_logs_enabled(std::env::var("DECPM_LOG_FORMAT").ok().as_deref()) {
         tracing_subscriber::registry()
-            .with(
-                tracing_subscriber::fmt::layer()
-                    .json()
-                    .with_ansi(false)
-                    .with_filter(filter),
-            )
+            .with(json_layer(std::io::stdout).with_filter(filter))
             .init();
     } else {
         tracing_subscriber::registry()
@@ -363,7 +373,85 @@ async fn run() -> Result {
 
 #[cfg(test)]
 mod tests {
-    use super::json_logs_enabled;
+    use std::sync::{Arc, Mutex};
+
+    use anyhow::anyhow;
+    use tracing_subscriber::{fmt::MakeWriter, prelude::*};
+
+    use super::{json_layer, json_logs_enabled};
+
+    /// A writer the test reads back once the layer has written to it.
+    #[derive(Clone, Default)]
+    struct SharedBuffer(Arc<Mutex<Vec<u8>>>);
+
+    impl std::io::Write for SharedBuffer {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            let mut written = self
+                .0
+                .lock()
+                .map_err(|_| std::io::Error::other("the buffer lock is poisoned"))?;
+            written.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> MakeWriter<'a> for SharedBuffer {
+        type Writer = Self;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    /// The dlc-infra log pipeline reads this exact shape. `severity_parser`
+    /// takes `level` and `timestamp` from the top level, and `json_parser`
+    /// flattens `fields` to the leaf key, so `count` arrives as a numeric
+    /// attribute. Adding `.flatten_event(true)` breaks both, and the string
+    /// tests below would still pass.
+    #[test]
+    fn the_json_line_carries_the_shape_the_pipeline_parses() -> anyhow::Result<()> {
+        let buffer = SharedBuffer::default();
+        let subscriber = tracing_subscriber::registry().with(json_layer(buffer.clone()));
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::info!(
+                count = 7,
+                decparty = "cbtc-network::1220",
+                "reassigned coupon batch"
+            );
+        });
+
+        let written = buffer
+            .0
+            .lock()
+            .map_err(|_| anyhow!("the buffer lock is poisoned"))?
+            .clone();
+        let line = String::from_utf8(written)?;
+        assert!(
+            !line.contains('\u{1b}'),
+            "an ANSI escape survived into the line: {line}"
+        );
+
+        let event: serde_json::Value = serde_json::from_str(line.trim())?;
+        assert_eq!(event["level"], "INFO");
+        assert!(
+            event["timestamp"].is_string(),
+            "the severity parser needs a top-level timestamp: {event}"
+        );
+        assert_eq!(event["fields"]["message"], "reassigned coupon batch");
+        assert_eq!(event["fields"]["decparty"], "cbtc-network::1220");
+        assert_eq!(event["fields"]["count"], 7);
+        assert!(
+            event["fields"]["count"].is_number(),
+            "count must stay numeric so an alert can compare it: {event}"
+        );
+
+        Ok(())
+    }
 
     #[test]
     fn json_is_the_default_when_the_variable_is_unset() {

--- a/crates/decman/src/main.rs
+++ b/crates/decman/src/main.rs
@@ -88,7 +88,6 @@ async fn main() -> Result {
             .with(
                 tracing_subscriber::fmt::layer()
                     .json()
-                    .flatten_event(true)
                     .with_ansi(false)
                     .with_filter(filter),
             )

--- a/crates/decman/src/main.rs
+++ b/crates/decman/src/main.rs
@@ -62,6 +62,13 @@ fn find_dir_arg() -> PathBuf {
     PathBuf::from(".")
 }
 
+/// JSON is the default so each `tracing` field becomes a queryable attribute in
+/// SigNoz. The console format stays available for a developer running the binary
+/// by hand: set `DECPM_LOG_FORMAT=text`.
+fn json_logs_enabled(format: Option<&str>) -> bool {
+    !format.is_some_and(|f| f.trim().eq_ignore_ascii_case("text"))
+}
+
 #[tokio::main]
 async fn main() -> Result {
     // Load .env from the root directory before clap parses,
@@ -76,9 +83,21 @@ async fn main() -> Result {
         EnvFilter::new("dec_party_manager=info,tokio_noise=error,hyper_noise=error")
     });
 
-    tracing_subscriber::registry()
-        .with(tracing_subscriber::fmt::layer().with_filter(filter))
-        .init();
+    if json_logs_enabled(std::env::var("DECPM_LOG_FORMAT").ok().as_deref()) {
+        tracing_subscriber::registry()
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .json()
+                    .flatten_event(true)
+                    .with_ansi(false)
+                    .with_filter(filter),
+            )
+            .init();
+    } else {
+        tracing_subscriber::registry()
+            .with(tracing_subscriber::fmt::layer().with_filter(filter))
+            .init();
+    }
 
     let args = Cli::parse();
 
@@ -319,4 +338,31 @@ async fn main() -> Result {
 
     tracing::info!("Command completed successfully");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::json_logs_enabled;
+
+    #[test]
+    fn json_is_the_default_when_the_variable_is_unset() {
+        assert!(json_logs_enabled(None));
+    }
+
+    #[test]
+    fn text_selects_the_console_format() {
+        assert!(!json_logs_enabled(Some("text")));
+    }
+
+    #[test]
+    fn the_text_value_tolerates_case_and_padding() {
+        assert!(!json_logs_enabled(Some(" TEXT ")));
+    }
+
+    #[test]
+    fn any_other_value_stays_on_json() {
+        assert!(json_logs_enabled(Some("json")));
+        assert!(json_logs_enabled(Some("")));
+        assert!(json_logs_enabled(Some("pretty")));
+    }
 }

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -105,9 +105,9 @@ Key conventions:
   including in tests; return `Result` and use `?`.
 - **Logging:** use `tracing` (`info!`/`warn!`/`error!`), never `println!`/`eprintln!`.
   Record each value as a field — `info!(count, "assigned")`, not `info!("assigned {count}")`.
-  The binary writes one JSON object per line, so a field becomes a queryable attribute in
-  SigNoz while text inside the message does not. Set `DECPM_LOG_FORMAT=text` for the readable
-  console format while you work.
+  The binary writes one JSON object per line, and a SigNoz log pipeline parses that line.
+  A field then becomes a queryable attribute. Text inside the message never does.
+  Set `DECPM_LOG_FORMAT=text` for the readable console format while you work.
 - **Cargo.toml:** dependencies and their features are kept in strict
   alphabetical order.
 - **Comments:** only where the logic isn't self-evident; remove dead code rather

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -104,6 +104,10 @@ Key conventions:
   `thiserror` for custom error types. **Avoid `unwrap()` / `expect()`** —
   including in tests; return `Result` and use `?`.
 - **Logging:** use `tracing` (`info!`/`warn!`/`error!`), never `println!`/`eprintln!`.
+  Record each value as a field — `info!(count, "assigned")`, not `info!("assigned {count}")`.
+  The binary writes one JSON object per line, so a field becomes a queryable attribute in
+  SigNoz while text inside the message does not. Set `DECPM_LOG_FORMAT=text` for the readable
+  console format while you work.
 - **Cargo.toml:** dependencies and their features are kept in strict
   alphabetical order.
 - **Comments:** only where the logic isn't self-evident; remove dead code rather

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -257,9 +257,10 @@ spec:
           env:
             - name: RUST_LOG
               value: dec_party_manager=info,tokio_noise=error,hyper_noise=error
-            # Logs are JSON on stdout by default, which is what a log collector
-            # indexes as attributes. Set DECPM_LOG_FORMAT=text for the console
-            # format instead.
+            # Logs are JSON on stdout by default. The collector indexes the
+            # fields as attributes only where a log pipeline parses the line,
+            # so this environment needs its own decman pipeline in dlc-infra.
+            # Set DECPM_LOG_FORMAT=text for the console format instead.
           envFrom:
             - secretRef:
                 name: dec-party-manager-secrets

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -257,6 +257,9 @@ spec:
           env:
             - name: RUST_LOG
               value: dec_party_manager=info,tokio_noise=error,hyper_noise=error
+            # Logs are JSON on stdout by default, which is what a log collector
+            # indexes as attributes. Set DECPM_LOG_FORMAT=text for the console
+            # format instead.
           envFrom:
             - secretRef:
                 name: dec-party-manager-secrets

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -403,6 +403,7 @@ Most variables have a default that's only useful for local development (loopback
 | `DECPM_TIMEOUT_MESSAGE` | `120` | optional | Noise message timeout (seconds) |
 | `DECPM_TIMEOUT_RETRY_ATTEMPTS` | `3` | optional | Connection retry attempts |
 | `DECPM_TIMEOUT_RETRY_DELAY` | `5` | optional | Connection retry delay (seconds) |
+| `DECPM_LOG_FORMAT` | `json` | optional | Leave it unset in a cluster, because the log pipeline parses JSON only. `text` gives the console format for local work |
 
 ¹ Required only for the chosen provider. Set the `DECPM_KEYCLOAK_*` trio **or** the `DECPM_AUTH0_*` trio, not both.
 


### PR DESCRIPTION
## What this PR does

**Old behavior**

decman wrote its logs in the `tracing` console format, the one meant for a terminal. Each line
arrived in SigNoz as a single opaque string, wrapped in ANSI colour escapes such as `[2m` and
`[32m`. SigNoz reported an empty `severity_text` on every one of them, so it did not know which
lines were errors. Fields recorded on an event, such as the reward automation's coupon count,
sat inside the message text rather than beside it.

Two consequences followed. No decman deployment could use the standard error-rate alert,
`count(log.level = "error") >= 1`. And no value in a log line could carry a threshold, because
every value was prose.

**New behavior**

The binary writes one flat JSON object per line, and the escapes are gone. A log pipeline can
now parse it, which is what turns each field into a queryable attribute and sets the severity
from the `level` key.

This PR is one half. SigNoz parses nothing by itself: a service's JSON body stays one opaque
string until a pipeline with a `json_parser` matches it. The decman pipeline is now live on
devnet and committed in dlc-infra as `5f422d8`, alongside the existing `participant` and
`validator-app` ones.

Measured on devnet after both halves landed, on the `reassigned coupon batch` line of
2026-08-11 15:05:02Z:

- `severity_text` is `INFO`, and `ERROR` on the error lines. It was empty on every decman line
  before.
- `decparty`, `assigner`, `message`, `level`, `target` and `timestamp` are string attributes.
- `count` is a **numeric** attribute.

Before:

```
^[[2m2026-08-11T13:52:49.334424Z^[[0m ^[[32m INFO^[[0m ^[[2m…reward_automation^[[0m: reassigned coupon batch ^[[3mdecparty^[[0m=cbtc-network::12202a83… ^[[3mcount^[[0m=7
```

After:

```json
{"timestamp":"2026-08-11T13:52:49.562661Z","level":"INFO","fields":{"message":"reassigned coupon batch","decparty":"cbtc-network::12202a83…","assigner":"bitsafe-validator-1::12202fdc…","count":7},"target":"dec_party_manager::server::reward_automation"}
```

**The change that enables it**

- The `fmt` layer becomes `.json().with_ansi(false)`.
- The event's fields nest under a `fields` object. That is deliberate, and it costs nothing:
  the pipeline's `json_parser` flattens with the leaf key, so the attribute is `count`, not
  `fields.count`. Lifting the fields in the formatter instead would let a field name collide
  with a generated key — an event carrying `level` emits `"level"` twice in one object, and
  parsers disagree on which value wins.
- `severity_parser` still works, because `level` and `timestamp` stay outside `fields`.
- `with_ansi(false)` removes the colouring. The layer colours by default and never checks
  whether stdout is a terminal, which is why container logs carried the escapes.
- JSON is the default, so no deployment needs a new environment variable.
  `DECPM_LOG_FORMAT=text` restores the console format for local work.
- `tracing-subscriber` gains the `json` feature, without which `.json()` does not compile.
- `main` logs the fatal error through `tracing` before it exits, and returns `ExitCode`.
  Returning the error instead printed it through `Termination`, as plain text no pipeline
  parses. A panic hook does the same for a panic, then calls the default hook so the backtrace
  still prints. Without these two, a node that dies on startup trips no alert.

**Caveats**

- This rewrites every decman log line, not just one subsystem's. Anyone reading
  `kubectl logs` sees JSON from now on, and pipes it through `jq` to read it comfortably.
- Nothing changes in SigNoz until a decman log pipeline exists for that environment. Devnet has
  one. Testnet and mainnet need theirs **after** their decman runs this build, or the parser
  meets console text. The pipelines push is a full replace, so decman's file always goes up
  alongside the existing two.
- The change makes fields searchable. It does not make the reward automation observable on its
  own. A tick that finds nothing assignable still logs nothing at all, so a stall stays
  invisible until the metrics land: [#278](https://github.com/DLC-link/decentralization-manager/issues/278).
- The six reward alerts in the design do **not** depend on this PR. They read metrics. What this
  unblocks is the general error-rate alert, `count(log.level = "error") >= 1`, which needs the
  severity that only a parsed `level` provides. The alert now counts a fatal exit and a panic
  too, which the first version of this PR left unparsed.
- That alert still cannot go to devnet yet. Every pod logs 14 Keycloak auth errors at startup,
  which this PR makes the alert count. The errors predate this PR, and
  [#319](https://github.com/DLC-link/decentralization-manager/issues/319) tracks them.

## Details

**What changed**

- `crates/decman/src/main.rs` — `json_logs_enabled` decides the format from
  `DECPM_LOG_FORMAT`, and `run` branches on it. The variable is read directly rather than
  through `NodeConfig`, because the subscriber initializes before `Cli::parse()`. `json_layer`
  builds the JSON layer, so the shape test drives the same code the binary does. `main` wraps
  `run` and logs the fatal error, and a panic hook logs a panic.
- `Cargo.toml` — the `json` feature on `tracing-subscriber`, in alphabetical order per
  `docs/CONTRIBUTING.md`.
- `Cargo.lock` — `tracing-serde`, `serde` and `serde_json`, pulled in by that feature.
- `docs/CONTRIBUTING.md` — record a value as a field, not as interpolated text, and how to get
  readable logs while working.
- `docs/DEPLOYMENT_GUIDE.md` — a note beside `RUST_LOG` in the manifest example.
- `docs/DEPLOYMENT_GUIDE.md`, `README.md`, `USER_GUIDE.md` — a `DECPM_LOG_FORMAT` row in each
  variable table, because an operator looks the variable up there.

**Verification**

- `cargo clippy -p decman --all-targets -- -D warnings` — clean, on every commit.
- `cargo test -p decman` — 340 lib tests, 5 binary tests, 44 integration tests, 2 ignored,
  0 failures.
- Four binary tests cover the format decision: JSON when the variable is unset, the console
  format on `text`, tolerance of ` TEXT ` for case and padding, and JSON for any other value.
- The fifth asserts the shape the pipeline parses: `level`, a top-level `timestamp`, the fields
  under `fields`, `count` numeric, and no ANSI escape. It reads back a real line from the layer
  the binary uses. I confirmed it is not vacuous: it fails on `.flatten_event(true)`, which is
  the change that would otherwise break the parser with CI green.
- Ran the real binary. Its first line is JSON, quoted under **New behavior** above. It then
  exited 1 because no Canton listens on the local admin port, which is expected outside a
  cluster. That fatal now leaves as `"level":"ERROR"` on stdout, and stderr stays empty.
- Ran it again with a temporary `panic!`. stdout carried
  `{"level":"ERROR","fields":{"message":"dec-party-manager panicked","panic":"panicked at …"}}`,
  and stderr kept the backtrace note. Then I reverted the panic.
- Checked that nothing consumes decman's log text: the only match for `reassigned coupon batch`
  in the repo is the `info!` call itself. No test, script, or justfile recipe greps the output.
- Established what makes attributes appear on devnet SigNoz, by checking two services against
  the live pipeline list. `participant` logs JSON and has `level`, `message`, `logger_name` and
  `trace-id` as attributes, because the committed "Participant formatter" pipeline parses it.
  `k8s-infra-otel-deployment` also logs JSON, has no pipeline, and carries only
  `log.file.path`, `log.iostream` and `logtag`. So the pipeline is the mechanism, and JSON on
  stdout is its precondition.
- **Deployed to devnet nodes 1, 2 and 4**, one at a time (dlc-infra PR #168). All three run
  `19298d3` with 0 restarts. Each assigned coupons within a second of startup: 17, then 1,
  then 1. Node 4's line is the one quoted above, and it is where the attribute types were read.
  The devnet nodes still run `19298d3`, which predates the review commits. Those commits change
  the fatal path and the docs, and they leave the logged line itself untouched.

---

First of two changes for [#278](https://github.com/DLC-link/decentralization-manager/issues/278).
The metrics and the SigNoz alert rules follow separately.

