### PR TITLE
Make peer fan-out failures name a cause

### DIFF
--- a/crates/decman/src/noise/client.rs
+++ b/crates/decman/src/noise/client.rs
@@ -140,9 +140,29 @@ impl NoiseClient {
         )
         .await?;
 
-        // Check response status
+        // Check response status.
+        //
+        // Read the body before giving up: the listener's deny paths answer a
+        // non-2xx with a `MessageType::Error` frame naming the reason, and
+        // discarding it here is what left the requester unable to tell "the
+        // peer refused us" from "the peer is down" (#332). Bounded by the same
+        // request timeout as the success path, and best-effort — a peer that
+        // sends no body, or an unparseable one, still yields the bare status.
         if response.status() != hyper::StatusCode::OK {
-            return Err(NoiseError::BadStatusCode(response.status()));
+            let status = response.status();
+            let reason = match tokio::time::timeout(
+                request_timeout,
+                hyper::body::to_bytes(response.body_mut()),
+            )
+            .await
+            {
+                Ok(Ok(bytes)) if !bytes.is_empty() => Message::from_bytes(&bytes)
+                    .ok()
+                    .filter(|m| m.msg_type == MessageType::Error)
+                    .map(|m| String::from_utf8_lossy(&m.payload).into_owned()),
+                _ => None,
+            };
+            return Err(NoiseError::BadStatusCode(status, reason));
         }
 
         // Read response body, bounded by `request_timeout`. `send_request`'s

--- a/crates/decman/src/noise/mod.rs
+++ b/crates/decman/src/noise/mod.rs
@@ -434,8 +434,16 @@ pub enum NoiseError {
     #[error("JSON serialization error: {0}")]
     JsonSerialization(#[from] serde_json::Error),
 
-    #[error("Bad status code: {0}")]
-    BadStatusCode(StatusCode),
+    /// Non-2xx from the peer. The second field carries the peer's own reason
+    /// when it sent one (a `MessageType::Error` frame on its deny path), which
+    /// is the difference between "peer refused us" and "peer is down" — the
+    /// two used to be indistinguishable at the requester (see #332).
+    #[error(
+        "Bad status code: {status}{reason}",
+        status = .0,
+        reason = .1.as_deref().map(|r| format!(" — peer said: {r}")).unwrap_or_default(),
+    )]
+    BadStatusCode(StatusCode, Option<String>),
 
     #[error("Invalid URI: {0}")]
     InvalidUri(#[from] http::uri::InvalidUri),
@@ -563,7 +571,7 @@ async fn send_noise_message_with_timeout(
         hyper_noise::client::send_request(tcp_stream, initiator, request, Some(timeout)).await?;
 
     if response.status() != StatusCode::OK {
-        return Err(NoiseError::BadStatusCode(response.status()));
+        return Err(NoiseError::BadStatusCode(response.status(), None));
     }
 
     let resp_body_bytes = hyper::body::to_bytes(response.body_mut()).await?;
@@ -784,7 +792,7 @@ pub(crate) fn is_transient(err: &NoiseError) -> bool {
         | NoiseError::RequestTimeout
         | NoiseError::Io(_)
         | NoiseError::Hyper(_) => true,
-        NoiseError::BadStatusCode(code) => code.is_server_error(),
+        NoiseError::BadStatusCode(code, _) => code.is_server_error(),
         NoiseError::Noise(_)
         | NoiseError::HandshakeFailed
         | NoiseError::DecryptionError
@@ -1328,11 +1336,11 @@ mod tests {
             let calls = calls_clone.clone();
             async move {
                 calls.fetch_add(1, Ordering::SeqCst);
-                Err::<Bytes, _>(NoiseError::BadStatusCode(StatusCode::BAD_REQUEST))
+                Err::<Bytes, _>(NoiseError::BadStatusCode(StatusCode::BAD_REQUEST, None))
             }
         })
         .await;
-        assert!(matches!(result, Err(NoiseError::BadStatusCode(_))));
+        assert!(matches!(result, Err(NoiseError::BadStatusCode(..))));
         assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
 
@@ -1345,11 +1353,14 @@ mod tests {
             let calls = calls_clone.clone();
             async move {
                 calls.fetch_add(1, Ordering::SeqCst);
-                Err::<Bytes, _>(NoiseError::BadStatusCode(StatusCode::INTERNAL_SERVER_ERROR))
+                Err::<Bytes, _>(NoiseError::BadStatusCode(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    None,
+                ))
             }
         })
         .await;
-        assert!(matches!(result, Err(NoiseError::BadStatusCode(_))));
+        assert!(matches!(result, Err(NoiseError::BadStatusCode(..))));
         assert_eq!(calls.load(Ordering::SeqCst), 2);
     }
 

