### PR TITLE
Log an absent-package sweep failure at trace

### DIFF
--- a/crates/decman/src/server/reward_automation.rs
+++ b/crates/decman/src/server/reward_automation.rs
@@ -789,6 +789,18 @@ fn canton_error_id(e: &anyhow::Error) -> Option<String> {
         .then(|| id.to_string())
 }
 
+/// Whether the tick failed only because this participant does not carry
+/// `governance-rewards-automation-v1`.
+///
+/// The delegation query names the package by alias, so a participant that has
+/// never had the DAR uploaded rejects the read with `PACKAGE_NAMES_NOT_FOUND`
+/// before any contract is looked at. Every tick fails the same way, and an
+/// operator cannot act on the line, so the loop logs it at `trace`. Issue #334
+/// carries the fix — not running the loop on such a node at all.
+fn package_absent(e: &anyhow::Error) -> bool {
+    canton_error_id(e).as_deref() == Some("PACKAGE_NAMES_NOT_FOUND")
+}
+
 /// Whether a fresh read on the next tick is the cure.
 ///
 /// A non-ledger failure (config, transport, auth) is transient here too: it is
@@ -958,7 +970,15 @@ pub(crate) async fn run_reward_automation_loop(data: actix_web::web::Data<AppSta
             .collect();
         for decparty in parties {
             if let Err(e) = run_once_for_party(&data, &decparty).await {
-                tracing::trace!(%decparty, error = %e, "reward automation tick failed");
+                if package_absent(&e) {
+                    tracing::trace!(
+                        %decparty,
+                        error = %e,
+                        "reward automation tick failed: this participant does not carry the DAR"
+                    );
+                } else {
+                    tracing::warn!(%decparty, error = %e, "reward automation tick failed");
+                }
             }
         }
     }
@@ -1634,6 +1654,29 @@ mod tests {
             Some("LOCAL_VERDICT_LOCKED_CONTRACTS")
         );
         assert!(assign_failure_is_transient(&e));
+    }
+
+    #[test]
+    fn only_the_missing_dar_error_is_quiet() {
+        // The devnet message, verbatim. The gRPC code here is deliberately not
+        // the one Canton sends: the error id is what classifies.
+        let absent = anyhow::Error::new(tonic::Status::internal(
+            "PACKAGE_NAMES_NOT_FOUND(11,21a20a9f): The following package names do not match \
+             upgradable packages uploaded on this participant: [governance-rewards-automation-v1].",
+        ));
+        assert!(package_absent(&absent));
+        // A context added on the way up must not lose the id and send the line
+        // back to warn.
+        assert!(package_absent(
+            &Err::<(), _>(absent)
+                .context("reading the delegation")
+                .unwrap_err()
+        ));
+
+        // Every other failure stays at warn: another ledger rejection, and one
+        // that carries no ledger status at all, such as auth or transport.
+        assert!(!package_absent(&canton_err("DAML_INTERPRETATION_ERROR")));
+        assert!(!package_absent(&anyhow::anyhow!("connection refused")));
     }
 
     #[test]

