### PR TITLE
Narrowed handler re-exports to pub(crate)

### DIFF
--- a/crates/decman/src/lib.rs
+++ b/crates/decman/src/lib.rs
@@ -11,6 +11,10 @@ pub mod consts;
 pub mod db;
 pub mod error;
 pub mod noise;
+// The `dec-party-manager` and `gen-types` binaries, plus the `tests/` integration
+// suite, are separate crates from this lib and reach into `server::` (e.g.
+// `server::start_server`, the `gen-types` wire DTOs, `server::GovernanceResponse`),
+// so this module path must stay `pub`.
 pub mod server;
 pub mod signing;
 pub mod utils;

--- a/crates/decman/src/server/handlers/mod.rs
+++ b/crates/decman/src/server/handlers/mod.rs
@@ -8,11 +8,13 @@ mod party_config;
 mod tenant;
 mod workflows;
 
-pub use auth::{get_auth_config, get_auth_status, grant_rights, test_auth};
-pub use config::{
-    NodeConfigResponse, get_network_config, get_node_config, healthz, save_network_config,
-};
-pub use governance::{
+pub(crate) use auth::{get_auth_config, get_auth_status, grant_rights, test_auth};
+// `NodeConfigResponse` is reached externally as `dec_party_manager::server::NodeConfigResponse`
+// by the `gen-types` binary (a separate crate from this lib), so it must stay `pub`; the
+// handler functions beside it have no such consumer.
+pub use config::NodeConfigResponse;
+pub(crate) use config::{get_network_config, get_node_config, healthz, save_network_config};
+pub(crate) use governance::{
     cancel_confirmation, cancel_proposal, confirm_action, execute_action, expire_confirmation,
     get_burn_requests_handler, get_coupon_reassignment_delegation, get_credential_offers_handler,
     get_governance, get_governance_audit, get_governance_chain_audit, get_governance_state,
@@ -26,16 +28,16 @@ pub use governance::{
 // re-exported here so they are reachable through the private `governance`
 // submodule.
 pub(crate) use governance::{get_party_credentials, packages};
-pub use invitations::{accept_invitation, decline_invitation, get_invitations};
-pub use keys::get_key_status;
-pub use parties::{
+pub(crate) use invitations::{accept_invitation, decline_invitation, get_invitations};
+pub(crate) use keys::get_key_status;
+pub(crate) use parties::{
     compare_peer_packages, fetch_decentralized_parties, get_decentralized_parties,
     get_participants_status, get_vetted_packages, resolve_owner_keys_from_peers,
     store_parties_to_db,
 };
-pub use party_config::{discover_member_party, get_party_config, save_party_config};
-pub use tenant::{tenant_onboard, tenant_prepare, tenant_status};
-pub use workflows::{
+pub(crate) use party_config::{discover_member_party, get_party_config, save_party_config};
+pub(crate) use tenant::{tenant_onboard, tenant_prepare, tenant_status};
+pub(crate) use workflows::{
     cancel_add_party, cancel_change_threshold, cancel_contracts, cancel_dars, cancel_kick,
     cancel_onboarding, cancel_workflow_instance, dismiss_workflow, get_add_party_status,
     get_change_threshold_status, get_contracts_status, get_dars_status, get_kick_status,

--- a/crates/decman/src/server/mod.rs
+++ b/crates/decman/src/server/mod.rs
@@ -21,8 +21,8 @@ mod reward_automation;
 mod transfer_context;
 mod types;
 
-pub mod health;
-pub mod peer_status;
+pub(crate) mod health;
+pub(crate) mod peer_status;
 
 use std::{
     collections::{HashMap, HashSet},
@@ -71,8 +71,21 @@ use crate::{
     workflow::{self, WorkflowType},
 };
 
+// Reached externally as `dec_party_manager::server::NodeConfigResponse` by the
+// `gen-types` binary (a separate crate from this lib), so it must stay `pub`.
 pub use handlers::NodeConfigResponse;
-pub use types::*;
+pub(crate) use types::*;
+// These wire DTOs are likewise reached externally as `dec_party_manager::server::…`,
+// by `gen-types` (TS generation) and, for `GovernanceResponse`, by the integration
+// tests under `tests/` — both are separate crates that can only see `pub` items.
+pub use types::{
+    AcceptTransferDetails, ActionType, AppRewardBeneficiary, BillingParams, BurnRequestsResponse,
+    ConfirmActionRequest, DomainGovernanceAction, ExecuteActionRequest, FarConfig,
+    GovernanceAction, GovernanceConfirmation, GovernanceResponse, HoldingInfo, HoldingsResponse,
+    MintRequestsResponse, PendingAction, ProposalType, ProposeActionRequest, ServiceRequestDetails,
+    TokenRequestInfo, TransferInstructionInfo, TransferInstructionStatus,
+    TransferInstructionsResponse, TransferProposalDetails, VaultLimits,
+};
 
 /// TTL for cached chunked ListPackages payloads (per peer).
 const LIST_PACKAGES_CHUNK_CACHE_TTL: Duration = Duration::from_secs(30);

--- a/crates/decman/src/server/types.rs
+++ b/crates/decman/src/server/types.rs
@@ -41,8 +41,7 @@ pub use common::types::{
     AuditLogEntry, AuthConfigResponse, ConnectionStatus, ContractInfo, DecentralizedParty,
     InvitationType, PackageInfo, ParticipantInfo, ParticipantStatus, ParticipantsStatusResponse,
     PartyMetadata, PeerErrorKind, PeerPackageComparison, PeerPackageResult, PendingInvitation,
-    Permission, VettedPackageInfo, WorkflowInfo, WorkflowKind, WorkflowProgress, WorkflowRole,
-    WorkflowRun,
+    Permission, VettedPackageInfo, WorkflowKind, WorkflowProgress, WorkflowRole, WorkflowRun,
 };
 
 use crate::{canton_id::CantonId, noise::server::ActiveWorkflow};


### PR DESCRIPTION
## Summary

`crates/decman/src/server/handlers/mod.rs` re-exported 79 items with `pub use`, but `decman-cli` talks to `decman` over HTTP and does not depend on the `dec_party_manager` library, `common` doesn't reference it either, and the only real consumers are the crate's own binaries. Narrowed the re-exports there and the analogous surfaces in `server/` to `pub(crate)`.

## What changed

- `crates/decman/src/server/handlers/mod.rs`: 78 of the 79 `pub use` items narrowed to `pub(crate) use`. The pre-existing `pub(crate) use governance::{get_party_credentials, packages}` is unchanged.
- `crates/decman/src/server/mod.rs`:
  - `pub mod health;` / `pub mod peer_status;` narrowed to `pub(crate) mod`.
  - `pub use types::*;` narrowed to `pub(crate) use types::*;`, which drops ~120 further DTO/helper names (reachable through that wildcard) out of the crate's public surface.
- `crates/decman/src/server/types.rs`: dropped `WorkflowInfo` from an unused `pub use common::types::{...}` re-export — narrowing surfaced it as genuinely dead inside the crate (nothing referenced it via that path; the code that needs `WorkflowInfo` already reaches it through `health.rs`'s own, separate re-export).

Visibility-only: no renames, no moves, no signature changes.

## Left `pub`, and why

`dec-party-manager` (binary) and `gen-types` (binary, `--features typegen`) are separate crates from the `dec_party_manager` lib even though they live in the same package, so `pub(crate)` isn't visible to them — confirmed by compiling with `cargo check --bin gen-types --features typegen`, which errors on anything narrowed that it still needs. The `tests/` integration suite is likewise a separate crate.

- `NodeConfigResponse` (`handlers/mod.rs` and `server/mod.rs`): `gen-types` reaches it as `dec_party_manager::server::NodeConfigResponse` for TS codegen.
- 25 wire DTOs re-exported explicitly from `server/mod.rs` (`AcceptTransferDetails`, `ActionType`, `AppRewardBeneficiary`, `BillingParams`, `BurnRequestsResponse`, `ConfirmActionRequest`, `DomainGovernanceAction`, `ExecuteActionRequest`, `FarConfig`, `GovernanceAction`, `GovernanceConfirmation`, `GovernanceResponse`, `HoldingInfo`, `HoldingsResponse`, `MintRequestsResponse`, `PendingAction`, `ProposalType`, `ProposeActionRequest`, `ServiceRequestDetails`, `TokenRequestInfo`, `TransferInstructionInfo`, `TransferInstructionStatus`, `TransferInstructionsResponse`, `TransferProposalDetails`, `VaultLimits`): same `gen-types` reason. `GovernanceResponse` is additionally imported directly by `tests/common/governance.rs` and `tests/common/phases/notification_feed.rs`.
- `pub mod server;` in `lib.rs`: both binaries and the integration tests reach into it (e.g. `server::start_server`, the DTOs above, `server::GovernanceResponse`), so the module path itself can't be narrowed.

Each of these carries an inline comment at the re-export site.

## Verification

- `cargo fmt --check` — clean
- `DECMAN_SKIP_FRONTEND=1 cargo clippy --all-targets --all-features --no-deps` — zero warnings
- `DECMAN_SKIP_FRONTEND=1 cargo test -p decman --lib` — 421 passed, 0 failed
- `DECMAN_SKIP_FRONTEND=1 cargo check --workspace --all-targets --all-features` — clean

Closes #281