### PR TITLE
Repair checksums of post-ship-edited migrations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1743,7 +1743,7 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "decman"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "actix-cors",
  "actix-web",

--- a/README.md
+++ b/README.md
@@ -735,21 +735,18 @@ TypeScript imports won't resolve.
 
 ## Docker Image
 
-Build and push to ECR:
+Release images are built and published by CI: pushing a `v<version>` tag (which
+must match the crate version in `crates/decman/Cargo.toml`) runs the release
+workflow, which builds the binary and pushes
+`public.ecr.aws/dlc-link/decentralization-manager:v<version>`. The root
+`Dockerfile` is that workflow's runtime wrapper — it copies in the CI-built
+binary and does no compilation, so it is not useful for a local build.
+
+To build an image from source locally, use the full-source build instead:
 
 ```bash
-# Build (forward an SSH key to fetch the canton-lib dependency — see
-# "Running with Docker" above)
-docker build --ssh default=$HOME/.ssh/id_ed25519 -t dec-party-manager .
-
-# Tag for ECR
-docker tag dec-party-manager:latest public.ecr.aws/dlc-link/canton-decparty-manager:<version>
-
-# Push
-docker push public.ecr.aws/dlc-link/canton-decparty-manager:<version>
+docker build --ssh default=$HOME/.ssh/id_ed25519 -f development/Dockerfile -t dec-party-manager .
 ```
-
-Replace the registry/org (`public.ecr.aws/dlc-link`) and `<version>` with your own.
 
 ## Deployment
 

--- a/crates/decman/Cargo.toml
+++ b/crates/decman/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "decman"
-version = "1.6.1"
+version = "1.6.2"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/crates/decman/src/db/mod.rs
+++ b/crates/decman/src/db/mod.rs
@@ -4,4 +4,4 @@ pub mod crypto;
 pub mod rows;
 pub mod schema;
 
-pub use sqlite::{MIGRATOR, connect};
+pub use sqlite::{MIGRATOR, connect, repair_migration_checksums};

--- a/crates/decman/src/db/sqlite.rs
+++ b/crates/decman/src/db/sqlite.rs
@@ -28,6 +28,63 @@ use crate::{
 
 pub static MIGRATOR: Migrator = sqlx::migrate!("./migrations");
 
+/// Checksum rewrites for migration files that were edited in place after
+/// operators had already applied them: (version, checksum recorded by the old
+/// file, checksum of the current file). Every entry must be a semantically
+/// neutral edit (comments, whitespace) — an edit that changes what the
+/// migration does needs a new migration, never an entry here.
+///
+/// Version 4: #239 changed "DAML" to "Daml" in a comment of
+/// `000004_workflow_runs.up.sql` after the migration had shipped, so databases
+/// initialized before that commit fail sqlx's checksum validation with
+/// "migration 4 was previously applied but has been modified".
+const MIGRATION_CHECKSUM_REPAIRS: &[(i64, &str, &str)] = &[(
+    4,
+    "137f46dbb8207525f71a15371f122ac9a22bddf6dfed826ff1d8dc1dd46e5b80965e1b8e46a0b7943b4a67ca9ddc5b33",
+    "eda7576bac7480932ea8b0a8e3d6ddddb65d045a3cec2ccff85a425ee8b89baf64dc5ca8e5482f5670198aafe350eb9e",
+)];
+
+/// Rewrite the recorded checksums of known post-ship-edited migrations to
+/// match the files this binary embeds. Run this before `MIGRATOR.run`, which
+/// otherwise refuses to start on a database that applied the pre-edit file.
+///
+/// # Errors
+///
+/// Returns an error if the `_sqlx_migrations` table cannot be read or updated.
+pub async fn repair_migration_checksums(pool: &SqlitePool) -> Result<()> {
+    // A fresh database has no `_sqlx_migrations` table yet — nothing to repair.
+    let table_exists = sqlx::query(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = '_sqlx_migrations'",
+    )
+    .fetch_optional(pool)
+    .await?
+    .is_some();
+    if !table_exists {
+        return Ok(());
+    }
+
+    for (version, old_checksum, new_checksum) in MIGRATION_CHECKSUM_REPAIRS {
+        // The checksums are compile-time hex constants, so inlining the blob
+        // literal is safe; version and the old checksum are bound.
+        let result = sqlx::query(&format!(
+            "UPDATE _sqlx_migrations SET checksum = X'{new_checksum}' \
+             WHERE version = ? AND lower(hex(checksum)) = ?"
+        ))
+        .bind(version)
+        .bind(old_checksum)
+        .execute(pool)
+        .await?;
+        if result.rows_affected() > 0 {
+            tracing::info!(
+                "Repaired the recorded checksum of migration {version} \
+                 (applied by an older build from a since-edited file)"
+            );
+        }
+    }
+
+    Ok(())
+}
+
 /// Create a new SQLite connection pool
 ///
 /// # Errors
@@ -1150,7 +1207,7 @@ mod tests {
         },
     };
 
-    use super::MIGRATOR;
+    use super::{MIGRATION_CHECKSUM_REPAIRS, MIGRATOR, repair_migration_checksums};
 
     const TEST_NS: &str = "1220aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 