--- a/crates/decman/src/server/reward_automation.rs
+++ b/crates/decman/src/server/reward_automation.rs
@@ -795,7 +795,6 @@ fn canton_error_id(e: &anyhow::Error) -> Option<String> {
 /// Both reads name their package by alias, so the ledger rejects the request
 /// before it reads a contract. A node in that state fails identically on every
 /// tick and no operator can act on the line, so the loop logs it at `trace`.
-/// Issue #334 stops running the loop there at all.
 ///
 /// One id covers both reads, because the delegation read runs first: a missing
 /// `governance-rewards-automation-v1` fails there, and a missing

--- a/crates/decman/src/server/reward_automation.rs
+++ b/crates/decman/src/server/reward_automation.rs
@@ -958,7 +958,7 @@ pub(crate) async fn run_reward_automation_loop(data: actix_web::web::Data<AppSta
             .collect();
         for decparty in parties {
             if let Err(e) = run_once_for_party(&data, &decparty).await {
-                tracing::warn!(%decparty, error = %e, "reward automation tick failed");
+                tracing::trace!(%decparty, error = %e, "reward automation tick failed");
             }
         }
     }

--- a/crates/decman/src/server/reward_automation.rs
+++ b/crates/decman/src/server/reward_automation.rs
@@ -789,26 +789,19 @@ fn canton_error_id(e: &anyhow::Error) -> Option<String> {
         .then(|| id.to_string())
 }
 
-/// Canton error ids that mean a package this automation reads is missing from
-/// the participant, or present and unusable.
+/// Whether the tick failed only because a package it reads by name is absent
+/// from this participant.
 ///
-/// A node in one of these states fails identically on every tick and no
-/// operator can act on the line, so the loop logs it at `trace`. Issue #334
-/// stops running the loop there at all.
+/// Both reads name their package by alias, so the ledger rejects the request
+/// before it reads a contract. A node in that state fails identically on every
+/// tick and no operator can act on the line, so the loop logs it at `trace`.
+/// Issue #334 stops running the loop there at all.
 ///
-/// Read-path ids only: [`drain_assignable`] absorbs every submission error, so
-/// the submission-side vetting ids cannot reach the loop.
-const UNUSABLE_PACKAGE_ERROR_IDS: &[&str] = &[
-    "PACKAGE_NAMES_NOT_FOUND",
-    "PACKAGE_NOT_FOUND",
-    "NO_TEMPLATES_FOR_PACKAGE_NAME_AND_QUALIFIED_NAME",
-    "NO_INTERFACE_FOR_PACKAGE_NAME_AND_QUALIFIED_NAME",
-    "NO_VETTED_INTERFACE_IMPLEMENTATION_PACKAGE",
-];
-
-/// Whether the tick failed only for a reason in [`UNUSABLE_PACKAGE_ERROR_IDS`].
-fn package_unusable(e: &anyhow::Error) -> bool {
-    canton_error_id(e).is_some_and(|id| UNUSABLE_PACKAGE_ERROR_IDS.contains(&id.as_str()))
+/// One id covers both reads, because the delegation read runs first: a missing
+/// `governance-rewards-automation-v1` fails there, and a missing
+/// `splice-api-reward-assignment-v1` fails the same way on the coupon read.
+fn package_absent(e: &anyhow::Error) -> bool {
+    canton_error_id(e).as_deref() == Some("PACKAGE_NAMES_NOT_FOUND")
 }
 
 /// Whether a fresh read on the next tick is the cure.
@@ -980,11 +973,11 @@ pub(crate) async fn run_reward_automation_loop(data: actix_web::web::Data<AppSta
             .collect();
         for decparty in parties {
             if let Err(e) = run_once_for_party(&data, &decparty).await {
-                if package_unusable(&e) {
+                if package_absent(&e) {
                     tracing::trace!(
                         %decparty,
                         error = %e,
-                        "reward automation tick failed: this participant cannot use the DAR"
+                        "reward automation tick failed: this participant does not hold the DAR"
                     );
                 } else {
                     tracing::warn!(%decparty, error = %e, "reward automation tick failed");
@@ -1667,29 +1660,25 @@ mod tests {
     }
 
     #[test]
-    fn only_an_unusable_package_is_quiet() {
+    fn only_an_absent_package_is_quiet() {
         // The devnet message, verbatim. The gRPC code here is deliberately not
         // the one Canton sends: the error id is what classifies.
         let absent = anyhow::Error::new(tonic::Status::internal(
             "PACKAGE_NAMES_NOT_FOUND(11,21a20a9f): The following package names do not match \
              upgradable packages uploaded on this participant: [governance-rewards-automation-v1].",
         ));
-        assert!(package_unusable(&absent));
+        assert!(package_absent(&absent));
         // A context added on the way up must not send the line back to warn.
-        assert!(package_unusable(
+        assert!(package_absent(
             &Err::<(), _>(absent)
                 .context("reading the delegation")
                 .unwrap_err()
         ));
-        // Uploaded but unvetted, on the coupon interface read.
-        assert!(package_unusable(&canton_err(
-            "NO_VETTED_INTERFACE_IMPLEMENTATION_PACKAGE"
-        )));
 
         // Another ledger rejection, then a failure carrying no ledger status at
         // all, such as auth or transport.
-        assert!(!package_unusable(&canton_err("DAML_INTERPRETATION_ERROR")));
-        assert!(!package_unusable(&anyhow::anyhow!("connection refused")));
+        assert!(!package_absent(&canton_err("DAML_INTERPRETATION_ERROR")));
+        assert!(!package_absent(&anyhow::anyhow!("connection refused")));
     }
 
     #[test]

--- a/crates/decman/src/server/reward_automation.rs
+++ b/crates/decman/src/server/reward_automation.rs
@@ -790,23 +790,14 @@ fn canton_error_id(e: &anyhow::Error) -> Option<String> {
 }
 
 /// Canton error ids that mean a package this automation reads is missing from
-/// the participant, or is present but unusable.
+/// the participant, or present and unusable.
 ///
-/// Every error the loop catches comes from a read: the delegation query, or the
-/// coupon interface query. [`drain_assignable`] absorbs every submission error,
-/// so the submission-side vetting ids cannot arrive here.
-///
-/// The ids split by what the read cannot resolve. The package name itself is
-/// unknown (`PACKAGE_NAMES_NOT_FOUND`), or a configured package id is
-/// (`PACKAGE_NOT_FOUND`). The name resolves but carries neither the template nor
-/// the interface asked for, which is what a partial or superseded upload looks
-/// like (`NO_TEMPLATES_…`, `NO_INTERFACE_…`). Or the participant holds the
-/// implementation and has not vetted it, so the interface view cannot be
-/// rendered (`NO_VETTED_INTERFACE_IMPLEMENTATION_PACKAGE`).
-///
-/// A node in any of these states fails identically on every tick, and no
+/// A node in one of these states fails identically on every tick and no
 /// operator can act on the line, so the loop logs it at `trace`. Issue #334
-/// carries the fix — not running the loop on such a node at all.
+/// stops running the loop there at all.
+///
+/// Read-path ids only: [`drain_assignable`] absorbs every submission error, so
+/// the submission-side vetting ids cannot reach the loop.
 const UNUSABLE_PACKAGE_ERROR_IDS: &[&str] = &[
     "PACKAGE_NAMES_NOT_FOUND",
     "PACKAGE_NOT_FOUND",
@@ -815,8 +806,7 @@ const UNUSABLE_PACKAGE_ERROR_IDS: &[&str] = &[
     "NO_VETTED_INTERFACE_IMPLEMENTATION_PACKAGE",
 ];
 
-/// Whether the tick failed only because a package it reads is missing or
-/// unusable on this participant. See [`UNUSABLE_PACKAGE_ERROR_IDS`].
+/// Whether the tick failed only for a reason in [`UNUSABLE_PACKAGE_ERROR_IDS`].
 fn package_unusable(e: &anyhow::Error) -> bool {
     canton_error_id(e).is_some_and(|id| UNUSABLE_PACKAGE_ERROR_IDS.contains(&id.as_str()))
 }
@@ -1685,8 +1675,7 @@ mod tests {
              upgradable packages uploaded on this participant: [governance-rewards-automation-v1].",
         ));
         assert!(package_unusable(&absent));
-        // A context added on the way up must not lose the id and send the line
-        // back to warn.
+        // A context added on the way up must not send the line back to warn.
         assert!(package_unusable(
             &Err::<(), _>(absent)
                 .context("reading the delegation")
@@ -1697,8 +1686,8 @@ mod tests {
             "NO_VETTED_INTERFACE_IMPLEMENTATION_PACKAGE"
         )));
 
-        // Every other failure stays at warn: another ledger rejection, and one
-        // that carries no ledger status at all, such as auth or transport.
+        // Another ledger rejection, then a failure carrying no ledger status at
+        // all, such as auth or transport.
         assert!(!package_unusable(&canton_err("DAML_INTERPRETATION_ERROR")));
         assert!(!package_unusable(&anyhow::anyhow!("connection refused")));
     }

--- a/crates/decman/src/server/reward_automation.rs
+++ b/crates/decman/src/server/reward_automation.rs
@@ -789,16 +789,36 @@ fn canton_error_id(e: &anyhow::Error) -> Option<String> {
         .then(|| id.to_string())
 }
 
-/// Whether the tick failed only because this participant does not carry
-/// `governance-rewards-automation-v1`.
+/// Canton error ids that mean a package this automation reads is missing from
+/// the participant, or is present but unusable.
 ///
-/// The delegation query names the package by alias, so a participant that has
-/// never had the DAR uploaded rejects the read with `PACKAGE_NAMES_NOT_FOUND`
-/// before any contract is looked at. Every tick fails the same way, and an
-/// operator cannot act on the line, so the loop logs it at `trace`. Issue #334
+/// Every error the loop catches comes from a read: the delegation query, or the
+/// coupon interface query. [`drain_assignable`] absorbs every submission error,
+/// so the submission-side vetting ids cannot arrive here.
+///
+/// The ids split by what the read cannot resolve. The package name itself is
+/// unknown (`PACKAGE_NAMES_NOT_FOUND`), or a configured package id is
+/// (`PACKAGE_NOT_FOUND`). The name resolves but carries neither the template nor
+/// the interface asked for, which is what a partial or superseded upload looks
+/// like (`NO_TEMPLATES_…`, `NO_INTERFACE_…`). Or the participant holds the
+/// implementation and has not vetted it, so the interface view cannot be
+/// rendered (`NO_VETTED_INTERFACE_IMPLEMENTATION_PACKAGE`).
+///
+/// A node in any of these states fails identically on every tick, and no
+/// operator can act on the line, so the loop logs it at `trace`. Issue #334
 /// carries the fix — not running the loop on such a node at all.
-fn package_absent(e: &anyhow::Error) -> bool {
-    canton_error_id(e).as_deref() == Some("PACKAGE_NAMES_NOT_FOUND")
+const UNUSABLE_PACKAGE_ERROR_IDS: &[&str] = &[
+    "PACKAGE_NAMES_NOT_FOUND",
+    "PACKAGE_NOT_FOUND",
+    "NO_TEMPLATES_FOR_PACKAGE_NAME_AND_QUALIFIED_NAME",
+    "NO_INTERFACE_FOR_PACKAGE_NAME_AND_QUALIFIED_NAME",
+    "NO_VETTED_INTERFACE_IMPLEMENTATION_PACKAGE",
+];
+
+/// Whether the tick failed only because a package it reads is missing or
+/// unusable on this participant. See [`UNUSABLE_PACKAGE_ERROR_IDS`].
+fn package_unusable(e: &anyhow::Error) -> bool {
+    canton_error_id(e).is_some_and(|id| UNUSABLE_PACKAGE_ERROR_IDS.contains(&id.as_str()))
 }
 
 /// Whether a fresh read on the next tick is the cure.
@@ -970,11 +990,11 @@ pub(crate) async fn run_reward_automation_loop(data: actix_web::web::Data<AppSta
             .collect();
         for decparty in parties {
             if let Err(e) = run_once_for_party(&data, &decparty).await {
-                if package_absent(&e) {
+                if package_unusable(&e) {
                     tracing::trace!(
                         %decparty,
                         error = %e,
-                        "reward automation tick failed: this participant does not carry the DAR"
+                        "reward automation tick failed: this participant cannot use the DAR"
                     );
                 } else {
                     tracing::warn!(%decparty, error = %e, "reward automation tick failed");
@@ -1657,26 +1677,30 @@ mod tests {
     }
 
     #[test]
-    fn only_the_missing_dar_error_is_quiet() {
+    fn only_an_unusable_package_is_quiet() {
         // The devnet message, verbatim. The gRPC code here is deliberately not
         // the one Canton sends: the error id is what classifies.
         let absent = anyhow::Error::new(tonic::Status::internal(
             "PACKAGE_NAMES_NOT_FOUND(11,21a20a9f): The following package names do not match \
              upgradable packages uploaded on this participant: [governance-rewards-automation-v1].",
         ));
-        assert!(package_absent(&absent));
+        assert!(package_unusable(&absent));
         // A context added on the way up must not lose the id and send the line
         // back to warn.
-        assert!(package_absent(
+        assert!(package_unusable(
             &Err::<(), _>(absent)
                 .context("reading the delegation")
                 .unwrap_err()
         ));
+        // Uploaded but unvetted, on the coupon interface read.
+        assert!(package_unusable(&canton_err(
+            "NO_VETTED_INTERFACE_IMPLEMENTATION_PACKAGE"
+        )));
 
         // Every other failure stays at warn: another ledger rejection, and one
         // that carries no ledger status at all, such as auth or transport.
-        assert!(!package_absent(&canton_err("DAML_INTERPRETATION_ERROR")));
-        assert!(!package_absent(&anyhow::anyhow!("connection refused")));
+        assert!(!package_unusable(&canton_err("DAML_INTERPRETATION_ERROR")));
+        assert!(!package_unusable(&anyhow::anyhow!("connection refused")));
     }
 
     #[test]


### PR DESCRIPTION
## What this PR does

**Old behavior**

Every decman node runs the reward automation loop, because `reward_automation_interval_secs` defaults
to 300 seconds. A node whose participant does not hold `governance-rewards-automation-v1` cannot
resolve that package name, so every sweep fails and logs a warning. That is one line per decparty,
twelve times an hour. Devnet nodes `dec-party-manager-3`, `-5` and `-6` have produced 864 such lines a
day between them.

**New behavior**

The loop now reads the Canton error id before it picks a level. It logs at `trace` when the
participant does not hold a package the automation reads, and the deployed filter
`dec_party_manager=info` drops that event before it is formatted. Every other failure still logs at
`warn`, so a genuine sweep failure keeps its warning.

Here is the quiet case on devnet. An operator recovers it by adding
`dec_party_manager::server::reward_automation=trace` to `RUST_LOG`, decparty and ledger error intact:

```
TRACE reward automation tick failed: this participant does not hold the DAR
  decparty=test-token-devnet-5::12203ea0…
  error=… PACKAGE_NAMES_NOT_FOUND(11,21a20a9f): The following package names do not match
         upgradable packages uploaded on this participant: [governance-rewards-automation-v1].
```

**The change that enables it**

- A new `package_absent()` helper answers one question: does the error carry the Canton error id
  `PACKAGE_NAMES_NOT_FOUND`?
- The loop's error arm branches on that helper. The quiet branch logs at `trace` and names the cause
  in its message; the other branch keeps the original `warn` line unchanged.

**Caveats**

- **This lowers the volume and fixes nothing.** The loop still runs on every node, and every failing
  sweep still fails. [#334](https://github.com/DLC-link/decentralization-manager/issues/334) carries
  the cause and the options for removing it, for the team to decide.
- **A node in this state now logs nothing about reward automation at the default filter.** The
  failure is unactionable, so that is the intent. The metric
  `decman_reward_sweep_failed_total` in [#325](https://github.com/DLC-link/decentralization-manager/pull/325)
  still counts it once that lands.
- The rule covers the read path only. A submission that fails on vetting is logged by
  `drain_assignable`, per coupon, at `error`. This PR does not touch that.

## Details

**What changed**

One file, `crates/decman/src/server/reward_automation.rs`. The classification reuses the existing
`canton_error_id()`, which reads the id from the message prefix of a `tonic::Status`. That helper
already backs the transient-assign rule, and it searches the whole `anyhow` chain, so a `.context(..)`
added later does not turn the line back into a warning.

**Why one error id is enough.** Canton raises three package errors on a read, and the loop can only
ever see the first. `IndexServiceImpl.checkNameTypeConRef` resolves a filter's package name against
the participant's uploaded packages, and rejects an unknown name with `PACKAGE_NAMES_NOT_FOUND`
before it checks anything else. The delegation read is also the loop's first ledger call, so the
coupon read never runs on an affected node. The remaining ids need a package that resolves by name
but lacks the template or the interface, which our own DARs cannot do.

Vetting does not reach this statement either. The read resolves names from uploaded packages, so a
DAR that a participant holds and has not vetted raises nothing here. A submission that fails on
vetting is caught by `drain_assignable()`, which absorbs every submission error and returns a count.

The failure happens on the read, not on a submission. `active_delegation()` looks up
`Governance.Rewards.CouponReassignmentDelegation` under the package name
`#governance-rewards-automation-v1`, which `default_package_config()` hardcodes. The ledger API
rejects that query with `PACKAGE_NAMES_NOT_FOUND` when the participant has never had the DAR uploaded.
A missing *delegation* is a different case: `active_delegation()` returns `Ok(None)`, the sweep
no-ops, and nothing is logged either way.

The DAR reaches a participant through the `Dars` workflow, which an operator runs. Nothing uploads it
at startup, and the image carries only the binary. So a fresh node running any release with this loop
warns until that upload happens.

**Verification**

- `DECMAN_SKIP_FRONTEND=1 cargo test -p decman` passes: 396 lib, 5 binary and 44 integration tests, 2
  ignored. That is the `main` baseline plus the one test below. The branch carries `origin/main`
  merged in.
- `cargo clippy -p decman --all-targets -- -D warnings` is clean, and `cargo fmt --all` made no
  changes.
- The new test `only_an_absent_package_is_quiet` covers both branches. It feeds the devnet message
  verbatim and asserts the quiet classification, including after a `.context(..)` wrapper. It then
  asserts that a different ledger rejection and a non-ledger failure both stay at `warn`.

**Verified on devnet.** Node `dec-party-manager-5` now runs this branch's commit image, for decparty
`test-token-devnet-5`. Its participant does not hold the DAR, so it is one of the three noisy nodes.

- Before the deploy, the pod logged 6 lines in 30 minutes. Every one was this warning, one per tick.
- After the deploy, at the unchanged filter `dec_party_manager=info`, the pod logged 15 lines in the
  first 6 minutes. All 15 are startup lines, and the reward loop logged nothing.
- After I added `dec_party_manager::server::reward_automation=trace` to `RUST_LOG`, the same failure
  came back at `TRACE`. It carries the decparty and the full `PACKAGE_NAMES_NOT_FOUND` message.
- The trace timestamps are 300 seconds apart, which is the tick interval. So the ticks kept running
  and failing through the quiet window. The line was suppressed, not absent.
- SigNoz ingests those rows as `severity_text = TRACE` and `severity_number = 1`. An operator who
  widens the filter can therefore query them by severity, not only through `kubectl`.

Two earlier measurements from devnet also stand behind the change.

**This statement accounts for all of the noise.** Grouping every log line from the three affected
devnet nodes by message and severity, over six hours, returns exactly one row: `reward automation tick
failed`, `WARN`, 216 lines. There is no second message and no other severity.

**It is the only site that can log this failure.** `main`'s `reward_automation.rs` has five `warn`
sites. Four sit in the assign path, which these nodes never reach, because they fail at the delegation
query. The fifth is the `interval_secs == 0` guard at startup.

---
[#325](https://github.com/DLC-link/decentralization-manager/pull/325) adds the failure metric ·
[#334](https://github.com/DLC-link/decentralization-manager/issues/334) removes the loop from nodes
that cannot run it
