### PR TITLE
Get the devnet e2e harness running again

### DIFF
--- a/e2e/fixtures/auth.ts
+++ b/e2e/fixtures/auth.ts
@@ -17,9 +17,12 @@ export async function getAuthConfig(port: number): Promise<AuthConfig> {
 }
 
 function tokenUrl(cfg: AuthConfig): string {
-  // Mirror src/auth/mod.rs / tests/common/auth.rs: tolerate trailing /auth.
-  const base = cfg.keycloak_host.replace(/\/+$/, "").replace(/\/auth$/, "");
-  return `${base}/auth/realms/${cfg.keycloak_realm}/protocol/openid-connect/token`;
+  // Match DecMan's runtime auth path (src/auth/validators/common.rs::
+  // oidc_issuer_of): Keycloak issues `{url}/realms/{realm}`. KeycloakX serves
+  // no `/auth` prefix, so a deployment that still needs one carries it in the
+  // configured URL rather than having it appended here.
+  const base = cfg.keycloak_host.replace(/\/+$/, "");
+  return `${base}/realms/${cfg.keycloak_realm}/protocol/openid-connect/token`;
 }
 
 export async function fetchRopcTokens(cfg: AuthConfig) {

--- a/e2e/tests/governance-happy-path.spec.ts
+++ b/e2e/tests/governance-happy-path.spec.ts
@@ -177,6 +177,12 @@ test.describe.serial("governance happy path", () => {
   test("04 check peer DARs", async () => {
     await gotoTab(parts.p1, "Packages");
     await parts.p1.getByRole("button", { name: "Check Peer DARs" }).click();
+    // Narrow the table before asserting on it. The comparison view pages its
+    // rows 25 at a time and devnet vets 300+ packages, so `governance-core`
+    // sorts onto a later page and is never mounted — the count below sees 0 no
+    // matter how long it polls. Search filters comparison.local_packages ahead
+    // of pagination (PackagesPanel.tsx:92), so the matches land on page 1.
+    await parts.p1.getByPlaceholder("Search packages").fill("governance-core");
     // Comparison table renders one peer-status cell per package per peer
     // (data-testid="peer-dar-status", data-pkg, data-status), populated async
     // after /packages/compare-peers returns. Poll (NOT a one-shot count) until

--- a/integration-tests/bring-up.sh
+++ b/integration-tests/bring-up.sh
@@ -43,8 +43,9 @@ teardown() {
     # the retry-loop subshells above were killed. Mirrors stop_canton_tunnels in
     # devnet.env.sh (see #142 for why bare `kill` on the loop PID is not enough).
     # KUBE_CONTEXT_DEVNET default must match the one in devnet.env.sh.
-    local _ctx="${KUBE_CONTEXT_DEVNET:-ieu-devnet}"
-    pkill -f "kubectl --context=$_ctx port-forward svc/participant-ibtc-devnet" 2>/dev/null || true
+    local _ctx="${KUBE_CONTEXT_DEVNET:-devnet}"
+    local _svc="${KUBE_CANTON_SVC:-participant}"
+    pkill -f "kubectl --context=$_ctx port-forward svc/$_svc" 2>/dev/null || true
 }
 
 if [[ "${1:-}" == "--teardown" ]]; then

--- a/integration-tests/devnet.env.sh
+++ b/integration-tests/devnet.env.sh
@@ -30,6 +30,24 @@ for _penv in "$PARTICIPANT_1_ENV" "$PARTICIPANT_2_ENV" "$PARTICIPANT_3_ENV"; do
 done
 unset _penv
 
+# Repoint Keycloak without editing the per-participant .env files (they hold
+# secrets). The loop above runs under `set -a`, so it would clobber a plain
+# pre-set value; these overrides apply after the sourcing. Useful for feeding a
+# password straight from a secret manager, e.g.
+#   DECPM_KEYCLOAK_PASSWORD_OVERRIDE=$(op read op://vault/item/password)
+if [ -n "${DECPM_KEYCLOAK_URL_OVERRIDE:-}" ]; then
+    DECPM_KEYCLOAK_URL="$DECPM_KEYCLOAK_URL_OVERRIDE"
+    export DECPM_KEYCLOAK_URL
+fi
+if [ -n "${DECPM_KEYCLOAK_USERNAME_OVERRIDE:-}" ]; then
+    DECPM_KEYCLOAK_USERNAME="$DECPM_KEYCLOAK_USERNAME_OVERRIDE"
+    export DECPM_KEYCLOAK_USERNAME
+fi
+if [ -n "${DECPM_KEYCLOAK_PASSWORD_OVERRIDE:-}" ]; then
+    DECPM_KEYCLOAK_PASSWORD="$DECPM_KEYCLOAK_PASSWORD_OVERRIDE"
+    export DECPM_KEYCLOAK_PASSWORD
+fi
+
 # ---------------------------------------------------------------------------
 # Keycloak config validation.
 # ---------------------------------------------------------------------------
@@ -97,30 +115,46 @@ unset ADMIN_VARS ADMIN_MISSING _v
 # we spend time on cargo build / DecMan spawn. The fetched token is NOT used by
 # the Rust runner.
 # ---------------------------------------------------------------------------
-# Normalize the base URL: strip a trailing slash, then strip a trailing
-# `/auth` if present. This lets users configure DECPM_KEYCLOAK_URL either as
-# `https://kc.example.com` or `https://kc.example.com/auth` — same shape as
-# src/auth/mod.rs::token_url uses on the DecMan side, so the smoke check
-# composes the same endpoint the DecMan's runtime auth path will reach.
-_KC_BASE="${DECPM_KEYCLOAK_URL%/}"; _KC_BASE="${_KC_BASE%/auth}"
-TOKEN_URL="${_KC_BASE}/auth/realms/${DECPM_KEYCLOAK_REALM}/protocol/openid-connect/token"
-_SMOKE_TOKEN=$(curl -s -f -X POST "$TOKEN_URL" \
+# Compose the endpoint the same way DecMan's runtime auth path does
+# (src/auth/validators/common.rs::oidc_issuer_of): Keycloak issues
+# `{url}/realms/{realm}`. The old form stripped a trailing `/auth` and then
+# re-added it unconditionally, so every configured value produced
+# `/auth/realms/...` — which a KeycloakX server 404s, with no config value
+# able to fix it. A deployment that still serves the legacy prefix carries
+# it in DECPM_KEYCLOAK_URL.
+_KC_BASE="${DECPM_KEYCLOAK_URL%/}"
+TOKEN_URL="${_KC_BASE}/realms/${DECPM_KEYCLOAK_REALM}/protocol/openid-connect/token"
+# Capture curl's status instead of piping straight into jq. run.sh and
+# bring-up.sh both run under `set -o pipefail`, so a failing curl made the
+# whole pipeline fail and `set -e` killed the script BEFORE the diagnostic
+# below could print — the caller saw a bare non-zero exit and no reason.
+# Same class of bug as the `if ! cmd` note in start_canton_tunnels.
+# No `-f`: it discards the response body, and on HTTP/2 it turns a plain 401
+# into exit 56 ("failure receiving data"), which reads as a network fault
+# rather than as the rejected login it actually is. Ask for the status code
+# instead and keep the body, so the OAuth error reaches the operator.
+_CURL_RC=0
+_SMOKE_RAW=$(curl -s -w '\n%{http_code}' -X POST "$TOKEN_URL" \
     -d "grant_type=password" \
     -d "client_id=${DECPM_KEYCLOAK_CLIENT_ID}" \
     -d "username=${DECPM_KEYCLOAK_USERNAME}" \
-    -d "password=${DECPM_KEYCLOAK_PASSWORD}" \
-    | jq -r .access_token)
-if [ -z "$_SMOKE_TOKEN" ] || [ "$_SMOKE_TOKEN" = "null" ]; then
-    echo "ERROR: Keycloak password grant failed." >&2
+    -d "password=${DECPM_KEYCLOAK_PASSWORD}") || _CURL_RC=$?
+_SMOKE_CODE="${_SMOKE_RAW##*$'\n'}"
+_SMOKE_RESP="${_SMOKE_RAW%$'\n'*}"
+_SMOKE_TOKEN=$(printf '%s' "$_SMOKE_RESP" | jq -r .access_token 2>/dev/null || true)
+if [ "$_CURL_RC" -ne 0 ] || [ -z "$_SMOKE_TOKEN" ] || [ "$_SMOKE_TOKEN" = "null" ]; then
+    echo "ERROR: Keycloak password grant failed (curl exit $_CURL_RC, HTTP ${_SMOKE_CODE:-none})." >&2
     echo "  TOKEN_URL: $TOKEN_URL" >&2
     echo "  CLIENT_ID: $DECPM_KEYCLOAK_CLIENT_ID" >&2
+    echo "  USERNAME:  ${DECPM_KEYCLOAK_USERNAME}" >&2
+    echo "  RESPONSE:  $(printf '%s' "$_SMOKE_RESP" | head -c 300)" >&2
     echo "Check that DECPM_KEYCLOAK_USERNAME and DECPM_KEYCLOAK_PASSWORD are correct and Keycloak is reachable." >&2
     exit 1
 fi
 # Reused by common.sh:wait_for_server for the readiness probes against the
 # real JwtValidator. Fresh token (~5min TTL) easily outlives start_nodes.
 export DECPM_IT_AUTH_TOKEN="$_SMOKE_TOKEN"
-unset _SMOKE_TOKEN
+unset _SMOKE_TOKEN _SMOKE_RESP _CURL_RC
 
 # ---------------------------------------------------------------------------
 # Target + run-id + DEV_DIR.
@@ -146,7 +180,7 @@ export DECPM_TOPOLOGY_RETRY_MAX_ATTEMPTS=90
 # - HTTP: 8081/8082/8083 (DecMan's own HTTP API)
 # - Noise: 9000/9001/9002 (per-DecMan Noise listener; matches DECPM_NOISE_PORT
 #   values in the per-participant .env files)
-# - Canton ledger:  5001/5011/5021 (tunneled to participant-ibtc-devnet-{1,2,3}
+# - Canton ledger:  5001/5011/5021 (tunneled to canton-node-{1,2,3}/svc/participant
 #   service port 5001 via kubectl port-forward)
 # - Canton admin:   5002/5012/5022 (tunneled the same way to service port 5002)
 # These are exported (not just shell vars) so chaos phases that respawn DecMan
@@ -182,18 +216,24 @@ export DECPM_CANTON_NETWORK=devnet
 unset DECPM_ADMIN_ROLE 2>/dev/null || true
 
 # ---------------------------------------------------------------------------
-# Canton tunnel lifecycle (kubectl port-forward against the catalyst-canton
-# namespace in the ieu-devnet EKS cluster).
+# Canton tunnel lifecycle (kubectl port-forward against the canton-node-{1,2,3}
+# namespaces in the devnet EKS cluster).
+#
+# The participants moved. The old ieu-devnet cluster (EKS ibtc-devnet, account
+# 377602329138) no longer exists; that account now holds only ibtc-mainnet.
+# Each participant now runs as svc/participant in its own namespace, rather
+# than as svc/participant-ibtc-devnet-$idx in one shared namespace.
 # ---------------------------------------------------------------------------
-KUBE_CONTEXT_DEVNET=${KUBE_CONTEXT_DEVNET:-ieu-devnet}
-KUBE_NS_CANTON=${KUBE_NS_CANTON:-catalyst-canton}
+KUBE_CONTEXT_DEVNET=${KUBE_CONTEXT_DEVNET:-devnet}
+KUBE_NS_CANTON_PREFIX=${KUBE_NS_CANTON_PREFIX:-canton-node-}
+KUBE_CANTON_SVC=${KUBE_CANTON_SVC:-participant}
 CANTON_TUNNEL_PIDS=()
 
 _canton_forward_loop() {
     local idx=$1 local_ledger=$2 local_admin=$3
     while true; do
         kubectl --context="$KUBE_CONTEXT_DEVNET" port-forward \
-            "svc/participant-ibtc-devnet-$idx" -n "$KUBE_NS_CANTON" \
+            "svc/$KUBE_CANTON_SVC" -n "${KUBE_NS_CANTON_PREFIX}${idx}" \
             "${local_ledger}:5001" "${local_admin}:5002" >/dev/null 2>&1
         echo "[P$idx canton-tunnel] port-forward disconnected, restarting in 5s..." >&2
         sleep 5
@@ -221,7 +261,7 @@ start_canton_tunnels() {
     # by Copilot's review on #142 ("comments suppressed due to low confidence
     # #2") — this is the followup landing that fix.
     local auth_probe
-    if ! auth_probe=$(kubectl --context="$KUBE_CONTEXT_DEVNET" -n "$KUBE_NS_CANTON" \
+    if ! auth_probe=$(kubectl --context="$KUBE_CONTEXT_DEVNET" -n "${KUBE_NS_CANTON_PREFIX}1" \
         get svc -o name 2>&1); then
         echo "ERROR: kubectl auth probe failed for context '$KUBE_CONTEXT_DEVNET':" >&2
         echo "$auth_probe" | sed 's/^/  /' >&2
@@ -247,7 +287,7 @@ start_canton_tunnels() {
             sleep 0.5
         done
     done
-    echo "All 6 Canton ports forwarded (5001/5002, 5011/5012, 5021/5022 → svc/participant-ibtc-devnet-{1,2,3})."
+    echo "All 6 Canton ports forwarded (5001/5002, 5011/5012, 5021/5022 → ${KUBE_NS_CANTON_PREFIX}{1,2,3}/svc/$KUBE_CANTON_SVC)."
 }
 
 stop_canton_tunnels() {
@@ -264,12 +304,12 @@ stop_canton_tunnels() {
         # children of $$) AND the kubectl-matching command pattern to
         # match — kubectl isn't a direct child, so nothing ever matched
         # and the forwards leaked between runs (observed 2026-05-19 after
-        # an EXIT_RUNSH=0 run #9 left three svc/participant-ibtc-devnet-*
+        # an EXIT_RUNSH=0 run #9 left three svc/participant-*
         # port-forwards alive). When the loop subshell above dies, kubectl
         # is reparented to init and stays alive until killed explicitly.
-        # The -f pattern is scoped to our devnet context + ibtc-devnet
+        # The -f pattern is scoped to our devnet context + the participant
         # service so it won't affect unrelated kubectl invocations.
-        pkill -f "kubectl --context=$KUBE_CONTEXT_DEVNET port-forward svc/participant-ibtc-devnet" 2>/dev/null || true
+        pkill -f "kubectl --context=$KUBE_CONTEXT_DEVNET port-forward svc/$KUBE_CANTON_SVC" 2>/dev/null || true
         CANTON_TUNNEL_PIDS=()
     fi
 }


### PR DESCRIPTION
## What this does

The devnet e2e and integration-test harness could not reach devnet at all. This
gets it running again. Issue #366 has the full findings; this PR carries the
five fixes I have working code for.

## Why

Devnet moved. The old EKS cluster `ibtc-devnet` no longer exists, and Keycloak
moved with it. The harness still pointed at both.

One bug hid the rest. `devnet.env.sh` piped `curl` into `jq`, and both `run.sh`
and `bring-up.sh` set `-o pipefail`. A failing curl therefore killed the script
before its own diagnostic could print, so the caller saw `exit 6` and nothing
else. `curl -f` compounded it by discarding the response body and, on HTTP/2,
turning a plain 401 into exit 56 — which reads as a network fault rather than a
rejected login.

That is why this went undiagnosed, and why #348 and #214 both shipped saying
the suite had not been run live. Nobody could run it.

## Changes

| Commit | Fix |
|---|---|
| Retarget the devnet harness | cluster coordinates, token-URL shape, smoke-check diagnostics, credential overrides |
| Match production on the token URL | `e2e/fixtures/auth.ts` stops forcing `/auth` |
| Filter before asserting | test 04 no longer counts paginated rows |

The participants now run one per namespace:

| | Was | Is |
|---|---|---|
| Context | `ieu-devnet` | `devnet` |
| Namespace | `catalyst-canton` | `canton-node-{1,2,3}` |
| Service | `participant-ibtc-devnet-$idx` | `participant` |

The `justfile` `port-forward` recipe already used this layout, down to the port
pairs. The migration updated it and missed `devnet.env.sh`.

## How tested

Brought the stack up against live devnet and ran the Playwright suite. **8 of
12 passed**, up from not starting at all.

```
e2e stack up: P1=:8081 P2=:8082 P3=:8083
8 passed  1 failed  3 did not run  (3.7m)
```

All three nodes serve the SPA and report the new Keycloak host. The login phase
mints a real ROPC token and DecMan accepts it, which is the direct check on the
token-URL change. Test 04 went from a 57.5s timeout to passing in 3.1s, which
is the check on the pagination change.

`npm run typecheck` is clean. Both shell scripts pass `bash -n`.

The run needed the current Keycloak password from 1Password, because the value
in `development/remote/participant-*/.env` is stale. Those files are not
touched here — see #366.

## What this does not fix

Phase 05 still fails, so phases 05-08 do not run. The Deploy Contracts dialog
renders the Governance Core card disabled even though phase 04 has just
confirmed both peers hold the DAR. That is defect 9 in #366, in the frontend
rather than the harness, and I have not pinned down the cause.

Also left alone: `crates/decman/tests/common/auth.rs:75` has the same `/auth`
bug and will fail the same way, `build.rs` never refreshes a stale
`node_modules`, and the README documents the old cluster and a run command that
fails under zsh. All in #366.

## Note for the reviewer

Commit 1 groups four changes to one file. They are facets of one fix rather
than separate concerns — none of them alone makes the harness work, so
splitting them would produce commits that cannot be tested independently.
Happy to split if you would rather.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
