### PR TITLE
Unbreak CI on the new h2 advisory (RUSTSEC-2026-0258)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -27,4 +27,22 @@ ignore = [
   # rust_decimal upstream. Latest (1.42.1) still requires 0.7. Drop this ignore
   # once it moves.
   "RUSTSEC-2026-0235",
+  # h2 0.3 accepts and queues empty DATA frames without limit (low severity:
+  # unbounded memory, or a panic if the length overflows). There is no fix in
+  # the 0.3 line — 0.3.27 is the last release ever published, and the patch
+  # landed only in 0.4.16 — so this cannot be resolved by updating.
+  #
+  # Two paths pull it, neither removable from here:
+  #   * actix-http (actix-web 4), whose `http2` is a default feature;
+  #   * hyper 0.14, required by hyper-noise 0.0.3, which declares
+  #     `hyper = { features = ["full"] }` itself. Narrowing our own hyper
+  #     features changes nothing, because feature unification keeps h2 in the
+  #     graph regardless.
+  #
+  # The h2 0.4 instance (AWS SDK / hyper 1.x) IS fixed, by the 0.4.16 bump in
+  # the same change as this ignore.
+  #
+  # Drop this ignore when hyper-noise moves off hyper 0.14, or actix-web
+  # ships an h2 0.4 release. Tracked in #351.
+  "RUSTSEC-2026-0258",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -764,7 +764,7 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "h2 0.4.14",
+ "h2 0.4.16",
  "http 1.4.0",
  "hyper 1.9.0",
  "hyper-rustls",
@@ -2131,7 +2131,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2522,9 +2522,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2754,7 +2754,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.14",
+ "h2 0.4.16",
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
@@ -2840,7 +2840,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4185,7 +4185,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -4223,7 +4223,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -4557,7 +4557,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.14",
+ "h2 0.4.16",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -4598,7 +4598,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.4.14",
+ "h2 0.4.16",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -4818,7 +4818,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4877,7 +4877,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5692,7 +5692,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6031,7 +6031,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.14",
+ "h2 0.4.16",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -6780,7 +6780,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -12,4 +12,20 @@ ignore = [
   # maintained drop-in until ratatui moves off it, so ignore the advisory
   # rather than block CI.
   "RUSTSEC-2024-0436",
+  # h2 0.3 accepts and queues empty DATA frames without limit (RUSTSEC-2026-0258,
+  # low severity: unbounded memory, or a panic if the length overflows).
+  #
+  # Unfixable by updating: 0.3.27 is the last 0.3.x release ever published and
+  # the patch landed only in 0.4.16. It arrives via actix-http (actix-web 4,
+  # `http2` on by default) and via hyper 0.14, which hyper-noise 0.0.3 requires
+  # with `features = ["full"]` — so the feature cannot be switched off from
+  # here either. Unlike the other entries in this file, cargo-deny flags this
+  # one too, i.e. it really is in the compiled graph, not just the lockfile.
+  #
+  # The separate h2 0.4 instance (AWS SDK / hyper 1.x) is fixed by the 0.4.16
+  # bump that accompanies this ignore.
+  #
+  # Drop when hyper-noise moves off hyper 0.14 or actix-web ships an h2 0.4
+  # release. Tracked in #351.
+  "RUSTSEC-2026-0258",
 ]


### PR DESCRIPTION
**This is not a PR-specific failure — `main` is red too.** `RUSTSEC-2026-0258` was published on 2026-08-17 and `rustsec/audit-check` fetches the advisory DB fresh on every run, so it turned Cargo Audit red across the repo with no code change. Cargo Deny started failing a few hours later as its own DB copy caught up, which is why the two jobs disagreed for a while.

The advisory: h2 accepts and queues empty DATA frames without limit. **Low severity** — unbounded memory growth, or a panic if the length overflows.

There are two h2 instances in the lock, and only one is fixable.

### Fixed: h2 0.4.14 → 0.4.16

Reached via the AWS SDK and hyper 1.x. `cargo update -p h2@0.4.14` takes it to the patched release. Lockfile only.

### Ignored: h2 0.3.27

There is **no fix in the 0.3 line** — `0.3.27` is the last release ever published there, and the patch landed only in 0.4.16. I checked the crates.io index rather than trusting the advisory text.

Two paths pull it, neither cuttable from this repo:

| Path | Why it is stuck |
|---|---|
| `actix-http` ← `actix-web` 4 | `http2` is a default feature and actix-web 4 has no h2 0.4 release |
| `hyper` 0.14 ← `hyper-noise` 0.0.3 | hyper-noise declares `hyper = { features = ["full"] }` **itself**, so narrowing our own hyper features changes nothing — feature unification keeps h2 0.3 in the graph |

I checked whether disabling `http2` could remove the exposure properly rather than paper over it. It cannot, because of that second row.

**This is the reviewable decision in this PR**, so flagging it plainly rather than burying it: the ignore is added to *both* `.cargo/audit.toml` and `deny.toml`, with the reasoning inline in each.

One thing that makes it different from the existing entries in `.cargo/audit.toml`: those are lockfile-only artifacts sitting behind disabled features, which is why cargo-deny does not flag them. **cargo-deny flags this one**, so h2 0.3 really is in the compiled graph.

On exposure: it is a DoS, not a data risk, and both HTTP/2 surfaces sit behind a gate — the actix API behind the ingress and a bearer token, the Noise listener behind a completed handshake against a known peer key. Worst realistic case is memory growth or a panic on one node, i.e. a restart.

Removal is tracked in **#351**, which spells out what has to change upstream first.

### Verification

```
cargo audit                    → exit 0
cargo deny check advisories    → advisories ok
```

### Knock-on

Once this lands, #347, #348, #349 and #350 need a merge from main to go green — none of them caused this.
