### PR TITLE
Four developer-experience follow-ups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,6 +513,8 @@ checksum = "1b180a3c8b55960db3426d8964b8745e652466a1a49fe1a2eda828046d30b5e4"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
  "aws-sdk-sts",
  "aws-smithy-async",
  "aws-smithy-http",
@@ -524,11 +526,14 @@ dependencies = [
  "aws-types",
  "bytes",
  "fastrand",
+ "hex",
  "http 1.4.0",
+ "sha1 0.10.6",
  "time",
  "tokio",
  "tracing",
  "url",
+ "zeroize",
 ]
 
 [[package]]
@@ -596,6 +601,58 @@ name = "aws-sdk-kms"
 version = "1.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b7d906608ee41e7ddea9983577ba82200435644d567d63dc34e822e088b453"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.105.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ffd0fbe7873cb548a7aa60f9573c268fff94155397fd4f14dc9f1ecaaab8516"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.107.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175763eb222a46377df7aa257a3bca980ab3e96703fefc8f4d0b8da6ad2e254c"
 dependencies = [
  "arc-swap",
  "aws-credential-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ actix-web = { version = "4" }
 aes-gcm = { version = "0.11" }
 anyhow = { version = "1.0.98" }
 async-trait = { version = "0.1" }
-aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio", "default-https-client"] }
+aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "default-https-client", "rt-tokio", "sso"] }
 aws-sdk-kms = { version = "1", default-features = false, features = ["rt-tokio", "default-https-client"] }
 base64 = { version = "0.23" }
 bytes = { version = "1.11.1" }