--- a/crates/decman/src/noise/mod.rs
+++ b/crates/decman/src/noise/mod.rs
@@ -571,7 +571,22 @@ async fn send_noise_message_with_timeout(
         hyper_noise::client::send_request(tcp_stream, initiator, request, Some(timeout)).await?;
 
     if response.status() != StatusCode::OK {
-        return Err(NoiseError::BadStatusCode(response.status(), None));
+        // Read the body before giving up. The listener's deny paths answer a
+        // non-2xx with a `MessageType::Error` frame naming the reason, and this
+        // is the path every peer-to-peer call takes (`send_noise_message`), so
+        // dropping it here would leave the fan-out exactly as blind as before
+        // (#332). Best-effort and bounded by the same timeout: a peer that
+        // sends no body, or an unparseable one, still yields the bare status.
+        let status = response.status();
+        let reason =
+            match tokio::time::timeout(timeout, hyper::body::to_bytes(response.body_mut())).await {
+                Ok(Ok(bytes)) if !bytes.is_empty() => Message::from_bytes(&bytes)
+                    .ok()
+                    .filter(|m| m.msg_type == MessageType::Error)
+                    .map(|m| String::from_utf8_lossy(&m.payload).into_owned()),
+                _ => None,
+            };
+        return Err(NoiseError::BadStatusCode(status, reason));
     }
 
     let resp_body_bytes = hyper::body::to_bytes(response.body_mut()).await?;

--- a/crates/decman/src/server/handlers/parties.rs
+++ b/crates/decman/src/server/handlers/parties.rs
@@ -299,10 +299,14 @@ pub async fn resolve_owner_keys_from_peers(
             }
         };
 
