### PR TITLE
Document the WARN lines chaos phases are expected to emit

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,17 +618,24 @@ so individual test cases narrate.
 
 The chaos phases (`restart_coordinator_resume`, `restart_peer_resume`,
 `invite_survives_peer_restart`, `retry_with_offline_peer`,
-`peer_3_strikes_abort`, `restart_with_concurrent_kinds`) kill and restart
-nodes on purpose. The lines below are the node correctly reporting what the
-test just did to it, so read them as part of the scenario rather than as
-findings. Anything **not** on this list is worth a look.
+`restart_with_concurrent_kinds`, `peer_health_flip`) kill and restart nodes
+on purpose. The lines below are the surviving nodes correctly reporting what
+the test just did to their peers, so read them as part of the scenario rather
+than as findings. Anything **not** on this list is worth a look.
 
-| Line | Source | Why it fires |
+(`peer_3_strikes_abort` is named G8 in the suite but is currently a skipped
+stub — it needs a raw-Noise-frame injection harness — so it kills nothing and
+emits none of this.)
+
+Grep the message text to find these; the emitting function is named so the
+reference survives the code moving.
+
+| Line | Emitted by | Why it fires |
 |---|---|---|
-| `Failed to send <label> to <participant>: TCP connection failed: … Connection refused` | `handlers/workflows.rs:3547` | The peer was killed by the phase. One shared broadcast helper, so `<label>` is whichever message was in flight — `CancelInvite`, `RetryWorkflow`, an invite. |
-| `Onboarding rejected: N missing peer mesh edge(s)` | `handlers/workflows.rs:1589` | The mesh is genuinely incomplete while a node is down. |
-| `Participant owner_key unresolved after onboarding` | `handlers/workflows.rs:1802` | The run was interrupted before it reached key resolution. |
-| `Best-effort CancelInvite to <peer> after decline failed` | `noise/server.rs:604` | Best-effort by name: the peer it would notify is the one that was killed. |
+| `Failed to send <label> to <participant>: TCP connection failed: … Connection refused` | `handlers::workflows::broadcast_simple_message` | The peer was killed by the phase. One shared broadcast helper, so `<label>` is whichever message was in flight — `CancelInvite`, `RetryWorkflow`, an invite. |
+| `Onboarding rejected: N missing peer mesh edge(s)` | `handlers::workflows::start_onboarding` | The mesh is genuinely incomplete while a node is down. |
+| `Participant owner_key unresolved after onboarding` | `handlers::workflows::start_onboarding` | The run was interrupted before it reached key resolution. |
+| `Best-effort CancelInvite to <peer> after decline failed` | `noise::server::broadcast_cancel_to_others` | Best-effort by name: the peer it would notify is the one that was killed. |
 
 Each is a real condition the code detects correctly, which is why none is
 downgraded — in production every one of them warrants a WARN. The two

--- a/README.md
+++ b/README.md
@@ -614,6 +614,33 @@ Surfaces all dec-party-manager INFO output (peer connections, Noise
 handshakes, workflow internals). The cargo test runner is also INFO,
 so individual test cases narrate.
 
+#### Expected WARN noise during chaos phases
+
+The chaos phases (`restart_coordinator_resume`, `restart_peer_resume`,
+`invite_survives_peer_restart`, `retry_with_offline_peer`,
+`peer_3_strikes_abort`, `restart_with_concurrent_kinds`) kill and restart
+nodes on purpose. The lines below are the node correctly reporting what the
+test just did to it, so read them as part of the scenario rather than as
+findings. Anything **not** on this list is worth a look.
+
+| Line | Source | Why it fires |
+|---|---|---|
+| `Failed to send <label> to <participant>: TCP connection failed: … Connection refused` | `handlers/workflows.rs:3547` | The peer was killed by the phase. One shared broadcast helper, so `<label>` is whichever message was in flight — `CancelInvite`, `RetryWorkflow`, an invite. |
+| `Onboarding rejected: N missing peer mesh edge(s)` | `handlers/workflows.rs:1589` | The mesh is genuinely incomplete while a node is down. |
+| `Participant owner_key unresolved after onboarding` | `handlers/workflows.rs:1802` | The run was interrupted before it reached key resolution. |
+| `Best-effort CancelInvite to <peer> after decline failed` | `noise/server.rs:604` | Best-effort by name: the peer it would notify is the one that was killed. |
+
+Each is a real condition the code detects correctly, which is why none is
+downgraded — in production every one of them warrants a WARN. The two
+alternatives weighed in #175, plumbing a "chaos window" hint down to the
+emitting code or tagging the lines with a structured `chaos_expected` field,
+both founder on the same point: the code emitting the warning has no way to
+know that a test killed the peer.
+
+When triaging a chaos-phase failure the signal is the scenario trace
+(`ERROR Scenario "<name>" failed at <KIND> "<step>"`) and its `anyhow` cause
+trail, not the WARN cluster around it.
+
 #### Prerequisites
 
 `docker`, `docker compose v2`, `jq`, `curl`, `lsof`. The script


### PR DESCRIPTION
Takes the third of the three directions #175 proposed, which is the one its author judged workable.

The chaos phases kill nodes deliberately, so the node truthfully reports connection-refused, an incomplete mesh and an unresolved owner key. Those clusters read as findings, and they sit right next to the real ones when a chaos phase actually fails — which is the cost, per #173.

### Why documenting rather than downgrading

Each line is a real condition the code detects correctly; in production every one warrants a WARN. The other two directions in the issue — plumbing a "chaos window" hint down to the emitting code, or tagging the lines with a structured `chaos_expected` field — both founder on the same point: the code emitting the warning has no way to know a test killed the peer. Downgrading them unconditionally would cost real signal in production to tidy a test log.

### Verified against the source, not the issue

The issue's paste is three months old, so I checked all four lines still exist:

| Line | Source |
|---|---|
| `Failed to send <label> to <participant>: … Connection refused` | `handlers/workflows.rs:3547` |
| `Onboarding rejected: N missing peer mesh edge(s)` | `handlers/workflows.rs:1589` |
| `Participant owner_key unresolved after onboarding` | `handlers/workflows.rs:1802` |
| `Best-effort CancelInvite to <peer> after decline failed` | `noise/server.rs:604` |

One thing that only shows up in the source: the `CancelInvite` and `RetryWorkflow` lines the issue lists as two separate entries are the **same** log statement — one shared broadcast helper with `label` interpolated. So the table documents the shape rather than pretending they are distinct, and it covers invites too, which the issue did not mention.

Also names the six phases the list applies to, so a reader can tell whether they are in one.

Goes in the README next to the existing quiet/verbose `RUST_LOG` sections, which is where someone reading confusing IT output already is.

Closes #175
