### PR TITLE
Parallelize the release binary build, and verify committed DARs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,6 +239,7 @@ jobs:
         run: |
           set -uo pipefail
           rc=0
+          compared=0
           matched=""
           for built in */.daml/dist/*.dar; do
             [ -e "$built" ] || continue
@@ -246,6 +247,7 @@ jobs:
             committed="../releases/v1/$base"
             [ -f "$committed" ] || continue
             matched="$matched $base"
+            compared=$((compared + 1))
             if cmp -s "$built" "$committed"; then
               echo "ok        $base"
             else
@@ -255,12 +257,23 @@ jobs:
           done
           echo
           for committed in ../releases/v1/*.dar; do
+            [ -e "$committed" ] || continue
             base=$(basename "$committed")
             case " $matched " in
               *" $base "*) ;;
               *) echo "not rebuilt (no current source at this version): $base" ;;
             esac
           done
+          # Zero comparisons means the gate verified nothing — a moved build
+          # output, a changed working-directory or a renamed releases/ would
+          # otherwise leave it passing while checking no DAR at all. There is
+          # always at least one package whose built name matches a committed
+          # one, so zero is a broken job, not a legitimate state.
+          if [ "$compared" -eq 0 ]; then
+            echo "::error::Verified no DARs at all. Expected at least one built DAR whose name matches a file in releases/v1/ — check the build output path and this step's working-directory."
+            rc=1
+          fi
+          echo "compared $compared DAR(s)"
           exit $rc
       - name: Test governance-core
         run: cd governance-core-test && ~/.dpm/bin/dpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,6 +224,44 @@ jobs:
         run: ~/.dpm/bin/dpm install 3.4.11
       - name: Build
         run: ~/.dpm/bin/dpm build --all
+      # No reviewer can read a DAR by eye, so a stale or hand-edited binary in
+      # releases/v1/ would otherwise pass review and ship. `dpm build` is
+      # byte-reproducible for a pinned SDK, so a plain `cmp` is the check.
+      #
+      # Only DARs whose freshly-built name+version still exists in releases/v1/
+      # are compared. A committed DAR with no current source is reported, not
+      # failed, because that is a legitimate state in two ways: a superseded
+      # version kept for the upgrade path (governance-utility-onboarding-v1
+      # 0.1.0 next to the current 0.2.0), and a package since renamed (the
+      # three governance-rewards-v1 DARs, now governance-rewards-automation-v1).
+      # Read the "not rebuilt" list: anything there is unverifiable by this job.
+      - name: Verify committed DARs match a fresh build
+        run: |
+          set -uo pipefail
+          rc=0
+          matched=""
+          for built in */.daml/dist/*.dar; do
+            [ -e "$built" ] || continue
+            base=$(basename "$built")
+            committed="../releases/v1/$base"
+            [ -f "$committed" ] || continue
+            matched="$matched $base"
+            if cmp -s "$built" "$committed"; then
+              echo "ok        $base"
+            else
+              echo "::error file=releases/v1/$base::$base differs from a fresh build of its source. Rebuild with 'dpm build' and commit the result, or revert the source change."
+              rc=1
+            fi
+          done
+          echo
+          for committed in ../releases/v1/*.dar; do
+            base=$(basename "$committed")
+            case " $matched " in
+              *" $base "*) ;;
+              *) echo "not rebuilt (no current source at this version): $base" ;;
+            esac
+          done
+          exit $rc
       - name: Test governance-core
         run: cd governance-core-test && ~/.dpm/bin/dpm test
       - name: Test governance-token-custody

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,13 @@ jobs:
           fi
           echo "Tag $GITHUB_REF_NAME matches crate version v$crate_version"
 
+  # Deliberately does NOT wait for `ci`: the binary build consumes nothing CI
+  # produces, so gating it on the ~29m integration tests only serialized two
+  # independent jobs. `docker` gates on both, so nothing unverified is ever
+  # published — a CI failure still blocks the push, it just no longer blocks
+  # the compile that runs alongside it.
   binary:
-    needs: [ci, verify-tag]
+    needs: [verify-tag]
     uses: ./.github/workflows/build-binary.yml
     with:
       profile: release
@@ -39,7 +44,7 @@ jobs:
 
   docker:
     name: Build & Push Public Image
-    needs: binary
+    needs: [ci, binary]
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
Two CI items. Both verified locally rather than shipped on reasoning.

### #331 — the release binary waited on the whole CI suite

`release.yml` had `binary: needs: [ci, verify-tag]`, but the binary build consumes nothing CI produces, so the 14m compile only started once the 29m integration tests had finished. That serialization was most of the ~45m a tag took to produce an image.

`binary` now needs only `verify-tag`; `docker` needs both `ci` and `binary`. The safety property is unchanged — a CI failure still blocks the push, it just no longer blocks the compile running beside it. Job graph after the change:

| job | needs |
|---|---|
| `ci` | — |
| `verify-tag` | — |
| `binary` | `verify-tag` |
| `docker` | `ci`, `binary` |

Should take roughly 15m off a release. I did not touch the second proposal in the issue (caching release-profile artifacts) — tags are rare so the cache is always cold, and it is a bigger change with its own tradeoffs.

### #293 — nothing checked the committed DARs

`releases/v1/` holds binaries no reviewer can read by eye, and CI never rebuilt them, so a stale or hand-edited DAR would pass.

The check rests on `dpm build` being byte-reproducible for a pinned SDK. I verified that rather than assuming it, because a flaky gate here would be worse than no gate. Against a full `dpm build --all` locally, **all seven DARs with current source matched byte for byte**:

```
ok        governance-action-v1-0.1.0.dar
ok        governance-core-v1-0.1.0.dar
ok        governance-rewards-automation-v1-0.1.0.dar
ok        governance-token-custody-v1-0.1.0.dar
ok        governance-utility-credential-v1-0.1.0.dar
ok        governance-utility-onboarding-v1-0.2.0.dar
ok        orphan-marker-0.1.0.dar
```

That includes the data-dependency chain (`governance-action` → `governance-core`) and `governance-utility-onboarding-v1-0.2.0`, the one a reviewer had checked by hand on #292.

Runs as a step inside the existing `daml` job, so it reuses the cached SDK and adds seconds rather than a second toolchain install.

**What it does not cover, and this is worth knowing.** Four committed DARs have no source at their version, so they are listed and skipped rather than failed:

- `governance-utility-onboarding-v1-0.1.0` — superseded by 0.2.0, kept for the upgrade path. Expected.
- `governance-rewards-v1-0.1.0`, `-0.1.1`, `-0.1.3` — **no package in this repo declares `governance-rewards-v1` at all.** It was renamed to `governance-rewards-automation-v1` (see `daml/governance-rewards-automation/README.md:34`), because the required `dso` field was not an SCU-compatible upgrade.

Nothing in the tree references those three any more — the IT distributes `governance-rewards-automation-v1-0.1.0.dar` and `config.rs` defaults to `#governance-rewards-automation-v1`. They look like dead artifacts, but they reached devnet, so deleting them is a call for whoever owns the upgrade story rather than a drive-by in a CI PR. Flagging it here; happy to remove them in a follow-up if you want them gone.

Note this also dates part of #273, which describes `governance-rewards-v1-0.1.3` as the vetted DAR the localnet IT distributes.

Closes #331, closes #293
