### PR TITLE
Unbreak main: drop the unused RequiredClaim re-export

### DIFF
--- a/crates/decman/src/server/action_serializer.rs
+++ b/crates/decman/src/server/action_serializer.rs
@@ -2265,9 +2265,11 @@ mod tests {
     use std::collections::HashMap;
 
     use super::*;
+    use common::api::RequiredClaim;
+
     use crate::{
         canton_id::{NAMESPACE_LENGTH, Namespace},
-        server::types::{InstrumentIssuerCredentials, RequiredClaim},
+        server::types::InstrumentIssuerCredentials,
     };
 
     #[test]

--- a/crates/decman/src/server/types.rs
+++ b/crates/decman/src/server/types.rs
@@ -35,10 +35,10 @@ pub use common::api::{
     PendingInvitationsResponse, ProviderConfigurationInfo, ProviderConfigurationsResponse,
     ProviderServiceInfo, ProviderServicesResponse, RegistrarServiceInfo,
     RegistrarServiceRequestInfo, RegistrarServiceRequestsResponse, RegistrarServicesResponse,
-    RequiredClaim, ResponseSource, RightsStatus, SuccessResponse, TenantOnboardRequest,
-    TenantOnboardResponse, TenantPrepareRequest, TenantPrepareResponse, TransferFactoriesResponse,
-    TransferFactoryInfo, TransferPreapprovalsResponse, UserServiceInfo, UserServicesResponse,
-    VaultInfo, VaultsResponse, WorkflowResponse, WorkflowRunsResponse, WorkflowStatusResponse,
+    ResponseSource, RightsStatus, SuccessResponse, TenantOnboardRequest, TenantOnboardResponse,
+    TenantPrepareRequest, TenantPrepareResponse, TransferFactoriesResponse, TransferFactoryInfo,
+    TransferPreapprovalsResponse, UserServiceInfo, UserServicesResponse, VaultInfo, VaultsResponse,
+    WorkflowResponse, WorkflowRunsResponse, WorkflowStatusResponse,
 };
 pub use common::types::{
     AuditLogEntry, AuthConfigResponse, ConnectionStatus, ContractInfo, DecentralizedParty,
@@ -1500,6 +1500,7 @@ pub fn chain_audit_entry_from_row(row: crate::db::rows::ChainAuditCacheRow) -> C
 
 #[cfg(test)]
 mod tests {
+    use common::api::RequiredClaim;
     use serde_json::Value;
     use sqlx::SqlitePool;
 


### PR DESCRIPTION
**`main` is red right now.** Both `Format, Clippy & Unit Tests` and `Integration Tests` fail at the *Generate frontend TypeScript bindings* step:

```
error: unused import: `RequiredClaim`
error: could not compile `decman` (lib) due to 1 previous error
```

### Cause

#359 narrowed `server/mod.rs` from `pub use types::*` to `pub(crate) use types::*`. That ended the re-export chain inside the crate, so `types.rs`'s `pub use common::api::{… RequiredClaim …}` stopped being read by anything the **library** compiles. Its only two readers are test modules — `types.rs` and `action_serializer.rs`.

### Why #359's verification missed it

`cargo clippy --all-targets` passes, because the test targets genuinely use the name. The `gen-types` step builds the **lib alone** with `--features typegen`, and that is the configuration where it is unused. CI compiles it with `-D warnings`, so a warning is a failure there.

Worth recording as a lesson: `--all-targets` is not sufficient for this repo. A `pub`-narrowing change needs `cargo run -p decman --features typegen --bin gen-types` run as well.

### Fix

`gen-types` never needed the re-export — `gen_types.rs:19` takes `common::{api::*, types::*}` directly. So the re-export goes, and the two test modules import `RequiredClaim` from `common::api`, where it is defined.

### Verification

Ran what CI runs:

- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features --no-deps` — **0 warnings**
- `cargo run -p decman --features typegen --bin gen-types` — succeeds, no warning
- `cargo test -p decman --lib` — 442 passed