### PR TITLE
chore(decman): bump version to 1.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1742,7 +1742,7 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "decman"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "actix-cors",
  "actix-web",

--- a/crates/decman/Cargo.toml
+++ b/crates/decman/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "decman"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
## What

Bump the decman crate version from 1.6.0 to 1.6.1, in `crates/decman/Cargo.toml` and `Cargo.lock`.

## Why

This prepares the v1.6.1 release. The release workflow's `verify-tag` job requires the pushed tag to match this crate version. Version 1.6.0 was never tagged or published, so the patch bump gives the release a fresh, unambiguous version.

## How tested

No code changes. CI covers the build; the `verify-tag` check runs when the tag is pushed after merge.