### PR TITLE
Add-party review follow-ups: shared helpers and dead UI

### DIFF
--- a/crates/decman/frontend/src/components/AddPartyDialog.tsx
+++ b/crates/decman/frontend/src/components/AddPartyDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect } from "react";
 import {
   Dialog,
   DialogTitle,
@@ -16,11 +16,7 @@ import { API_BASE } from "../constants";
 import { authenticatedFetch } from "../api";
 import { useSnackbar } from "../contexts";
 import { fieldHelpAdornment } from "./FieldHelp";
-import type {
-  AddPartyRequest,
-  AddPartyStatusResponse,
-  Peer,
-} from "../types";
+import type { AddPartyRequest, Peer } from "../types";
 
 interface AddPartyDialogProps {
   open: boolean;
@@ -47,7 +43,6 @@ export const AddPartyDialog = ({
   const [newThreshold, setNewThreshold] = useState(1);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [status, setStatus] = useState<AddPartyStatusResponse | null>(null);
   const [peers, setPeers] = useState<Peer[]>([]);
   const [loadingPeers, setLoadingPeers] = useState(false);
   const { showSnackbar } = useSnackbar();
@@ -90,48 +85,11 @@ export const AddPartyDialog = ({
   useEffect(() => {
     if (!open) {
       setError(null);
-      setStatus(null);
       setLoading(false);
       setNewParticipantId("");
     }
   }, [open]);
 
-  const pollStatus = useCallback(async () => {
-    try {
-      const res = await authenticatedFetch(`${API_BASE}/add-party/status`);
-      if (res.ok) {
-        const data: AddPartyStatusResponse = await res.json();
-        if (data.status === "cancelled") {
-          showSnackbar("Add member workflow cancelled");
-          onClose();
-          return;
-        }
-        setStatus(data);
-        if (data.status !== "inprogress") {
-          setLoading(false);
-          if (data.status === "completed") {
-            onAddComplete();
-          }
-        }
-      }
-    } catch {
-      // Ignore polling errors
-    }
-  }, [onAddComplete, onClose, showSnackbar]);
-
-  useEffect(() => {
-    let interval: number | undefined;
-
-    if (status?.status === "inprogress") {
-      // Poll immediately, then every 2 seconds
-      pollStatus();
-      interval = window.setInterval(pollStatus, 2000);
-    }
-
-    return () => {
-      if (interval) clearInterval(interval);
-    };
-  }, [status?.status, pollStatus]);
 
   const handleAdd = async () => {
     setLoading(true);
@@ -165,27 +123,6 @@ export const AddPartyDialog = ({
     } catch (err) {
       setError(err instanceof Error ? err.message : "Unknown error");
       setLoading(false);
-    }
-  };
-
-  const [cancelling, setCancelling] = useState(false);
-  const handleCancelWorkflow = async () => {
-    setCancelling(true);
-    try {
-      const res = await authenticatedFetch(`${API_BASE}/add-party/cancel`, {
-        method: "POST",
-      });
-      if (res.ok) {
-        showSnackbar("Add member workflow cancelled");
-        onClose();
-      } else {
-        const data = await res.json().catch(() => ({}));
-        setError(data.error || "Failed to cancel workflow");
-      }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to cancel workflow");
-    } finally {
-      setCancelling(false);
     }
   };
 
@@ -276,62 +213,25 @@ export const AddPartyDialog = ({
               {error}
             </Alert>
           )}
-
-          {status?.status === "inprogress" && (
-            <Alert severity="info" icon={<CircularProgress size={20} />}>
-              Add member workflow in progress... This may take a few minutes.
-            </Alert>
-          )}
-
-          {status?.status === "completed" && (
-            <Alert severity="success">
-              Participant has been successfully added to the party.
-            </Alert>
-          )}
-
-          {status?.status === "failed" && (
-            <Alert severity="error">
-              Add member workflow failed: {status.error || "Unknown error"}
-            </Alert>
-          )}
         </Box>
       </DialogContent>
       <DialogActions>
         <Button onClick={handleClose} disabled={loading}>
-          {status?.status === "completed" ||
-          status?.status === "failed" ||
-          status?.status === "inprogress"
-            ? "Close"
-            : "Cancel"}
+          Cancel
         </Button>
-        {status?.status === "inprogress" && (
-          <Button
-            onClick={handleCancelWorkflow}
-            variant="outlined"
-            color="error"
-            disabled={cancelling}
-            startIcon={cancelling ? <CircularProgress size={16} /> : undefined}
-          >
-            {cancelling ? "Cancelling…" : "Cancel Workflow"}
-          </Button>
-        )}
-        {!status?.status ||
-        status.status === "idle" ||
-        status.status === "failed" ? (
-          <Button
-            onClick={handleAdd}
-            variant="contained"
-            color="primary"
-            disabled={
-              loading ||
-              !newParticipantId ||
-              newThreshold < 1 ||
-              newThreshold > newOwnerCount
-            }
-          >
-            {loading ? <CircularProgress size={20} /> : "Add Member"}
-          </Button>
-        ) : null}
+        <Button
+          onClick={handleAdd}
+          variant="contained"
+          color="primary"
+          disabled={
+            loading ||
+            !newParticipantId ||
+            newThreshold < 1 ||
+            newThreshold > newOwnerCount
+          }
+        >
+          {loading ? <CircularProgress size={20} /> : "Add Member"}
+        </Button>
       </DialogActions>
     </Dialog>
   );

--- a/crates/decman/src/server/handlers/workflows.rs
+++ b/crates/decman/src/server/handlers/workflows.rs
@@ -898,19 +898,11 @@ pub async fn start_add_party(
         });
     }
 
-    if !data.workflows.insert(instance.clone()) {
-        return HttpResponse::Conflict().json(ErrorResponse {
-            error: format!(
-                "A workflow with instance {} is already running",
-                instance.instance_name
-            ),
-        });
-    }
-
-    if let Err(e) = insert_coordinator_run(
-        &data.db,
-        &instance_name,
-        WorkflowKind::AddParty,
+    // Register + persist atomically w.r.t. duplicates (registry insert dedups
+    // before the upsert; a persist failure unregisters so nothing leaks).
+    if let Err(resp) = register_and_persist(
+        &data,
+        &instance,
         AddPartyStep::WaitingForPeers,
         &add_party_config,
         &invitees,
@@ -918,11 +910,7 @@ pub async fn start_add_party(
     )
     .await
     {
-        data.workflows.remove(&instance_name);
-        tracing::warn!("Failed to persist add-party workflow run: {e:#}");
-        return HttpResponse::Conflict().json(ErrorResponse {
-            error: format!("Failed to start add-party workflow: {e}"),
-        });
+        return resp;
     }
 
     let invitees_for_invites = invitees.clone();

--- a/crates/decman/src/workflow/add_party/steps/export_state.rs
+++ b/crates/decman/src/workflow/add_party/steps/export_state.rs
@@ -5,7 +5,7 @@ use crate::{
     error::Result,
     utils,
     workflow::{
-        add_party::{AddPartyConfig, steps::generate_keys::current_ledger_offset},
+        add_party::{AddPartyConfig, steps::generate_keys::capture_offset_once},
         storage::{WorkflowStorage, artifact_kinds},
         topology,
     },
@@ -78,24 +78,16 @@ pub async fn export_state(
         .await?;
     tracing::info!("Saved namespace definition to storage");
 
-    // Capture the export offset exactly once: a resumed run that re-enters
-    // ExportState after the topology already activated must NOT move the
-    // offset forward past the activation, or ExportPartyAcs won't find it.
-    let existing = storage
-        .read_artifact(instance_name, artifact_kinds::ADD_PARTY_EXPORT_OFFSET, None)
-        .await?;
-    if existing.is_none() {
-        let offset = current_ledger_offset(config, ledger_token).await?;
-        storage
-            .write_artifact(
-                instance_name,
-                artifact_kinds::ADD_PARTY_EXPORT_OFFSET,
-                None,
-                offset.to_string().as_bytes(),
-            )
-            .await?;
-        tracing::info!("Captured pre-activation export offset {offset}");
-    }
+    capture_offset_once(
+        config,
+        storage,
+        instance_name,
+        artifact_kinds::ADD_PARTY_EXPORT_OFFSET,
+        None,
+        ledger_token,
+        "pre-activation export",
+    )
+    .await?;
 
     tracing::info!("Add-party state exported successfully");
     Ok(())

--- a/crates/decman/src/workflow/add_party/steps/generate_keys.rs
+++ b/crates/decman/src/workflow/add_party/steps/generate_keys.rs
@@ -92,30 +92,53 @@ pub async fn generate_keys(
         )
         .await?;
 
-    // Capture this participant's pre-activation ledger offset. Idempotent on
-    // retry by design: only the FIRST capture is kept, so a retry after the
-    // topology already activated can't move the offset past the activation.
-    let existing_offset = storage
-        .read_artifact(
-            instance_name,
-            artifact_kinds::ADD_PARTY_PRE_ACTIVATION_OFFSET,
-            Some(&self_id),
-        )
-        .await?;
-    if existing_offset.is_none() {
-        let offset = current_ledger_offset(config, ledger_token).await?;
-        storage
-            .write_artifact(
-                instance_name,
-                artifact_kinds::ADD_PARTY_PRE_ACTIVATION_OFFSET,
-                Some(&self_id),
-                offset.to_string().as_bytes(),
-            )
-            .await?;
-        tracing::info!("Captured pre-activation ledger offset {offset}");
-    }
+    capture_offset_once(
+        config,
+        storage,
+        instance_name,
+        artifact_kinds::ADD_PARTY_PRE_ACTIVATION_OFFSET,
+        Some(&self_id),
+        ledger_token,
+        "pre-activation",
+    )
+    .await?;
 
     tracing::info!("Add-party keys persisted to workflow_artifacts");
+    Ok(())
+}
+
+/// Capture this participant's ledger offset into `kind` exactly once.
+///
+/// Both add-party offsets (`ADD_PARTY_PRE_ACTIVATION_OFFSET`, scoped to the
+/// participant, and `ADD_PARTY_EXPORT_OFFSET`, unscoped) exist to name a point
+/// BEFORE the party is activated. A resumed run that re-enters its step after
+/// the activation must therefore keep the original value: re-capturing would
+/// move the offset past the activation, and `ExportPartyAcs` /
+/// `ClearPartyOnboardingFlag` would then look for it in a window that no longer
+/// contains it.
+///
+/// So the first capture wins and later calls are a no-op.
+pub(crate) async fn capture_offset_once(
+    config: &NodeConfig,
+    storage: &SqlitePool,
+    instance_name: &str,
+    kind: &str,
+    scope: Option<&str>,
+    ledger_token: Option<&str>,
+    label: &str,
+) -> Result {
+    if storage
+        .read_artifact(instance_name, kind, scope)
+        .await?
+        .is_some()
+    {
+        return Ok(());
+    }
+    let offset = current_ledger_offset(config, ledger_token).await?;
+    storage
+        .write_artifact(instance_name, kind, scope, offset.to_string().as_bytes())
+        .await?;
+    tracing::info!("Captured {label} ledger offset {offset}");
     Ok(())
 }
 


### PR DESCRIPTION
The cleanup checklist from #222 (its item 2). **#222 stays open** for item 1 — peer signatures living only in memory across a coordinator restart — which is the substantive one and not a cleanup.

Checking each item against the code first turned up that one was already done.

### `start_add_party` now uses `register_and_persist`

It was the only one of the six `start_*` handlers still inlining the register-or-409 / persist-or-unregister sequence. The other five — kick, change-threshold, onboarding, contracts, dars — already call the shared helper, and the helper exists precisely so that contract cannot drift between handlers.

Behaviour is identical: the helper maps `WorkflowKind::AddParty` to the same `"add-party"` label, so both 409 bodies read exactly as before.

### `capture_offset_once`

`generate_keys` and `export_state` each hand-rolled read-artifact → if-absent → capture → write-artifact, differing only in the artifact kind and whether it is participant-scoped.

They exist for the same reason — the offset must name a point *before* the party is activated, so a resumed run re-entering its step after activation has to keep the original value. Worth stating once, in the helper, so the two cannot drift apart on the invariant they share.

### The add-party dialog's progress UI was unreachable

`handleAdd` calls `onClose()` on success, so the dialog is gone before progress could render. But the machinery could never have run regardless: `status` was only ever set by `pollStatus`, and `pollStatus` only ran from an effect gated on `status?.status === "inprogress"` — the poller could only start if it had already started.

Removed the `status` state, `pollStatus` and its interval effect, the in-progress/completed/failed alerts, the Close-vs-Cancel label ternary, the Cancel Workflow button and its `cancelling` state, and two now-unused imports. **16 insertions, 116 deletions.**

The backend endpoints stay — `/add-party/cancel` is still used by decman-cli (`api.rs:1010`). This removes dead UI, not the API behind it. Progress lives in the Pending approvals feed, which is where `handleAdd` already sends the user.

### Already done, no change needed

> Consolidate the 6 copies of the `varint(len)||proto` encoder (`encode_length_prefixed_message`) into one `utils` helper

Done by #233. It lives once at `utils.rs:109` and all 11 call sites go through `utils::encode_length_prefixed_message`. Ticking that box on the issue.

### Deliberately not done

> Drop the no-op `PrepareClearOnboarding` beat

Not a cleanup — it changes the step enum *and* the frontend's `index/13` progress denominator. Wants its own change.

### Checks

`cargo fmt --check` and `cargo clippy --all-targets --all-features --no-deps -D warnings` clean; `tsc --noEmit` clean on the frontend. One commit per item.