@@ -2728,6 +2785,62 @@ mod tests {
         assert_eq!(remaining[0].id, dars.id);
         assert_eq!(remaining[0].invitation_type, InvitationType::Dars);
 
+        Ok(())
+    }
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn repair_migration_checksums_unblocks_pre_edit_database(pool: SqlitePool) -> Result {
+        let (version, old_checksum, _) = MIGRATION_CHECKSUM_REPAIRS[0];
+
+        // Simulate a database whose migration was applied from the pre-edit
+        // file: record the old checksum, as operator databases have it.
+        sqlx::query(&format!(
+            "UPDATE _sqlx_migrations SET checksum = X'{old_checksum}' WHERE version = ?"
+        ))
+        .bind(version)
+        .execute(&pool)
+        .await?;
+
+        // Without the repair, the migrator refuses to start — this is the
+        // operator-reported crash.
+        let err = MIGRATOR
+            .run(&pool)
+            .await
+            .expect_err("checksum must mismatch");
+        assert!(
+            err.to_string()
+                .contains("previously applied but has been modified"),
+            "unexpected error: {err}"
+        );
+
+        repair_migration_checksums(&pool).await?;
+        MIGRATOR.run(&pool).await?;
+
+        Ok(())
+    }
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn repair_migration_checksums_is_a_noop_on_current_database(pool: SqlitePool) -> Result {
+        let (version, _, new_checksum) = MIGRATION_CHECKSUM_REPAIRS[0];
+
+        repair_migration_checksums(&pool).await?;
+
+        let recorded: (String,) =
+            sqlx::query_as("SELECT lower(hex(checksum)) FROM _sqlx_migrations WHERE version = ?")
+                .bind(version)
+                .fetch_one(&pool)
+                .await?;
+        assert_eq!(recorded.0, new_checksum);
+        MIGRATOR.run(&pool).await?;
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn repair_migration_checksums_tolerates_missing_table(pool: SqlitePool) -> Result {
+        // A database that has never run migrations has no `_sqlx_migrations`
+        // table; the repair must not fail on it.
+        repair_migration_checksums(&pool).await?;
         Ok(())
     }
 }

--- a/crates/decman/src/main.rs
+++ b/crates/decman/src/main.rs
@@ -345,6 +345,7 @@ async fn run() -> Result {
     let pool = db::connect(&db_path).await?;
 
     tracing::info!("Running database migrations");
+    db::repair_migration_checksums(&pool).await?;
     db::MIGRATOR.run(&pool).await?;
 
     match args.command {

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -25,10 +25,22 @@ The longest step is usually the cross-team coordination needed to exchange Noise
 The Dec Party Manager is published as a public container image:
 
 ```
-public.ecr.aws/dlc-link/canton-decparty-manager:<tag>
+public.ecr.aws/dlc-link/decentralization-manager:<tag>
 ```
 
-Use the latest tagged release (for example `0.1.7`). Pin the version explicitly — do not use `latest`. If your cluster cannot pull from Public ECR directly, mirror the image into your own registry first.
+Use the latest tagged release (for example `v1.6.2`). Pin the version explicitly — do not use `latest`. If your cluster cannot pull from Public ECR directly, mirror the image into your own registry first.
+
+> [!NOTE]
+> Releases before v1.6.0 were published under the old repository name,
+> `public.ecr.aws/dlc-link/canton-decparty-manager`. That repository stays up for
+> existing pins, but new releases only go to `decentralization-manager` — update
+> your manifests when you upgrade.
+
+The image is distroless: it contains the `dec-party-manager` binary (entrypoint
+`dec-party-manager serve`, binary on `PATH`) and no shell or coreutils. Run
+anything that needs `sh` — init containers, `kubectl exec` debugging, exec
+probes — on a utility image such as `busybox`, not on this image. The
+Deployment example below shows the pattern.
 
 To check the version of a running pod:
 
@@ -232,7 +244,7 @@ spec:
               mountPath: /app
       containers:
         - name: dec-party-manager
-          image: public.ecr.aws/dlc-link/canton-decparty-manager:<tag>
+          image: public.ecr.aws/dlc-link/decentralization-manager:<tag>
           imagePullPolicy: Always
           command:
             - dec-party-manager


### PR DESCRIPTION
## What

DecMan now rewrites the recorded checksum of a known post-ship-edited migration before it runs the migrator. The repair table pairs the pre-edit and current checksums, so it only touches a database that holds the exact pre-edit value. A fresh database, or one already on the current checksum, is untouched.

## Why

Commit 353c3909 (#239) edited a comment in the already-shipped `000004_workflow_runs.up.sql` (`DAML` → `Daml`). A database that applied migration 4 before that commit recorded the old checksum. sqlx validates checksums on every start, so v1.6.1 crashloops on such a database with "migration 4 was previously applied but has been modified". A testnet operator reported exactly this after upgrading to v1.6.1.

The edit was comment-only, so the schema on those databases is identical to the current file. Rewriting the recorded checksum is therefore safe, and only the exact old value is rewritten.

## How tested

Three new tests in `db::sqlite`:
- reproduce the operator crash (set the pre-edit checksum, assert the migrator refuses), then assert the repair unblocks the migrator
- assert the repair is a no-op on a current database
- assert the repair tolerates a database with no `_sqlx_migrations` table

Full unit suite passes (392 tests), clippy clean, fmt clean.

## Notes

Any future entry in the repair table must be a semantically neutral edit (comments, whitespace) — the constant's doc comment states this. A CI guard that rejects modifications to existing migration files would prevent the next occurrence; proposed as a follow-up.

## Release

This PR also bumps the crate version to 1.6.2, so the tag `v1.6.2` can be pushed on the merge commit directly and the release workflow publishes the fixed image without a separate bump PR.