### PR TITLE
Verify the Daml upgrade lineage in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,6 +275,17 @@ jobs:
           fi
           echo "compared $compared DAR(s)"
           exit $rc
+      # Canton runs this same validator when a participant uploads a DAR, so a
+      # broken lineage otherwise fails at deploy time on a real network and the
+      # PR that introduced it gets no signal. #320 bumped
+      # governance-utility-onboarding-v1 to 0.3.0 and someone ran this by hand;
+      # this makes the next bump automatic.
+      #
+      # Checks every committed version together, so a package with three
+      # releases has its whole chain validated, not just the newest pair.
+      # Reads the DARs `dpm build --all` already produced, so it costs seconds.
+      - name: Verify Daml upgrade lineage
+        run: ~/.dpm/bin/dpm upgrade-check --both ../releases/v1/*.dar
       - name: Test governance-core
         run: cd governance-core-test && ~/.dpm/bin/dpm test
       - name: Test governance-token-custody

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,11 +281,18 @@ jobs:
       # governance-utility-onboarding-v1 to 0.3.0 and someone ran this by hand;
       # this makes the next bump automatic.
       #
-      # Checks every committed version together, so a package with three
-      # releases has its whole chain validated, not just the newest pair.
-      # Reads the DARs `dpm build --all` already produced, so it costs seconds.
+      # Takes both sets of DARs:
+      #   */.daml/dist  — what `dpm build --all` just produced, so a version
+      #                   bumped in daml.yaml is checked before its DAR is
+      #                   ever committed. That is exactly when a reviewer
+      #                   wants to hear about a broken upgrade.
+      #   ../releases/v1 — the shipped history, so a package with three
+      #                   releases has its whole chain validated rather than
+      #                   only the newest pair.
+      # A package present in both appears once: the validator keys on package
+      # id, and the DAR-verification step above already pins those identical.
       - name: Verify Daml upgrade lineage
-        run: ~/.dpm/bin/dpm upgrade-check --both ../releases/v1/*.dar
+        run: ~/.dpm/bin/dpm upgrade-check --both */.daml/dist/*.dar ../releases/v1/*.dar
       - name: Test governance-core
         run: cd governance-core-test && ~/.dpm/bin/dpm test
       - name: Test governance-token-custody


### PR DESCRIPTION
Same shape of gate as #293/#347, one step in the existing `daml` job.

Canton runs this exact validator when a participant uploads a DAR, so today a broken lineage fails at **deploy time, on a real network**, and the PR that introduced it gets no signal. #320 bumped `governance-utility-onboarding-v1` to 0.3.0 and a reviewer ran the check by hand and pasted the output. The next bump had no such guarantee.

### The command in the issue does not run as written

The issue proposes:

```yaml
run: ~/.dpm/bin/dpm upgrade-check --both
```

That fails. The tool requires DAR arguments:

```
Usage: upgrade-check [options] DAR_FILE(S)
Error: Missing argument DAR_FILE(S)
```

So the step passes `../releases/v1/*.dar` (the `daml` job's working-directory is `daml/`). Checking every committed version **together** matters: a package with three releases gets its whole chain validated, not just the newest pair. The run confirms that — it walks `0.1.0 → 0.2.0 → 0.3.0` for onboarding and `0.1.0 → 0.1.1 → 0.1.3` for rewards.

### I verified it fails, not just that it passes

A gate that cannot fail is worse than none — the lesson from the review of #347, where the DAR check could have silently verified nothing. So I built a deliberately illegal upgrade: `governance-action-v1` as 0.2.0 with a non-`Optional` field added to `GovernableActionView`.

```
EXIT CODE: 1
NOT_VALID_UPGRADE_PACKAGE(8,0): … cannot be an upgrade of … v0.1.0.
Reason: The upgraded data type GovernableActionView has added new fields,
but those fields are not Optional.
```

It also caught a second problem in the same build (`interfaces cannot be upgraded`). The break was reverted; nothing from it is in this diff.

### Cost and coverage

Green run: **57 lineages validated, exit 0**, covering all 7 of our package families plus their dependencies. It reads DARs that `dpm build --all` already produced, so it adds seconds to a ~7 minute job.

### Scope

This repo only, as the issue says. It is a convenience gate, not a safety gate — Canton still enforces this at upload. The value is moving the signal from deploy time to PR time.

Closes #357