--- a/crates/decman/build.rs
+++ b/crates/decman/build.rs
@@ -2,9 +2,11 @@ use std::{path::Path, process::Command};
 
 fn main() {
     // The frontend's TypeScript wire types are generated from the Rust DTOs by
-    // the `gen-types` binary (ts-rs) and committed to the repo — see
-    // `crates/decman/src/bin/gen_types.rs` and `just gen-types`. This build
-    // script only compiles and embeds the frontend bundle.
+    // the `gen-types` binary (ts-rs) and are gitignored — see
+    // `crates/decman/src/bin/gen_types.rs` and `just gen-types`. CI regenerates
+    // them before every frontend build. This build script only compiles and
+    // embeds the frontend bundle; it cannot generate the types itself, because
+    // the generator is a binary in this same crate.
     //
     // `DECMAN_SKIP_FRONTEND=1` skips the (slow) npm build while iterating on the
     // Rust side locally. CI and release builds leave it unset.
@@ -57,5 +59,18 @@ fn build_frontend() {
         .status()
         .expect("Failed to run npm build");
 
-    assert!(status.success(), "Frontend build failed");
+    let generated_types = frontend_dir.join("src/types.generated.ts");
+    assert!(
+        status.success(),
+        "Frontend build failed.\n\
+         \n\
+         If the error above is TypeScript rejecting a property that should \
+         exist, {} is stale. It is generated from the Rust DTOs and \
+         gitignored, so merging or rebasing onto main brings new backend \
+         fields without the matching types, and nothing prompts a \
+         regeneration.\n\
+         \n\
+         Fix: run `just gen-types`, then build again.",
+        generated_types.display()
+    );
 }

--- a/crates/decman/tests/common/operator.rs
+++ b/crates/decman/tests/common/operator.rs
@@ -23,11 +23,23 @@ pub fn operator_response_timeout_devnet() -> Duration {
 const POLL_INTERVAL: Duration = Duration::from_millis(500);
 
 #[derive(Debug, Error)]
-#[error("operator automation did not produce {awaited} for action {action} within {elapsed:?}")]
-pub struct OperatorAutomationTimeout {
-    pub action: String,
-    pub awaited: String,
-    pub elapsed: Duration,
+pub enum OperatorAutomationFailure {
+    /// This wait polled for its full budget and produced nothing.
+    #[error("operator automation did not produce {awaited} for action {action} within {elapsed:?}")]
+    Timeout {
+        action: String,
+        awaited: String,
+        elapsed: Duration,
+    },
+    /// An *earlier* wait timed out and tripped the fixture's circuit breaker,
+    /// so this one bailed without polling. Reported separately because the
+    /// timeout that matters happened in a previous phase, and a shared
+    /// `elapsed` field could only have described this one.
+    #[error(
+        "skipped waiting for {awaited} on action {action}: an earlier operator-automation wait \
+         already timed out and tripped the suite's circuit breaker"
+    )]
+    BreakerTripped { action: String, awaited: String },
 }
 
 /// Poll `path` on `port`, deserialize the response as `R`, and call
@@ -49,10 +61,9 @@ where
     F: Fn(R) -> Option<String>,
 {
     if f.operator_timeout_tripped {
-        anyhow::bail!(OperatorAutomationTimeout {
+        anyhow::bail!(OperatorAutomationFailure::BreakerTripped {
             action: action.to_string(),
             awaited: awaited.to_string(),
-            elapsed: Duration::ZERO,
         });
     }
 
@@ -67,7 +78,7 @@ where
         }
         if start.elapsed() >= timeout {
             f.operator_timeout_tripped = true;
-            anyhow::bail!(OperatorAutomationTimeout {
+            anyhow::bail!(OperatorAutomationFailure::Timeout {
                 action: action.to_string(),
                 awaited: awaited.to_string(),
                 elapsed: start.elapsed(),
@@ -155,7 +166,14 @@ mod tests {
         )
         .await
         .unwrap_err();
-        assert!(format!("{err:#}").contains("TestAction"));
+        let msg = format!("{err:#}");
+        assert!(msg.contains("TestAction"));
+        // A real timeout reports as one, and carries the elapsed budget.
+        assert!(msg.contains("did not produce"), "unexpected message: {msg}");
+        assert!(
+            !msg.contains("circuit breaker"),
+            "unexpected message: {msg}"
+        );
         assert!(f.operator_timeout_tripped);
     }
 
@@ -178,7 +196,15 @@ mod tests {
         )
         .await
         .unwrap_err();
-        assert!(format!("{err:#}").contains("TestAction"));
+        let msg = format!("{err:#}");
+        assert!(msg.contains("TestAction"));
+        // The pre-tripped path must not read as a 0ns timeout of its own.
+        assert!(msg.contains("circuit breaker"), "unexpected message: {msg}");
+        assert!(
+            !msg.contains("did not produce"),
+            "unexpected message: {msg}"
+        );
+        assert!(!msg.contains("0ns"), "unexpected message: {msg}");
 
         // Verify the breaker short-circuited BEFORE any HTTP call — wiremock
         // received zero requests on the mounted MockServer.

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -166,8 +166,9 @@ if [ ! -f "$BINARY" ]; then
     exit 1
 fi
 
-# Localnet
-log_phase "Starting localnet"
+# Canton bring-up. Both hooks are target-polymorphic: devnet.env.sh redefines
+# download_localnet as a no-op and start_localnet as start_canton_tunnels.
+log_phase "Starting Canton ($TARGET)"
 download_localnet
 start_localnet
 


### PR DESCRIPTION
Four developer-experience items from the backlog. No production behaviour changes; the one runtime-visible change is a dependency feature.

### #321 — `aws-config` built without `sso`

`default-features = false` dropped `sso`, one of `aws-config`'s defaults, so the SSO credential provider was never compiled in. A developer with an AWS SSO profile could not exercise decman's AWS paths locally even though `aws --profile <same>` worked:

```
ProfileFile provider could not be built:
This behavior requires following cargo feature(s) enabled: sso
```

Adds exactly two crates to the lock (`aws-sdk-sso`, `aws-sdk-ssooidc`), nothing else. Sorted the feature list while there, per the Cargo conventions.

Flagging the trade-off since the `default-features = false` was presumably deliberate: this does put two more SDK crates in the release binary. If keeping them out of the shipped image matters more than local SSO, say so and I will back it out.

### #280 — "Frontend build failed" named nothing

`build.rs` reported every npm failure with that bare string, naming neither TypeScript nor the generated types. The usual cause has to be known in advance to be recognised: `types.generated.ts` is gitignored, so a branch that merges main carries a stale copy predating any backend DTO field that arrived with the merge, and `tsc` rejects the frontend reading it.

The panic now names the file and `just gen-types`.

Also corrects the header comment, which claimed the generated types are **committed and CI-checked**. They are gitignored (`crates/decman/frontend/.gitignore:17`) and CI regenerates them before each frontend build. That comment would have sent the next reader looking for a file that is not in git.

### #167 — banner said "localnet" on a devnet run

`run.sh --target devnet` printed `Starting localnet` immediately before opening kubectl port-forwards to devnet. Purely cosmetic: the hooks are already target-polymorphic (`devnet.env.sh` redefines `download_localnet` as a no-op and `start_localnet` as `start_canton_tunnels`); only the banner and its section comment hardcoded the target.

Left `env.sh`'s own `Starting localnet...` alone — that one lives inside the localnet implementation of the hook, where it is accurate.

### #150 — 0ns timeouts in the operator harness

The circuit-breaker fast-fail path reused `OperatorAutomationTimeout` with `elapsed: Duration::ZERO`, so once the first phase timed out, every later phase reported as a 0-nanosecond timeout. That reads like an instant failure of the phase you are looking at, when the real timeout was in an earlier one.

`OperatorAutomationFailure` now has two variants: `Timeout` keeps `elapsed`, `BreakerTripped` has no such field because there was no wait to measure. Both existing tests now assert the variant they mean instead of only that the action name appears.

### Checks

`cargo fmt --check` and `cargo clippy --all-targets --all-features --no-deps -D warnings` clean locally; `bash -n` on run.sh. One commit per issue.

Closes #321, closes #280, closes #167, closes #150

