### PR TITLE
Canton 3.5 topology audit (#60)

### DIFF
--- a/crates/decman/src/workflow/contracts/steps/sign.rs
+++ b/crates/decman/src/workflow/contracts/steps/sign.rs
@@ -286,10 +286,10 @@ fn encode_messages_length_prefixed<M: prost::Message>(messages: &[M]) -> Vec<u8>
 /// signing keys is the Daml key this node contributes to the party.
 ///
 /// The keys live in one of two places depending on when the party was
-/// onboarded: `PartyToParticipant.party_signing_keys` (Canton 3.4 — what the
+/// onboarded: `PartyToParticipant.party_signing_keys` (Canton 3.4+ — what the
 /// current onboarding submits) or a separate legacy `PartyToKeyMapping`
-/// transaction (Canton 3.3 — parties onboarded before the switch). Both are
-/// checked, newest format first.
+/// transaction (Canton 3.3 — parties onboarded before the switch; deprecated
+/// as of Canton 3.5, still served). Both are checked, newest format first.
 ///
 /// Returns the same `varint(len)||SigningPublicKey` × 2 byte layout that
 /// `read_all_messages_from_bytes` expects. Index `[0]` is unused downstream

--- a/crates/decman/src/workflow/onboarding/steps/proposals/create.rs
+++ b/crates/decman/src/workflow/onboarding/steps/proposals/create.rs
@@ -215,7 +215,8 @@ pub async fn create_proposals(
     );
 
     // Step 9: Create PartyToParticipant mapping
-    // Canton 3.4: PartyToParticipant now includes signing keys (PartyToKeyMapping is deprecated)
+    // PartyToParticipant carries the signing keys (Canton 3.4+); the standalone
+    // PartyToKeyMapping is formally deprecated as of Canton 3.5.
     let p2p_mapping = PartyToParticipant {
         party: party_id_str.clone(),
         threshold,
@@ -301,8 +302,8 @@ pub async fn create_proposals(
         .transaction
         .ok_or_else(|| anyhow::anyhow!("No P2P transaction returned"))?;
 
-    // Note: Canton 3.4+ - Signing keys are now included directly in the PartyToParticipant mapping above
-    // No separate PartyToKeyMapping transaction needed
+    // Signing keys ride in the PartyToParticipant mapping above (Canton 3.4+), so there is
+    // no separate PartyToKeyMapping transaction — that mapping is deprecated in Canton 3.5.
 
     // Step 13: Persist proposals to storage. Each protobuf is written with the
     // same `varint(len)||proto` framing the original on-disk format used.

--- a/crates/decman/src/workflow/onboarding/steps/proposals/submit.rs
+++ b/crates/decman/src/workflow/onboarding/steps/proposals/submit.rs
@@ -169,8 +169,8 @@ async fn wait_for_dns_in_topology(
 
 /// Aggregate and submit P2P proposals
 ///
-/// **Canton 3.4+**: Submits P2P proposals with embedded signing keys
-/// (replaces the separate PartyToKeyMapping transactions from Canton 3.3).
+/// **Canton 3.4+**: Submits P2P proposals with embedded signing keys, replacing the
+/// separate PartyToKeyMapping transactions of Canton 3.3 (deprecated in Canton 3.5).
 ///
 /// This step must be run once by the coordinator after all peers have signed the P2P proposals.
 /// It aggregates all signatures and submits the fully-signed proposal to Canton.


### PR DESCRIPTION
Closes #60.

Verification task, so most of this is the audit below. The code change is comment-only: the
deprecation notes said Canton 3.4/3.3, and the deprecation only became formal in 3.5.

Checked against upstream: `PartyToKeyMapping` has no `option deprecated = true` in
`release-line-3.4` and does have it in `release-line-3.5`. The "signing keys are embedded
since 3.4" half of each comment is still true, so it stays; only the deprecation half moves
to 3.5.

## 1. Nothing constructs or submits a PartyToKeyMapping

No `topology_mapping::Mapping::PartyToKeyMapping` anywhere in the tree. Every write path
builds a `PartyToParticipant`:

- onboarding `create.rs:220`
- add-party `create.rs:134`
- kick `create.rs:136`, change-threshold `create.rs:98`
- clear-onboarding `clear_onboarding.rs:181`
- external-party `steps.rs:386`

One live *read* remains, which the issue did not list: `contracts/steps/sign.rs:346` calls
`ListPartyToKeyMapping` as a fallback when `PartyToParticipant.party_signing_keys` comes back
empty, i.e. for parties onboarded before the 3.4 switch. It is a read-only backfill, not a
submission, so it does not conflict with the migration, and it still works: the RPC and the
message are present (deprecated) in `release-line-3.5` and are still present on `main`. Left
as is.

## 2. Deprecated-since comments

Updated in `onboarding/steps/proposals/create.rs` (2 sites), `onboarding/steps/proposals/submit.rs`,
and `contracts/steps/sign.rs`.

## 3. Readers tolerate a populated party_signing_keys

Nine direct `list_party_to_participant` calls, one of which is the shared
`topology::fetch_p2p_mapping` helper used by seven more sites. Two classes:

- Pure readers that ignore the field: `handlers/parties.rs:727`, `topology.rs:239`,
  onboarding `submit.rs:466` (the waiter), kick `export_state.rs:106`, kick `submit.rs:145`,
  change-threshold `submit.rs:184`, `external_party/steps.rs:602,681`,
  `contracts/steps/sign.rs:322`, add-party `submit.rs:152`, add-party `export_state.rs:50`.
- Read-modify-write paths, the ones that could silently drop the keys. Kick and
  change-threshold carry `current_p2p.party_signing_keys` through verbatim; add-party merges
  the new member's Daml key deduped by fingerprint; clear-onboarding mutates the fetched
  mapping in place and only nulls the onboarding marker. Nothing rebuilds a mapping from
  scratch, so no path wipes a party's signing keys.

Worth recording while I was in there: our vendored protos (`canton-proto-rs`, canton-lib rev
`651ea52`) track canton `main`, not `release-line-3.5`. Two differences in
`topology_manager_read_service.proto`: main wraps results in `oneof item { ... v30 = 2 }`
where 3.5 has a plain `item = 2`, and main adds `BaseQuery.client_version = 10`. Both are
wire-compatible with a 3.5 server (a single-variant oneof encodes identically to the plain
field, and we always send `client_version: None`), which is why the ITs are green against
3.5.8.

## 4. PV35 topology events: punt, and here is why

`ParticipantAuthorizationAdded/Changed/Revoked/Onboarding` are present in our vendored
`ledger-api/.../topology_transaction.proto` and unused by decman today.

Our waiters need more than participant authorization. Onboarding polls for the
`DecentralizedNamespaceDefinition` as well as the P2P mapping, and it needs the P2P mapping's
`valid_from` to compute effective time (onboarding `submit.rs:474`). The topology events carry
`party_id`, `participant_id` and `permission` plus the transaction's `record_time`, not the DNS
mapping and not the mapping's `valid_from`. An event-driven waiter would therefore replace only
part of the polling while adding a ledger-API stream consumer alongside the admin-API path we
already have.

The one place where it would pay off if we revisit: add-party's flag-clearing round could key
off `ParticipantAuthorizationOnboarding` to `ParticipantAuthorizationAdded` instead of
`wait_for_flag_cleared`'s poll loop (`clear_onboarding.rs:331`).

## 5. ITs against a Canton 3.5 backend

Already covered. `integration-tests/env.sh:19` pins `LOCALNET_VERSION=0.6.12`, and splice
`v0.6.12`'s `nix/canton-sources.json` pins Canton `3.5.8`, so every PR's IT run has been
exercising a 3.5 backend since the localnet bump. Deployed environments are on the infra side,
not this repo.
