### PR TITLE
perf(server): compress and cache frontend assets

### DIFF
--- a/crates/decman/src/server/assets.rs
+++ b/crates/decman/src/server/assets.rs
@@ -1,9 +1,34 @@
-use actix_web::{HttpRequest, HttpResponse, get};
+use actix_web::{
+    HttpRequest, HttpResponse, get,
+    http::header::{CACHE_CONTROL, HeaderValue},
+};
 use rust_embed::Embed;
+
+const IMMUTABLE_CACHE_CONTROL: &str = "public, max-age=31536000, immutable";
+const REVALIDATE_CACHE_CONTROL: &str = "no-cache";
 
 #[derive(Embed)]
 #[folder = "frontend/dist"]
 struct Assets;
+
+fn cache_control(file_path: &str) -> HeaderValue {
+    // Vite fingerprints everything emitted under /assets, so those URLs can
+    // safely be cached forever. Entry points and other public files keep stable
+    // URLs and must be revalidated so a deployment is picked up immediately.
+    HeaderValue::from_static(if file_path.starts_with("assets/") {
+        IMMUTABLE_CACHE_CONTROL
+    } else {
+        REVALIDATE_CACHE_CONTROL
+    })
+}
+
+fn embedded_response(file_path: &str, content: rust_embed::EmbeddedFile) -> HttpResponse {
+    let mime = mime_guess::from_path(file_path).first_or_octet_stream();
+    HttpResponse::Ok()
+        .content_type(mime.as_ref())
+        .insert_header((CACHE_CONTROL, cache_control(file_path)))
+        .body(content.data.into_owned())
+}
 
 #[get("/{path:.*}")]
 pub async fn serve_frontend(req: HttpRequest) -> HttpResponse {
@@ -12,20 +37,54 @@ pub async fn serve_frontend(req: HttpRequest) -> HttpResponse {
     let file_path = if path.is_empty() { "index.html" } else { path };
 
     match Assets::get(file_path) {
-        Some(content) => {
-            let mime = mime_guess::from_path(file_path).first_or_octet_stream();
-            HttpResponse::Ok()
-                .content_type(mime.as_ref())
-                .body(content.data.into_owned())
-        }
+        Some(content) => embedded_response(file_path, content),
         None => {
             // For SPA routing, serve index.html for non-asset paths
             match Assets::get("index.html") {
-                Some(content) => HttpResponse::Ok()
-                    .content_type("text/html")
-                    .body(content.data.into_owned()),
+                Some(content) => embedded_response("index.html", content),
                 None => HttpResponse::NotFound().body("404 Not Found"),
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::{App, http::header::CONTENT_TYPE, test as actix_test};
+
+    #[test]
+    fn vite_assets_are_cached_immutably() {
+        assert_eq!(
+            cache_control("assets/index-C4G4w4u6.js"),
+            IMMUTABLE_CACHE_CONTROL
+        );
+        assert_eq!(
+            cache_control("assets/space-grotesk-DiSf0yqz.woff2"),
+            IMMUTABLE_CACHE_CONTROL
+        );
+    }
+
+    #[test]
+    fn stable_urls_are_revalidated() {
+        assert_eq!(cache_control("index.html"), REVALIDATE_CACHE_CONTROL);
+        assert_eq!(cache_control("favicon.svg"), REVALIDATE_CACHE_CONTROL);
+    }
+
+    #[actix_web::test]
+    async fn entrypoint_and_spa_fallback_are_revalidated() {
+        let app = actix_test::init_service(App::new().service(serve_frontend)).await;
+
+        for uri in ["/", "/notifications"] {
+            let request = actix_test::TestRequest::get().uri(uri).to_request();
+            let response = actix_test::call_service(&app, request).await;
+
+            assert!(response.status().is_success());
+            assert_eq!(
+                response.headers().get(CACHE_CONTROL).unwrap(),
+                REVALIDATE_CACHE_CONTROL
+            );
+            assert_eq!(response.headers().get(CONTENT_TYPE).unwrap(), "text/html");
         }
     }
 }

--- a/crates/decman/src/server/mod.rs
+++ b/crates/decman/src/server/mod.rs
@@ -28,7 +28,7 @@ use std::{
 };
 
 use actix_cors::Cors;
-use actix_web::{App, HttpServer, web};
+use actix_web::{App, HttpServer, middleware::Compress, web};
 use canton_proto_rs::com::digitalasset::canton::{
     admin::participant::v30::{ListPackagesRequest, package_service_client::PackageServiceClient},
     crypto::{
@@ -1187,7 +1187,13 @@ pub async fn start_server(
             .service(handlers::discover_member_party)
             .split_for_parts();
 
-        let mut app = app.wrap(AuthMiddleware).wrap(cors);
+        // Compress static bundles and API responses according to the client's
+        // Accept-Encoding header. This is especially important for the embedded
+        // frontend, whose JavaScript bundle is otherwise served verbatim.
+        let mut app = app
+            .wrap(AuthMiddleware)
+            .wrap(cors)
+            .wrap(Compress::default());
         if insecure {
             app = app
                 .service(SwaggerUi::new("/swagger-ui/{_:.*}").url("/api-docs/openapi.json", api));


### PR DESCRIPTION
## Summary

- negotiate response compression through Actix for frontend bundles and API responses
- cache Vite-fingerprinted `/assets/*` URLs for one year with `immutable`
- require revalidation for `index.html`, SPA fallbacks, and other stable public URLs
- add focused cache-policy and SPA fallback tests

## Motivation

The deployed frontend currently transfers its 1.12 MB JavaScript bundle without `Content-Encoding` or `Cache-Control`. Gzip reduces the same bundle to roughly 317 KB, while immutable caching prevents repeat downloads across reloads.

## Verification

- `cargo fmt --all -- --check`
- `DECMAN_SKIP_FRONTEND=1 cargo test -p decman --lib` (289 passed)
- `DECMAN_SKIP_FRONTEND=1 cargo clippy -p decman --lib --all-features --no-deps -- -D warnings`