### PR TITLE
feat(governance): expose proposal cancellation to the proposer

### DIFF
--- a/crates/common/src/api.rs
+++ b/crates/common/src/api.rs
@@ -845,6 +845,23 @@ pub struct CancelConfirmationRequest {
     pub governance_type: GovernanceType,
 }
 
+/// Request to retract a proposal the caller proposed.
+///
+/// `confirmation_cid` carries the caller's own confirmation on that proposal,
+/// which `/governance/propose` always creates. The server archives it in the
+/// same transaction, because a confirmation that outlives its proposal can
+/// only be cleared by its own confirmer, and only `GovernanceConfirmation_Cancel`
+/// clears it without waiting for the expiry time.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "typegen", derive(ts_rs::TS), ts(optional_fields))]
+pub struct CancelProposalRequest {
+    pub party_id: CantonId,
+    pub proposal_cid: String,
+    #[serde(default)]
+    pub confirmation_cid: Option<String>,
+}
+
 /// State of a VaultGovernanceRules contract
 #[derive(Clone, Debug, Serialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]

--- a/crates/decman/frontend/src/components/GovernanceAuditTrail.tsx
+++ b/crates/decman/frontend/src/components/GovernanceAuditTrail.tsx
@@ -61,6 +61,7 @@ const eventTypeColor = (
     case "expire":
       return "warning";
     case "cancel":
+    case "cancel_proposal":
       return "error";
     default:
       return "default";

--- a/crates/decman/frontend/src/components/NotificationsView.tsx
+++ b/crates/decman/frontend/src/components/NotificationsView.tsx
@@ -107,6 +107,17 @@ const formatRelativeTime = (epochSeconds: number): string => {
   return `${days}d ago`;
 };
 
+const formatTimeUntil = (epochSeconds: number): string => {
+  const seconds = Math.max(0, epochSeconds - Math.floor(Date.now() / 1000));
+  if (seconds < 60) return "in under a minute";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `in ${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `in ${hours}h`;
+  const days = Math.floor(hours / 24);
+  return `in ${days}d`;
+};
+
 const truncatePartyId = (id: string): string => {
   const parts = id.split("::");
   if (parts.length !== 2) return id;
@@ -868,9 +879,20 @@ const DomainActionCard = ({
   const otherConfirmations = domainAction.confirmations.filter(
     (c) => c.confirming_party !== party.memberPartyId,
   );
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  // GovernanceConfirmation_Expire refuses to run before a confirmation's
+  // expiry time, and only its own confirmer can archive it any earlier. So
+  // another member's live confirmation is nobody else's to clear yet.
+  const expiredOthers = otherConfirmations.filter(
+    (c) => (c.expires_at ?? 0) > 0 && (c.expires_at ?? 0) <= nowSeconds,
+  );
+  const nextOtherExpiry = otherConfirmations
+    .map((c) => c.expires_at ?? 0)
+    .filter((t) => t > nowSeconds)
+    .sort((a, b) => a - b)[0];
   // Only the proposer controls GovernableAction_ProposerCancel, so anyone else
   // pressing the button would just collect a ledger rejection.
-  const isProposer =
+  const canCancelProposal =
     !!domainAction.proposer && domainAction.proposer === party.memberPartyId;
 
   // The on-chain proposal already encodes the action — server only needs the
@@ -972,12 +994,11 @@ const DomainActionCard = ({
 
   // For orphaned actions (underlying proposal is gone) the only valid
   // operation is to clear the stranded Confirmation contracts off the ledger.
-  // Our own goes through Revoke instead: GovernanceConfirmation_Expire refuses
-  // to run before the confirmation's expiry time, and only the confirmer can
-  // archive it any earlier. Loop sequentially so the `busy` lock on each
-  // /governance/expire call serializes correctly.
+  // Our own goes through Revoke instead, and another member's live one is not
+  // ours to clear, so this covers the expired remainder. Loop sequentially so
+  // the `busy` lock on each /governance/expire call serializes correctly.
   const handleDismissOrphan = async () => {
-    for (const c of otherConfirmations) {
+    for (const c of expiredOthers) {
       await handleExpire(c.contract_id);
     }
   };
@@ -1045,8 +1066,9 @@ const DomainActionCard = ({
 
       {domainAction.orphaned && (
         <Alert severity="warning" sx={{ py: 0.5 }}>
-          The underlying proposal has been archived. These confirmation
-          contracts are stranded on the ledger — dismiss to clear them.
+          The underlying proposal has been archived, so these confirmation
+          contracts are stranded on the ledger. Each member revokes their own.
+          Anyone can dismiss the rest once they expire.
         </Alert>
       )}
 
@@ -1293,7 +1315,6 @@ const DomainActionCard = ({
           (a, b) => (a.created_at ?? 0) - (b.created_at ?? 0),
         );
         const proposerCid = sorted[0]?.contract_id;
-        const nowSeconds = Math.floor(Date.now() / 1000);
         return (
           <Box
             sx={{
@@ -1420,15 +1441,31 @@ const DomainActionCard = ({
               </Button>
             )}
             {otherConfirmations.length > 0 && (
-              <Button
-                size="small"
-                variant="outlined"
-                color="warning"
-                onClick={handleDismissOrphan}
-                disabled={busy || !party.rulesContractId}
+              <Tooltip
+                title={
+                  expiredOthers.length > 0
+                    ? "Clear the other members' expired confirmations"
+                    : `Only each member clears their own confirmation until it expires${
+                        nextOtherExpiry
+                          ? `, and the next one expires ${formatTimeUntil(nextOtherExpiry)}`
+                          : ""
+                      }`
+                }
               >
-                Dismiss
-              </Button>
+                <span>
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    color="warning"
+                    onClick={handleDismissOrphan}
+                    disabled={
+                      busy || !party.rulesContractId || expiredOthers.length === 0
+                    }
+                  >
+                    Dismiss
+                  </Button>
+                </span>
+              </Tooltip>
             )}
           </>
         ) : (
@@ -1453,7 +1490,7 @@ const DomainActionCard = ({
                 Confirm
               </Button>
             )}
-            {isProposer && (
+            {canCancelProposal && (
               <Button
                 size="small"
                 variant="outlined"

--- a/crates/decman/frontend/src/components/NotificationsView.tsx
+++ b/crates/decman/frontend/src/components/NotificationsView.tsx
@@ -865,6 +865,13 @@ const DomainActionCard = ({
   const ownConfirmation = domainAction.confirmations.find(
     (c) => c.confirming_party === party.memberPartyId,
   );
+  const otherConfirmations = domainAction.confirmations.filter(
+    (c) => c.confirming_party !== party.memberPartyId,
+  );
+  // Only the proposer controls GovernableAction_ProposerCancel, so anyone else
+  // pressing the button would just collect a ledger rejection.
+  const isProposer =
+    !!domainAction.proposer && domainAction.proposer === party.memberPartyId;
 
   // The on-chain proposal already encodes the action — server only needs the
   // proposal_cid and governance_type to confirm/execute. action is a
@@ -879,7 +886,12 @@ const DomainActionCard = ({
     body: T,
     successMsg: string,
   ): Promise<void> => {
-    if (!party.rulesContractId) {
+    // Only the endpoints that exercise a choice on the rules contract need it.
+    // Cancelling a confirmation or a proposal goes straight to the contract
+    // being archived, so it stays available when the rules cid is unknown.
+    const needsRulesContract =
+      typeof body === "object" && body !== null && "rules_contract_id" in body;
+    if (needsRulesContract && !party.rulesContractId) {
       showSnackbar("Governance rules contract is not set", "error");
       return;
     }
@@ -944,12 +956,28 @@ const DomainActionCard = ({
       "Confirmation expired",
     );
 
+  // Retract the proposal, and archive our own confirmation with it. The server
+  // sends both as one transaction, because nobody else can clear that
+  // confirmation once the proposal it points at is gone.
+  const handleCancelProposal = () =>
+    post(
+      "cancel-proposal",
+      {
+        party_id: party.partyId,
+        proposal_cid: domainAction.proposal_cid,
+        confirmation_cid: ownConfirmation?.contract_id,
+      },
+      "Proposal cancelled",
+    );
+
   // For orphaned actions (underlying proposal is gone) the only valid
   // operation is to clear the stranded Confirmation contracts off the ledger.
-  // Loop sequentially so the `busy` lock on each /governance/expire call
-  // serializes correctly.
+  // Our own goes through Revoke instead: GovernanceConfirmation_Expire refuses
+  // to run before the confirmation's expiry time, and only the confirmer can
+  // archive it any earlier. Loop sequentially so the `busy` lock on each
+  // /governance/expire call serializes correctly.
   const handleDismissOrphan = async () => {
-    for (const c of domainAction.confirmations) {
+    for (const c of otherConfirmations) {
       await handleExpire(c.contract_id);
     }
   };
@@ -1379,15 +1407,30 @@ const DomainActionCard = ({
           variant={domainAction.can_execute ? "filled" : "outlined"}
         />
         {domainAction.orphaned ? (
-          <Button
-            size="small"
-            variant="outlined"
-            color="warning"
-            onClick={handleDismissOrphan}
-            disabled={busy || !party.rulesContractId}
-          >
-            Dismiss
-          </Button>
+          <>
+            {ownConfirmation && (
+              <Button
+                size="small"
+                variant="outlined"
+                color="warning"
+                onClick={handleRevoke}
+                disabled={busy}
+              >
+                Revoke
+              </Button>
+            )}
+            {otherConfirmations.length > 0 && (
+              <Button
+                size="small"
+                variant="outlined"
+                color="warning"
+                onClick={handleDismissOrphan}
+                disabled={busy || !party.rulesContractId}
+              >
+                Dismiss
+              </Button>
+            )}
+          </>
         ) : (
           <>
             {ownConfirmation ? (
@@ -1408,6 +1451,17 @@ const DomainActionCard = ({
                 disabled={busy || !party.rulesContractId}
               >
                 Confirm
+              </Button>
+            )}
+            {isProposer && (
+              <Button
+                size="small"
+                variant="outlined"
+                color="error"
+                onClick={handleCancelProposal}
+                disabled={busy}
+              >
+                Cancel proposal
               </Button>
             )}
             {domainAction.can_execute && (

--- a/crates/decman/src/bin/gen_types.rs
+++ b/crates/decman/src/bin/gen_types.rs
@@ -58,6 +58,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         AuthTestResponse,
         AuthTestResult,
         CancelConfirmationRequest,
+        CancelProposalRequest,
         ChainAuditEntry,
         ChainAuditResponse,
         ChangeThresholdInvitePayload,

--- a/crates/decman/src/server/audit.rs
+++ b/crates/decman/src/server/audit.rs
@@ -14,6 +14,7 @@ pub enum AuditEvent {
     Execute,
     Expire,
     Cancel,
+    CancelProposal,
 }
 
 impl AuditEvent {
@@ -24,6 +25,7 @@ impl AuditEvent {
             AuditEvent::Execute => "execute",
             AuditEvent::Expire => "expire",
             AuditEvent::Cancel => "cancel",
+            AuditEvent::CancelProposal => "cancel_proposal",
         }
     }
 }

--- a/crates/decman/src/server/handlers/governance.rs
+++ b/crates/decman/src/server/handlers/governance.rs
@@ -44,10 +44,10 @@ use crate::{
         },
         types::{
             ActiveCouponReassignmentDelegation, AuditLogEntry, AuditLogQuery, AuditLogResponse,
-            BurnRequestsResponse, CancelConfirmationRequest, ChainAuditEntry, ChainAuditQuery,
-            ChainAuditResponse, ConfirmActionRequest, ContractQueryResponse,
-            CouponReassignmentDelegationSummary, CredentialOffersResponse, ErrorResponse,
-            ExecuteActionRequest, ExpireConfirmationRequest, GovernanceResponse,
+            BurnRequestsResponse, CancelConfirmationRequest, CancelProposalRequest,
+            ChainAuditEntry, ChainAuditQuery, ChainAuditResponse, ConfirmActionRequest,
+            ContractQueryResponse, CouponReassignmentDelegationSummary, CredentialOffersResponse,
+            ErrorResponse, ExecuteActionRequest, ExpireConfirmationRequest, GovernanceResponse,
             GovernanceStateResponse, GovernanceType, HoldingsResponse, InstrumentsResponse,
             KnownMember, KnownMembersResponse, MessageResponse, MintRequestsResponse, NetworkInfo,
             OperatorInfo, ProposalType, ProposeActionRequest, ProviderServicesResponse,
@@ -1953,6 +1953,85 @@ pub async fn cancel_confirmation(
     }
 }
 
+/// Retract a proposal the caller proposed
+#[utoipa::path(
+    tag = "Governance",
+    request_body = CancelProposalRequest,
+    responses(
+        (status = 200, description = "Proposal cancelled", body = MessageResponse),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 403, description = "Forbidden: admin role required", body = ErrorResponse),
+        (status = 500, description = "Internal server error", body = ErrorResponse)
+    )
+)]
+#[post("/governance/cancel-proposal")]
+pub async fn cancel_proposal(
+    http_req: HttpRequest,
+    data: web::Data<AppState>,
+    body: web::Json<CancelProposalRequest>,
+) -> impl Responder {
+    if let Err(resp) = require_admin(&http_req, data.admin_role.as_deref()) {
+        return resp;
+    }
+    let party_id = &body.party_id;
+
+    let (token, member_party_id) = match get_party_credentials(&data, party_id).await {
+        Some(creds) => creds,
+        None => {
+            return HttpResponse::Unauthorized().json(ErrorResponse {
+                error: "No credentials configured for party".to_string(),
+            });
+        }
+    };
+
+    let audit_pool = data.db.clone();
+    let audit_details = serde_json::to_string(&*body).unwrap_or_default();
+    let audit_party_id = party_id.clone();
+    let audit_member = member_party_id.clone();
+
+    let packages = packages();
+
+    match execute_cancel_proposal(&data.config, &body, &token, &member_party_id, &packages).await {
+        Ok(()) => {
+            spawn_audit_log(
+                audit_pool,
+                AuditParams {
+                    event_type: AuditEvent::CancelProposal,
+                    party_id: audit_party_id,
+                    member_party_id: audit_member,
+                    governance_type: GovernanceType::CoreDomain,
+                    action_summary: "cancel_proposal".to_string(),
+                    details: audit_details,
+                    status: "success",
+                    error_message: None,
+                },
+            );
+            HttpResponse::Ok().json(MessageResponse {
+                message: "Proposal cancelled successfully".to_string(),
+            })
+        }
+        Err(e) => {
+            tracing::error!("Failed to cancel proposal: {e}");
+            spawn_audit_log(
+                audit_pool,
+                AuditParams {
+                    event_type: AuditEvent::CancelProposal,
+                    party_id: audit_party_id,
+                    member_party_id: audit_member,
+                    governance_type: GovernanceType::CoreDomain,
+                    action_summary: "cancel_proposal".to_string(),
+                    details: audit_details,
+                    status: "failed",
+                    error_message: Some(format!("{e}")),
+                },
+            );
+            HttpResponse::InternalServerError().json(ErrorResponse {
+                error: format!("Failed to cancel proposal: {e}"),
+            })
+        }
+    }
+}
+
 /// Get package configuration for a party
 #[utoipa::path(
     tag = "Configuration",
@@ -2860,6 +2939,220 @@ async fn execute_cancel_confirmation(
     client.submit_and_wait(req).await?;
 
     Ok(())
+}
+
+/// Build the exercise commands that retract a proposal.
+///
+/// The first command archives the proposal itself. `GovernableAction_ProposerCancel`
+/// is declared on the interface rather than on any one template, so the
+/// exercise carries the `GovernableAction` interface id and never the id of
+/// the template that actually created the contract. That also rules out
+/// [`resolve_contract_package_ref`]: it reports the package of the contract,
+/// which here is the proposal's own package, not the interface's.
+///
+/// The second command archives the caller's confirmation on that proposal,
+/// which `/governance/propose` creates for every proposal. Both choices take
+/// no arguments, and the caller controls both — `proposer` on one, `confirmer`
+/// on the other — so one submission covers them.
+fn build_cancel_proposal_commands(
+    proposal_cid: &str,
+    action_package_ref: &str,
+    confirmation: Option<(&str, &str)>,
+) -> Vec<Command> {
+    let no_arguments = || {
+        Some(Value {
+            sum: Some(value::Sum::Record(Record {
+                record_id: None,
+                fields: vec![],
+            })),
+        })
+    };
+
+    let mut commands = vec![Command {
+        command: Some(command::Command::Exercise(ExerciseCommand {
+            template_id: Some(Identifier {
+                package_id: action_package_ref.to_string(),
+                module_name: "Governance.Action".to_string(),
+                entity_name: "GovernableAction".to_string(),
+            }),
+            contract_id: proposal_cid.to_string(),
+            choice: "GovernableAction_ProposerCancel".to_string(),
+            choice_argument: no_arguments(),
+        })),
+    }];
+
+    if let Some((confirmation_cid, confirmation_package_ref)) = confirmation {
+        commands.push(Command {
+            command: Some(command::Command::Exercise(ExerciseCommand {
+                template_id: Some(Identifier {
+                    package_id: confirmation_package_ref.to_string(),
+                    module_name: "Governance.Confirmation".to_string(),
+                    entity_name: "GovernanceConfirmation".to_string(),
+                }),
+                contract_id: confirmation_cid.to_string(),
+                choice: "GovernanceConfirmation_Cancel".to_string(),
+                choice_argument: no_arguments(),
+            })),
+        });
+    }
+
+    commands
+}
+
+/// Exercise `GovernableAction_ProposerCancel` on a proposal, and archive the
+/// caller's own confirmation alongside it.
+///
+/// The two commands share one submission so they succeed or fail together. A
+/// confirmation that outlives its proposal is only clearable by its own
+/// confirmer: `GovernanceConfirmation_Expire` refuses to run before the
+/// confirmation's expiry time.
+async fn execute_cancel_proposal(
+    config: &NodeConfig,
+    request: &CancelProposalRequest,
+    token: &str,
+    member_party_id: &CantonId,
+    packages: &PackageConfig,
+) -> Result {
+    let action_package_ref = packages
+        .governance_action
+        .as_deref()
+        .context("governance_action package not configured")?;
+
+    let confirmation_package_ref = match request.confirmation_cid.as_deref() {
+        Some(cid) => {
+            let core = packages
+                .governance_core
+                .as_deref()
+                .context("governance_core package not configured")?;
+            // The confirmation is created by the rules contract's choice, so it
+            // shares that contract's possibly out-of-date package.
+            Some(
+                resolve_contract_package_ref(
+                    config,
+                    &request.party_id,
+                    Some(token.to_string()),
+                    cid,
+                    core,
+                )
+                .await,
+            )
+        }
+        None => None,
+    };
+
+    let commands = build_cancel_proposal_commands(
+        &request.proposal_cid,
+        action_package_ref,
+        request
+            .confirmation_cid
+            .as_deref()
+            .zip(confirmation_package_ref.as_deref()),
+    );
+
+    let channel = config.ledger_channel().await?;
+
+    let mut client =
+        CommandServiceClient::new(channel).max_decoding_message_size(utils::MAX_GRPC_MESSAGE_SIZE);
+
+    let commands = Commands {
+        workflow_id: String::new(),
+        user_id: String::new(),
+        command_id: uuid::Uuid::new_v4().to_string(),
+        commands,
+        deduplication_period: None,
+        min_ledger_time_abs: None,
+        min_ledger_time_rel: None,
+        act_as: vec![member_party_id.to_string()],
+        read_as: vec![request.party_id.to_string()],
+        submission_id: String::new(),
+        disclosed_contracts: vec![],
+        synchronizer_id: String::new(),
+        package_id_selection_preference: vec![],
+        prefetch_contract_keys: vec![],
+        taps_max_passes: None,
+    };
+
+    let mut req = tonic::Request::new(SubmitAndWaitRequest {
+        commands: Some(commands),
+    });
+    req.metadata_mut()
+        .insert("authorization", format!("Bearer {token}").parse().unwrap());
+
+    client.submit_and_wait(req).await?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod cancel_proposal_tests {
+    use super::*;
+
+    fn exercise(command: &Command) -> &ExerciseCommand {
+        match command.command.as_ref() {
+            Some(command::Command::Exercise(e)) => e,
+            _ => panic!("the builder only emits exercise commands"),
+        }
+    }
+
+    #[test]
+    fn cancels_the_proposal_through_the_interface() {
+        let commands = build_cancel_proposal_commands("proposal-1", "action-pkg", None);
+
+        assert_eq!(commands.len(), 1);
+        let exercised = exercise(&commands[0]);
+        assert_eq!(exercised.contract_id, "proposal-1");
+        assert_eq!(exercised.choice, "GovernableAction_ProposerCancel");
+
+        let template_id = exercised
+            .template_id
+            .as_ref()
+            .expect("exercise carries a template id");
+        assert_eq!(template_id.package_id, "action-pkg");
+        assert_eq!(template_id.module_name, "Governance.Action");
+        assert_eq!(template_id.entity_name, "GovernableAction");
+    }
+
+    #[test]
+    fn archives_the_own_confirmation_in_the_same_batch() {
+        let commands = build_cancel_proposal_commands(
+            "proposal-1",
+            "action-pkg",
+            Some(("confirmation-1", "core-pkg")),
+        );
+
+        assert_eq!(commands.len(), 2);
+        let exercised = exercise(&commands[1]);
+        assert_eq!(exercised.contract_id, "confirmation-1");
+        assert_eq!(exercised.choice, "GovernanceConfirmation_Cancel");
+
+        let template_id = exercised
+            .template_id
+            .as_ref()
+            .expect("exercise carries a template id");
+        assert_eq!(template_id.package_id, "core-pkg");
+        assert_eq!(template_id.module_name, "Governance.Confirmation");
+        assert_eq!(template_id.entity_name, "GovernanceConfirmation");
+    }
+
+    #[test]
+    fn neither_choice_takes_arguments() {
+        let commands = build_cancel_proposal_commands(
+            "proposal-1",
+            "action-pkg",
+            Some(("confirmation-1", "core-pkg")),
+        );
+
+        for command in &commands {
+            let argument = exercise(command)
+                .choice_argument
+                .as_ref()
+                .and_then(|v| v.sum.as_ref());
+            match argument {
+                Some(value::Sum::Record(record)) => assert!(record.fields.is_empty()),
+                _ => panic!("choice argument is an empty record"),
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/decman/src/server/handlers/mod.rs
+++ b/crates/decman/src/server/handlers/mod.rs
@@ -13,7 +13,7 @@ pub use config::{
     NodeConfigResponse, get_network_config, get_node_config, healthz, save_network_config,
 };
 pub use governance::{
-    cancel_confirmation, confirm_action, execute_action, expire_confirmation,
+    cancel_confirmation, cancel_proposal, confirm_action, execute_action, expire_confirmation,
     get_burn_requests_handler, get_coupon_reassignment_delegation, get_credential_offers_handler,
     get_governance, get_governance_audit, get_governance_chain_audit, get_governance_state,
     get_holdings_handler, get_instruments_handler, get_known_members, get_mint_requests_handler,

--- a/crates/decman/src/server/mod.rs
+++ b/crates/decman/src/server/mod.rs
@@ -1192,6 +1192,7 @@ pub async fn start_server(
             .service(handlers::execute_action)
             .service(handlers::expire_confirmation)
             .service(handlers::cancel_confirmation)
+            .service(handlers::cancel_proposal)
             .service(handlers::get_governance_audit)
             .service(handlers::get_governance_chain_audit)
             .service(handlers::get_token_standard_contracts)

--- a/crates/decman/src/server/queries.rs
+++ b/crates/decman/src/server/queries.rs
@@ -743,6 +743,7 @@ pub async fn get_governance_confirmations(
                 transfer_details,
                 accept_transfer_details,
                 service_request_info,
+                proposer,
                 orphaned,
             ) = match proposal_infos.remove(&proposal_cid) {
                 Some(info) => (
@@ -750,9 +751,10 @@ pub async fn get_governance_confirmations(
                     info.transfer,
                     info.accept_transfer,
                     info.service_request,
+                    info.proposer,
                     false,
                 ),
-                None => (None, None, None, None, proposal_infos_complete),
+                None => (None, None, None, None, None, proposal_infos_complete),
             };
             // Service-request parties are only meaningful on the two
             // service-request proposal kinds; clear them otherwise so an
@@ -783,6 +785,7 @@ pub async fn get_governance_confirmations(
                 transfer_details,
                 accept_transfer_details,
                 service_request_details,
+                proposer,
             }
         })
         .collect();
@@ -1042,6 +1045,10 @@ pub struct ProposalInfo {
     /// `Create{User,Provider}ServiceRequest` proposals so the notification card
     /// can render the full summary.
     pub service_request: Option<ServiceRequestDetails>,
+    /// The member who created the proposal. Only that member controls
+    /// `GovernableAction_ProposerCancel`, so the card offers the retract
+    /// button on this field alone. `None` when the party id fails to parse.
+    pub proposer: Option<CantonId>,
 }
 
 /// Extract proposal info from a GovernableAction contract's create_arguments.
@@ -1077,6 +1084,17 @@ fn extract_proposal_info(
             _ => None,
         });
 
+    let proposer = field_party(record, "proposer").and_then(|p| match CantonId::parse(&p) {
+        Ok(id) => Some(id),
+        Err(e) => {
+            tracing::warn!(
+                "Proposal {cid} carries an unparseable proposer '{p}': {e}",
+                cid = created.contract_id
+            );
+            None
+        }
+    });
+
     let transfer = extract_transfer_proposal_details(record);
     let service_request = extract_service_request_details(record);
 
@@ -1105,6 +1123,7 @@ fn extract_proposal_info(
             accept_transfer_instruction_cid,
             accept_transfer: None,
             service_request,
+            proposer,
         },
     );
 }

--- a/crates/decman/src/server/types.rs
+++ b/crates/decman/src/server/types.rs
@@ -17,20 +17,21 @@ pub use common::api::PAGE_SIZE;
 pub use common::api::{
     ActiveCouponReassignmentDelegation, AddPartyInvitePayload, AddPartyRequest, AuditLogResponse,
     AuthStatus, AuthStatusResponse, AuthTestResponse, AuthTestResult, CancelConfirmationRequest,
-    ChainAuditEntry, ChainAuditResponse, ChangeThresholdInvitePayload, ChangeThresholdRequest,
-    Claim, ContractQueryResponse, ContractWithBlob, ContractsInvitePayload, ContractsRequest,
-    CouponReassignmentDelegationSummary, CredentialOfferInfo, CredentialOffersResponse,
-    DarsInvitePayload, DarsRequest, DecentralizedPartiesResponse, DeclineInvitationPayload,
-    DisclosedContractInput, DiscoverMemberPartyRequest, DiscoverMemberPartyResponse, ErrorResponse,
-    ExpireConfirmationRequest, ExternalPartiesResponse, ExternalPartyInfo, GovernanceState,
-    GovernanceStateResponse, GovernanceType, GrantRightsRequest, GrantRightsResponse,
-    InstrumentAllowance, InstrumentId, InstrumentIdentifier, InstrumentInfo, InstrumentsResponse,
-    InvitationActionRequest, KeyStatusResponse, KickInvitePayload, KickRequest, KnownMember,
-    KnownMembersResponse, MessageResponse, MissingEdgeKind, MissingPeerEdge, NetworkInfo,
-    OnboardingInvitePayload, OnboardingMeshErrorResponse, OnboardingRequest, OperatorInfo,
-    PartyAuthStatus, PartyConfigRequest, PartyConfigResponse, PendingInvitationsResponse,
-    ProviderServiceInfo, ProviderServicesResponse, RegistrarServiceInfo, RegistrarServicesResponse,
-    ResponseSource, RightsStatus, SuccessResponse, TenantOnboardRequest, TenantOnboardResponse,
+    CancelProposalRequest, ChainAuditEntry, ChainAuditResponse, ChangeThresholdInvitePayload,
+    ChangeThresholdRequest, Claim, ContractQueryResponse, ContractWithBlob, ContractsInvitePayload,
+    ContractsRequest, CouponReassignmentDelegationSummary, CredentialOfferInfo,
+    CredentialOffersResponse, DarsInvitePayload, DarsRequest, DecentralizedPartiesResponse,
+    DeclineInvitationPayload, DisclosedContractInput, DiscoverMemberPartyRequest,
+    DiscoverMemberPartyResponse, ErrorResponse, ExpireConfirmationRequest, ExternalPartiesResponse,
+    ExternalPartyInfo, GovernanceState, GovernanceStateResponse, GovernanceType,
+    GrantRightsRequest, GrantRightsResponse, InstrumentAllowance, InstrumentId,
+    InstrumentIdentifier, InstrumentInfo, InstrumentsResponse, InvitationActionRequest,
+    KeyStatusResponse, KickInvitePayload, KickRequest, KnownMember, KnownMembersResponse,
+    MessageResponse, MissingEdgeKind, MissingPeerEdge, NetworkInfo, OnboardingInvitePayload,
+    OnboardingMeshErrorResponse, OnboardingRequest, OperatorInfo, PartyAuthStatus,
+    PartyConfigRequest, PartyConfigResponse, PendingInvitationsResponse, ProviderServiceInfo,
+    ProviderServicesResponse, RegistrarServiceInfo, RegistrarServicesResponse, ResponseSource,
+    RightsStatus, SuccessResponse, TenantOnboardRequest, TenantOnboardResponse,
     TenantPrepareRequest, TenantPrepareResponse, TransferFactoriesResponse, TransferFactoryInfo,
     TransferPreapprovalsResponse, UserServiceInfo, UserServicesResponse, VaultInfo, VaultsResponse,
     WorkflowResponse, WorkflowRunsResponse, WorkflowStatusResponse,
@@ -952,6 +953,13 @@ pub struct DomainGovernanceAction {
     /// proposal kinds.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub service_request_details: Option<ServiceRequestDetails>,
+    /// The member who created the proposal, read from the proposal contract.
+    /// Only that member can retract it with `GovernableAction_ProposerCancel`,
+    /// so the card shows the retract button when this equals the node's own
+    /// member party. Absent on an orphaned card, where the proposal contract
+    /// is no longer readable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub proposer: Option<CantonId>,
 }
 
 /// Operator + counterparty parties extracted from a service-request proposal

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -487,6 +487,16 @@ Choices:
 - `GovernanceConfirmation_Expire` -- Remove if past `expiresAt`
 - `GovernanceConfirmation_Cancel` -- Confirmer revokes their own confirmation
 
+### Cancelling a proposal
+
+The proposer retracts their own proposal with `GovernableAction_ProposerCancel`, which needs no vote. `POST /governance/cancel-proposal` exercises it, and the UI offers it as "Cancel proposal" on the proposer's card.
+
+A cancel archives the proposal, and it leaves the confirmations behind. Those confirmations are inert, because execution fetches the proposal and fails without it. Decman marks such a card `orphaned` and shows the stranded contracts.
+
+Each member clears their own confirmation whenever they want, through `GovernanceConfirmation_Cancel` ("Revoke"). Nobody clears another member's confirmation early: `GovernanceConfirmation_Expire` requires the confirmation to be past `expiresAt`, which is `actionConfirmationTimeout` after the vote. That time lock is deliberate, because the same choice would otherwise let one member strip another member's live vote.
+
+The cancel endpoint therefore archives the proposer's own confirmation in the same transaction as the proposal. `POST /governance/propose` always creates that confirmation, so a cancel would otherwise strand a contract that only the proposer could clear.
+
 ### GovernanceExecutionResult
 
 The `GovernanceExecutionResult` contract (from `Governance.ExecutionResult`) provides an immutable on-chain audit trail. It is created automatically when a domain action is executed:


### PR DESCRIPTION
## Summary

A proposer could not retract their own governance proposal from decman. The Daml
interface has always offered `GovernableAction_ProposerCancel`, whose controller is
the proposer, but no endpoint exercised it. The UI's "Revoke" button calls
`/governance/cancel`, which archives a confirmation, so it pulls back a vote and
leaves the proposal active. Until now the only way to retract a proposal was a
direct ledger call outside decman.

This PR adds `POST /governance/cancel-proposal` and a "Cancel proposal" button on
the proposer's card.

**The endpoint sends two exercises in one submission.** The first archives the
proposal through the `GovernableAction` interface. The second archives the caller's
own confirmation, which `/governance/propose` creates for every proposal. They share
a submission because a confirmation that outlives its proposal is clearable only by
its own confirmer: `GovernanceConfirmation_Expire` refuses to run before the
confirmation's expiry time. Without the second command, every cancel would strand a
contract that only the proposer could clear.

**The query layer now reports each proposal's proposer.** The card previously guessed
the proposer from the earliest confirmation. The button needs the real party, because
the ledger rejects the choice from anyone else.

**One pre-existing bug surfaced during testing.** An orphaned card offered only
"Dismiss", which calls `/governance/expire`. That choice is time-locked, so the button
failed on any confirmation that had not expired. The card now offers "Revoke" for your
own confirmation, which works at once, and limits "Dismiss" to the confirmations that
have actually expired, disabled with an explanation until then.

## Related issues

Closes #322

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Build / CI / chore

## Checklist

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` is clean
- [x] `cargo test` passes
- [x] Added/updated tests where appropriate
- [x] Updated documentation where appropriate
- [x] Commits follow the `<type>(<scope>): <subject>` convention

## Notes for reviewers

**Why the exercise carries an interface id.** `GovernableAction_ProposerCancel` is
declared on the interface, not on any one template, so `template_id` holds the
`GovernableAction` identifier and the package comes from `packages.governance_action`.
That also rules out `resolve_contract_package_ref`, which every neighbouring exercise
calls: it reports the contract's own package, which here is the proposal's package,
not the interface's.

**What a cancel deliberately leaves behind.** Other members' confirmations stay until
they revoke them or they expire, which is `actionConfirmationTimeout` after the vote
(24 hours on our rules contracts). Nobody can clear them early, and that is on purpose:
the same choice would otherwise let one member strip another member's live vote. Daml
cannot express the narrower "allow early expiry only when the proposal is archived",
because it has no way to prove a contract's absence. `docs/ARCHITECTURE.md` now records
this.

**Testing.** Three unit tests cover the command builder: the interface id on the first
command, the template and choice on the second, and the empty argument records. Manual
testing on a three-node devnet stack covered a cancel with one confirmation, a cancel at
full threshold, and clearing the leftover confirmation from the confirming member's own
card.

**One small change beyond the issue.** The card's shared `post` helper demanded a rules
contract id on every call. Only the calls that exercise a choice on the rules contract
need one, so it now checks the body. That also unblocks the existing Revoke button when
the rules cid is unknown.
