### PR TITLE
Force a topology refresh when filtering parties by prefix

### DIFF
--- a/crates/decman/frontend/src/App.tsx
+++ b/crates/decman/frontend/src/App.tsx
@@ -678,7 +678,7 @@ const App = () => {
               onChange={(e) => setPartyFilter(e.target.value)}
               onKeyDown={(e) => {
                 if (e.key === "Enter") {
-                  refreshParties();
+                  refreshParties(true);
                 }
               }}
               disabled={refreshingParties}
@@ -721,7 +721,7 @@ const App = () => {
               </span>
             </Tooltip>
             <IconButton
-              onClick={() => refreshParties()}
+              onClick={() => refreshParties(true)}
               disabled={refreshingParties}
               color="primary"
               sx={{
@@ -914,7 +914,7 @@ const App = () => {
                       onChange={(e) => setPartyFilter(e.target.value)}
                       onKeyDown={(e) => {
                         if (e.key === "Enter") {
-                          refreshParties();
+                          refreshParties(true);
                         }
                       }}
                       disabled={refreshingParties}
@@ -950,7 +950,7 @@ const App = () => {
                       </span>
                     </Tooltip>
                     <IconButton
-                      onClick={() => refreshParties()}
+                      onClick={() => refreshParties(true)}
                       disabled={refreshingParties}
                       color="primary"
                       sx={{ mt: "1px" }}


### PR DESCRIPTION
One frontend fix. The batch started as two, but #312 turned out to be already fixed on main (#255 restructured the delegation beneficiary row in `beaf02b`), so it is closed with no change.

### #206 — prefix filter did not force a topology refresh

Applying a prefix filter queried `/decentralized-parties?prefix=…` **without** `refresh=true`, so a freshly-onboarded party stayed invisible in the filtered result until the node's periodic topology refresh caught up — reported at up to a few minutes. The party existed the whole time; `&refresh=true` returned it immediately.

The bad moment is right after Create Party: the user filters for the party they just created and the list is empty.

Went slightly wider than the report. The filter UI is duplicated across a wide and a narrow layout, so there are **four** apply-the-filter entry points, not one:

| Site | What it is |
|---|---|
| `App.tsx:681` | Enter in the filter field (wide) |
| `App.tsx:724` | Search button (wide) |
| `App.tsx:917` | Enter in the filter field (narrow) |
| `App.tsx:953` | Search button (narrow) |

All four now force. Fixing only the reported one would have left the same bug live on whichever screen width was missed.

Deliberately left unforced: `App.tsx:382`, the unfiltered periodic load. That is the background poll, not a user asking after a specific party, and forcing it would put a topology read on every tab switch.

### Checks

`npx tsc --noEmit -p tsconfig.app.json` clean.

Worth noting for #280 (in PR #341): the first typecheck on this branch failed with `Property 'proposer' does not exist on type 'DomainGovernanceAction'` — the stale-`types.generated.ts` trap, hit for real while doing this. `just gen-types` fixed it. That PR's better panic message is the thing that would have named the cause.

Closes #206