-        // An empty body is the single most misleading case: the always-on
-        // listener answers a denied or unparseable request with an empty 503,
-        // and a proxy with no healthy backend answers the same way. Reporting
-        // it as "message too short" reads like a protocol bug in the peer.
+        // A 200 with an empty body. The peer accepted the request and then
+        // said nothing, which used to surface as "message too short: got 0" and
+        // read like a protocol bug in the peer.
+        //
+        // A denied request is NOT this case: it arrives as a 503, so
+        // `send_noise_message` returns `BadStatusCode` above and never reaches
+        // here. This arm is a peer that answered 200 with no frame at all, or a
+        // proxy that terminated the request and returned an empty 200.
         if response.is_empty() {
             tracing::warn!(
                 peer = %peer_uid,
@@ -316,8 +320,11 @@ pub async fn resolve_owner_keys_from_peers(
         let response_msg = match Message::from_bytes(&response) {
             Ok(m) if m.msg_type == MessageType::OwnerKeys => m,
             Ok(m) if m.msg_type == MessageType::Error => {
-                // The peer told us why (see the Error frame the listener now
-                // sends on its deny path); prefer its words to our guess.
+                // An Error frame under 200 OK. The listener's own deny paths
+                // send that frame with a 503, so those surface as
+                // `BadStatusCode(_, Some(reason))` above rather than here. This
+                // arm catches a peer that reports the error in the body while
+                // still answering 200. Either way, prefer its words to a guess.
                 tracing::warn!(
                     peer = %peer_uid,
                     endpoint = %format!("{}:{}", peer.address, peer.port),

--- a/crates/decman/src/server/handlers/parties.rs
+++ b/crates/decman/src/server/handlers/parties.rs
@@ -280,23 +280,69 @@ pub async fn resolve_owner_keys_from_peers(
         {
             Ok(Ok(bytes)) => bytes,
             Ok(Err(e)) => {
-                tracing::warn!("Noise request to {peer_uid} failed: {e}");
+                tracing::warn!(
+                    peer = %peer_uid,
+                    endpoint = %format!("{}:{}", peer.address, peer.port),
+                    "RequestOwnerKeys failed: {e} — {hint}",
+                    hint = peer_failure_hint(&e)
+                );
                 continue;
             }
             Err(_) => {
-                tracing::warn!("Noise request to {peer_uid} timed out");
+                tracing::warn!(
+                    peer = %peer_uid,
+                    endpoint = %format!("{}:{}", peer.address, peer.port),
+                    "RequestOwnerKeys timed out after 10s — {hint}",
+                    hint = peer_failure_hint(&NoiseError::RequestTimeout)
+                );
                 continue;
             }
         };
 
+        // An empty body is the single most misleading case: the always-on
+        // listener answers a denied or unparseable request with an empty 503,
+        // and a proxy with no healthy backend answers the same way. Reporting
+        // it as "message too short" reads like a protocol bug in the peer.
+        if response.is_empty() {
+            tracing::warn!(
+                peer = %peer_uid,
+                endpoint = %format!("{}:{}", peer.address, peer.port),
+                "RequestOwnerKeys got an empty reply — {hint}",
+                hint = peer_failure_hint(&NoiseError::InvalidMessage)
+            );
+            continue;
+        }
+
         let response_msg = match Message::from_bytes(&response) {
             Ok(m) if m.msg_type == MessageType::OwnerKeys => m,
+            Ok(m) if m.msg_type == MessageType::Error => {
+                // The peer told us why (see the Error frame the listener now
+                // sends on its deny path); prefer its words to our guess.
+                tracing::warn!(
+                    peer = %peer_uid,
+                    endpoint = %format!("{}:{}", peer.address, peer.port),
+                    "RequestOwnerKeys refused by the peer: {reason}",
+                    reason = String::from_utf8_lossy(&m.payload)
+                );
+                continue;
+            }
             Ok(m) => {
-                tracing::warn!("Unexpected response type from {peer_uid}: {:?}", m.msg_type);
+                tracing::warn!(
+                    peer = %peer_uid,
+                    endpoint = %format!("{}:{}", peer.address, peer.port),
+                    "RequestOwnerKeys got an unexpected response type {:?} — the peer may be on a \
+                     different wire format",
+                    m.msg_type
+                );
                 continue;
             }
             Err(e) => {
-                tracing::warn!("Failed to parse response from {peer_uid}: {e}");
+                tracing::warn!(
+                    peer = %peer_uid,
+                    endpoint = %format!("{}:{}", peer.address, peer.port),
+                    "RequestOwnerKeys reply did not parse: {e} — {hint}",
+                    hint = peer_failure_hint(&NoiseError::InvalidMessage)
+                );
                 continue;
             }
         };
@@ -1028,6 +1074,53 @@ pub async fn compare_peer_packages(data: web::Data<AppState>) -> impl Responder 
 
 /// Pure mapping from `NoiseError` to the wire-stable `PeerErrorKind`.
 ///
+/// What an operator should check, for a peer request that failed.
+///
+/// The raw error names a symptom — `snow error: input error`,
+/// `Message too short: got 0` — and an operator reading it has no way to get
+/// from there to an action. Each arm below names the thing to go and look at.
+///
+/// Exhaustive for the same reason as [`peer_error_kind_from_noise_err`]: a new
+/// `NoiseError` variant must be given a hint rather than silently inheriting a
+/// vague one.
+fn peer_failure_hint(err: &NoiseError) -> &'static str {
+    match err {
+        NoiseError::TcpConnectionTimeout(_) | NoiseError::TcpConnectionFailed(_) => {
+            "nothing is accepting connections on that address — check the peer is up and that \
+             its advertised host/port reach it from here"
+        }
+        NoiseError::RequestTimeout => {
+            "connected, but the peer never answered — it may be overloaded, or wedged mid-request"
+        }
+        NoiseError::Noise(_) | NoiseError::HandshakeFailed | NoiseError::DecryptionError => {
+            "the Noise handshake failed — this node's key or the derived PSK does not match what \
+             the peer expects, so check each side has the other's current public key"
+        }
+        NoiseError::BadStatusCode(..) => {
+            "the peer answered but refused the request — it may not have this node registered as \
+             a peer, or a load balancer in front of it has no healthy backend"
+        }
+        NoiseError::InvalidMessage => {
+            "the peer answered with something this build cannot parse — most often an empty body \
+             from a denied request or an unhealthy proxy, or a peer on an older wire format"
+        }
+        NoiseError::JsonSerialization(_) => {
+            "the peer's payload did not deserialize — likely a version skew between the two builds"
+        }
+        NoiseError::Io(_) | NoiseError::Hyper(_) => {
+            "the connection broke mid-request — check for a proxy or firewall closing idle \
+             connections between the two nodes"
+        }
+        NoiseError::Http(_)
+        | NoiseError::InvalidUri(_)
+        | NoiseError::UriParsingError(_)
+        | NoiseError::UnknownPeer(_)
+        | NoiseError::Anyhow(_) => {
+            "check this peer's address, port and public key in the peers table"
+        }
+    }
+}
+
 /// Exhaustive match (no wildcard) — adding a new `NoiseError` variant will
 /// fail to compile here until it's explicitly classified.
 fn peer_error_kind_from_noise_err(err: &NoiseError) -> PeerErrorKind {
@@ -1039,7 +1132,7 @@ fn peer_error_kind_from_noise_err(err: &NoiseError) -> PeerErrorKind {
         NoiseError::Noise(_) | NoiseError::HandshakeFailed | NoiseError::DecryptionError => {
             PeerErrorKind::HandshakeFailed
         }
-        NoiseError::BadStatusCode(_) => PeerErrorKind::BadStatus,
+        NoiseError::BadStatusCode(..) => PeerErrorKind::BadStatus,
         NoiseError::InvalidMessage | NoiseError::JsonSerialization(_) => {
             PeerErrorKind::DecodeFailed
         }
@@ -1224,7 +1317,7 @@ mod tests {
             (NoiseError::HandshakeFailed, PeerErrorKind::HandshakeFailed),
             (NoiseError::DecryptionError, PeerErrorKind::HandshakeFailed),
             (
-                NoiseError::BadStatusCode(StatusCode::INTERNAL_SERVER_ERROR),
+                NoiseError::BadStatusCode(StatusCode::INTERNAL_SERVER_ERROR, None),
                 PeerErrorKind::BadStatus,
             ),
             (NoiseError::InvalidMessage, PeerErrorKind::DecodeFailed),
@@ -1273,5 +1366,60 @@ mod tests {
 
         assert_eq!(request.filter_participant, "participant::abc123");
         assert_eq!(request.filter_party, "alice");
+    }
+
+    /// Every hint must name something to go and look at. The failure this
+    /// guards is a new `NoiseError` variant being handed a vague catch-all,
+    /// which is how the logs got unactionable in the first place (#332).
+    #[test]
+    fn every_peer_failure_hint_is_actionable() {
+        let cases = [
+            NoiseError::TcpConnectionFailed("x".into()),
+            NoiseError::TcpConnectionTimeout("x".into()),
+            NoiseError::RequestTimeout,
+            NoiseError::HandshakeFailed,
+            NoiseError::DecryptionError,
+            NoiseError::BadStatusCode(StatusCode::SERVICE_UNAVAILABLE, None),
+            NoiseError::InvalidMessage,
+            NoiseError::UnknownPeer("x".into()),
+        ];
+        for e in &cases {
+            let hint = peer_failure_hint(e);
+            assert!(!hint.is_empty(), "no hint for {e:?}");
+            // "check", "the peer", an instruction of some kind — not a restatement.
+            assert!(
+                hint.len() > 30,
+                "hint for {e:?} is too terse to act on: {hint}"
+            );
+        }
+
+        // The two that used to be indistinguishable must not read alike.
+        assert_ne!(
+            peer_failure_hint(&NoiseError::InvalidMessage),
+            peer_failure_hint(&NoiseError::TcpConnectionFailed("x".into())),
+        );
+    }
+
+    /// The peer's own reason reaches the operator through Display, which is
+    /// what `{e}` in the fan-out warnings renders.
+    #[test]
+    fn bad_status_code_surfaces_the_peers_reason() {
+        let bare = NoiseError::BadStatusCode(StatusCode::SERVICE_UNAVAILABLE, None);
+        let bare_rendered = format!("{bare}");
+        assert!(
+            bare_rendered.starts_with("Bad status code: 503"),
+            "unexpected Display: {bare_rendered}"
+        );
+        assert!(!bare_rendered.contains("peer said"));
+
+        let with_reason = NoiseError::BadStatusCode(
+            StatusCode::SERVICE_UNAVAILABLE,
+            Some("request rejected: unknown sender".to_string()),
+        );
+        let rendered = format!("{with_reason}");
+        assert!(
+            rendered.contains("unknown sender"),
+            "reason missing from Display: {rendered}"
+        );
     }
 }

--- a/crates/decman/src/server/mod.rs
+++ b/crates/decman/src/server/mod.rs
@@ -1438,7 +1438,19 @@ async fn handle_incoming_connection(
                             "Denied Noise request from {sender}: {e}",
                             sender = peer_id_str.as_deref().unwrap_or("<unidentified peer>")
                         );
-                        let mut resp = Response::new(Body::empty());
+                        // Answer WITH the reason rather than an empty body.
+                        // An empty 503 here is indistinguishable at the
+                        // requester from a proxy with no healthy backend, so
+                        // the operator on the other side saw only "message too
+                        // short" (#332). Status stays 503, so an older
+                        // requester behaves exactly as before.
+                        let mut resp = Response::new(Body::from(
+                            Message::new(
+                                MessageType::Error,
+                                format!("request rejected: {e}").into_bytes(),
+                            )
+                            .to_bytes(),
+                        ));
                         *resp.status_mut() = StatusCode::SERVICE_UNAVAILABLE;
                         return Ok(resp);
                     }
@@ -1590,7 +1602,17 @@ async fn handle_incoming_connection(
                                     (None, _) => {
                                         // The named run is gone (cancelled/finished) —
                                         // 503 so the peer's bounded retry gives up.
-                                        let mut resp = Response::new(Body::empty());
+                                        // Says so in the body, so the requester
+                                        // reports the cause rather than an empty reply.
+                                        let mut resp = Response::new(Body::from(
+                                            Message::new(
+                                                MessageType::Error,
+                                                b"no such workflow run on this peer: it was \
+                                                  cancelled or already finished"
+                                                    .to_vec(),
+                                            )
+                                            .to_bytes(),
+                                        ));
                                         *resp.status_mut() = StatusCode::SERVICE_UNAVAILABLE;
                                         return Ok(resp);
                                     }

--- a/crates/decman/src/workflow/mod.rs
+++ b/crates/decman/src/workflow/mod.rs
@@ -282,7 +282,7 @@ pub async fn start_peer(
                 // (re-)register before giving up, so a resumed run doesn't poll
                 // a dead coordinator forever. The counter resets on any real
                 // reply above, so a slow resume rides through.
-                if matches!(&e, NoiseError::BadStatusCode(code) if code.as_u16() == 503) {
+                if matches!(&e, NoiseError::BadStatusCode(code, _) if code.as_u16() == 503) {
                     consecutive_errors = 0;
                     consecutive_no_workflow += 1;
                     if consecutive_no_workflow >= MAX_CONSECUTIVE_NO_WORKFLOW_POLLS {


### PR DESCRIPTION
Proposals 1 and 2 from #332. Proposal 3 is deliberately left out — see the end.

The owner-keys fan-out reported symptoms nobody could act on:

```
Noise request to FCS-0::1220…59 failed: Noise protocol error: Noise snow error: input error
Failed to parse response from dsrv-testnetValidator-01::1220…ac: Message too short: expected at least 9 bytes, got 0
Noise request to ibtc-catalyst-testnet::1220…62 timed out
```

I confirmed this on **mainnet** as well as the reported testnet case — three peers on three *different* operators — so it is not one node's misconfiguration.

### The empty reply was ambiguous by construction

Both of the listener's deny paths answered a **503 with an empty body**, which is byte-for-byte what a load balancer with no healthy backend returns. The requester genuinely could not tell "this peer refused me" from "this peer is down", and reported the more alarming of the two: a message-too-short parse error, which reads like a protocol bug in the peer.

They now send a `MessageType::Error` frame naming the reason. **The status stays 503**, so an older requester behaves exactly as it does today.

### The client was throwing the reason away

This is the part that makes the responder change worth anything. `noise/client.rs` returned `BadStatusCode` the moment it saw a non-2xx, *before* reading the body — so the reason would never have arrived. It now reads the body (bounded by the same request timeout, best-effort) and decodes an `Error` frame into a new second field on `BadStatusCode`, which `Display` renders.

`BadStatusCode(StatusCode)` → `BadStatusCode(StatusCode, Option<String>)` touches eight sites. The two behavioural ones are preserved deliberately and worth a reviewer's eye:

- `noise/mod.rs` `is_transient` — still `code.is_server_error()`, so retry behaviour is unchanged.
- `workflow/mod.rs:285` — still matches 503 specifically for the bounded-retry give-up.

### Warnings now name an endpoint and an action

Every warning carries the **endpoint actually dialed** — the party id alone never said which address failed — plus a hint from a new exhaustive `peer_failure_hint`. Exhaustive on purpose: a new `NoiseError` variant has to be given a hint rather than inheriting a vague catch-all, which is how this got unactionable in the first place.

An empty reply is now detected *before* parsing, so it stops being reported as a malformed message. And a peer that sends an `Error` frame gets its own words logged in preference to our guess.

Before / after for the worst one:

| | |
|---|---|
| before | `Failed to parse response from dsrv-…: Message too short: expected at least 9 bytes, got 0` |
| after | `RequestOwnerKeys got an empty reply — the peer answered with something this build cannot parse — most often an empty body from a denied request or an unhealthy proxy, or a peer on an older wire format` with `peer` and `endpoint` as structured fields |

### Tests

Two unit tests: every hint is non-empty and long enough to be an instruction rather than a restatement, the two formerly-indistinguishable cases do not read alike, and the peer's reason reaches `Display` while a bare status does not gain a phantom one.

### Not in scope

Proposal 3 — logging per-peer reachability *changes* at warn and the steady state at debug, instead of a full set every time the UI polls. That needs per-peer state and probably belongs with the existing `peer_status` / `LastSeen` machinery, so it wants its own change. This PR makes the lines actionable; it does not yet reduce how often they appear.

Refs #332
