### PR TITLE
fix(auth): protect party config bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,11 +297,12 @@ curl http://localhost:8081/network-config
 
 ### Party Credentials
 
-Per-party credentials (outbound OAuth for Canton, package IDs) are stored in the SQLite database and managed via the `/party-config` API endpoint. Either the Keycloak fields or the Auth0 fields are supplied — whichever matches the node's top-level provider:
+Per-party credentials (outbound OAuth for Canton, package IDs) are stored in the SQLite database and managed via the `/party-config` API endpoint. The first write is protected exactly like later updates: callers must authenticate and, when `DECPM_ADMIN_ROLE` is set, carry that role. Either the Keycloak fields or the Auth0 fields are supplied — whichever matches the node's top-level provider:
 
 ```bash
 # Keycloak (client_credentials)
 curl -X PUT http://localhost:8081/party-config \
+  -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
     "dec_party_id": "decparty::1220abc...",
@@ -315,6 +316,7 @@ curl -X PUT http://localhost:8081/party-config \
 
 # Auth0 M2M (client_credentials)
 curl -X PUT http://localhost:8081/party-config \
+  -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
     "dec_party_id": "decparty::1220abc...",

--- a/crates/decman/src/server/handlers/auth.rs
+++ b/crates/decman/src/server/handlers/auth.rs
@@ -738,7 +738,7 @@ mod tests {
     };
     use serde_json::{Value, json};
     use sqlx::SqlitePool;
-    use tokio::sync::{Mutex, RwLock};
+    use tokio::sync::RwLock;
 
     use super::{AdminTokenSource, grant_rights};
     use crate::{
@@ -774,7 +774,6 @@ mod tests {
             ))),
             admin_role: admin_role.map(str::to_string),
             party_credentials,
-            bootstrap_mu: Arc::new(Mutex::new(())),
             test_mode: true,
             refreshing_prefixes: Arc::new(RwLock::new(HashSet::new())),
             http_client: reqwest::Client::new(),

--- a/crates/decman/src/server/handlers/governance.rs
+++ b/crates/decman/src/server/handlers/governance.rs
@@ -3514,7 +3514,6 @@ mod get_party_credentials_tests {
             ))),
             admin_role: None,
             party_credentials: Arc::new(RwLock::new(Vec::new())),
-            bootstrap_mu: Arc::new(tokio::sync::Mutex::new(())),
             test_mode: true,
             refreshing_prefixes: Arc::new(RwLock::new(HashSet::new())),
             http_client: reqwest::Client::new(),

--- a/crates/decman/src/server/handlers/party_config.rs
+++ b/crates/decman/src/server/handlers/party_config.rs
@@ -124,6 +124,10 @@ pub async fn save_party_config(
     data: web::Data<AppState>,
     body: web::Json<PartyConfigRequest>,
 ) -> impl Responder {
+    if let Err(resp) = require_admin(&http_req, data.admin_role.as_deref()) {
+        return resp;
+    }
+
     let req = body.into_inner();
 
     // Credential merge: None = keep existing, Some("") = clear, Some(val) = set
@@ -137,14 +141,6 @@ pub async fn save_party_config(
             existing.and_then(|p| p.auth0.clone()),
         )
     };
-
-    // Bootstrap exemption: the middleware lets first-run PUT /party-config
-    // through unauthenticated. Once any party credential exists, require the
-    // caller to carry the admin role.
-    let is_fresh = data.party_credentials.read().await.is_empty();
-    if !is_fresh && let Err(resp) = require_admin(&http_req, data.admin_role.as_deref()) {
-        return resp;
-    }
 
     let auth0_requested = req.auth0_domain.as_deref().is_some_and(|s| !s.is_empty());
 
@@ -577,7 +573,7 @@ mod tests {
     };
     use serde_json::json;
     use sqlx::SqlitePool;
-    use tokio::sync::{Mutex, RwLock};
+    use tokio::sync::RwLock;
 
     use super::{discover_member_party, get_party_config, save_party_config};
     use crate::{
@@ -615,7 +611,6 @@ mod tests {
             ))),
             admin_role: Some("decman-admin".to_string()),
             party_credentials,
-            bootstrap_mu: Arc::new(Mutex::new(())),
             test_mode: true,
             refreshing_prefixes: Arc::new(RwLock::new(HashSet::new())),
             http_client: reqwest::Client::new(),
@@ -639,9 +634,8 @@ mod tests {
     /// `keycloak_url` without supplying a fresh `keycloak_client_secret`
     /// must get a 400 — otherwise `merge_optional_secret` would forward
     /// the existing real secret to the new (potentially attacker-controlled)
-    /// host on the next token mint. State is pre-populated with one party so
-    /// the bootstrap exemption does not apply; the request is admin-authed
-    /// via `AuthMiddleware` + `MockValidator`.
+    /// host on the next token mint. The request is admin-authenticated via
+    /// `AuthMiddleware` + `MockValidator`.
     #[actix_web::test]
     async fn save_party_config_rejects_url_change_without_fresh_secret() {
         let db = SqlitePool::connect("sqlite::memory:")
@@ -684,7 +678,6 @@ mod tests {
             ))),
             admin_role: Some("decman-admin".to_string()),
             party_credentials,
-            bootstrap_mu: Arc::new(Mutex::new(())),
             test_mode: true,
             refreshing_prefixes: Arc::new(RwLock::new(HashSet::new())),
             http_client: reqwest::Client::new(),
@@ -751,7 +744,6 @@ mod tests {
             ))),
             admin_role: None,
             party_credentials,
-            bootstrap_mu: Arc::new(Mutex::new(())),
             test_mode: true,
             refreshing_prefixes: Arc::new(RwLock::new(HashSet::new())),
             http_client: reqwest::Client::new(),

--- a/crates/decman/src/server/middleware/auth.rs
+++ b/crates/decman/src/server/middleware/auth.rs
@@ -1,10 +1,8 @@
 //! Bearer-token auth middleware.
 //!
 //! Runs in front of every request. Public paths (SPA assets, `/auth-config`,
-//! swagger) pass through. `PUT /party-config` is special-cased for first-run
-//! bootstrap: if the `party_credentials` table is empty we let the call
-//! through unauthenticated so a fresh node can be configured; after the first
-//! row lands, normal auth applies and the handler enforces admin role.
+//! swagger) pass through. All other routes, including the first
+//! `PUT /party-config`, require authentication.
 //!
 //! Everything else requires a valid `Authorization: Bearer <token>` that the
 //! configured `TokenValidator` accepts. The resolved `Principal` is attached
@@ -80,41 +78,6 @@ where
                     .json(json!({"error": "application state missing"}));
                 return Ok(req.into_response(response).map_into_right_body());
             };
-
-            // Bootstrap: first `PUT /party-config` on a fresh node is allowed
-            // without a token. The operator typically has not provisioned an
-            // admin user in the IdP at this point, so requiring one would be
-            // a chicken-and-egg block.
-            //
-            // Concurrency: two unauthenticated requests racing while the table
-            // is empty must not both pass through (otherwise the second
-            // overwrites the first without ever authenticating). We serialize
-            // the bootstrap window with `bootstrap_mu` held across the entire
-            // request: only one bootstrap-shaped call is in flight at a time;
-            // any concurrent attempt is rejected with 409. After the holder
-            // writes credentials, subsequent calls fall through to normal auth.
-            if method == "PUT"
-                && path == "/party-config"
-                && app_state.party_credentials.read().await.is_empty()
-            {
-                let Ok(guard) = app_state.bootstrap_mu.clone().try_lock_owned() else {
-                    let response = HttpResponse::Conflict()
-                        .json(json!({"error": "bootstrap already in progress"}));
-                    return Ok(req.into_response(response).map_into_right_body());
-                };
-                // Recheck under the guard. A previous holder may have just
-                // finished writing; if so, drop the lock and require auth.
-                if app_state.party_credentials.read().await.is_empty() {
-                    tracing::info!(
-                        "PUT /party-config bootstrap: unauthenticated call allowed because \
-                         party_credentials is empty. Subsequent writes will require admin role."
-                    );
-                    let res = service.call(req).await?;
-                    drop(guard);
-                    return Ok(res.map_into_left_body());
-                }
-                drop(guard);
-            }
 
             let token = bearer_token(&req).unwrap_or_default();
             match app_state.token_validator.validate(&token).await {
@@ -346,7 +309,7 @@ mod tests {
         web::Data,
     };
     use sqlx::SqlitePool;
-    use tokio::sync::{Mutex, RwLock};
+    use tokio::sync::RwLock;
 
     use crate::{
         auth::{JwtValidator, MockValidator, TokenValidator},
@@ -386,7 +349,6 @@ mod tests {
             token_validator: validator,
             admin_role: Some("decman-admin".to_string()),
             party_credentials,
-            bootstrap_mu: Arc::new(Mutex::new(())),
             test_mode: true,
             refreshing_prefixes: Arc::new(RwLock::new(HashSet::new())),
             http_client: reqwest::Client::new(),
@@ -423,8 +385,8 @@ mod tests {
     async fn jwt_validator_rejects_when_no_trusted_issuer() {
         // JwtValidator with no inbound config and no party_credentials
         // trusts no issuer. Empty / arbitrary tokens are rejected — the
-        // only way to reach the handler is the public allowlist or the
-        // bootstrap exemption (neither of which apply to /node-config).
+        // only way to reach the handler is the public allowlist (which does
+        // not apply to /node-config).
         let parties = Arc::new(RwLock::new(Vec::new()));
         let validator = TokenValidator::Jwt(Arc::new(JwtValidator::new(
             None,
@@ -486,8 +448,15 @@ mod tests {
     }
 
     #[actix_web::test]
-    async fn put_party_config_bootstrap_allowed_when_empty() {
-        let state = build_app_state(Vec::new()).await;
+    async fn put_party_config_bootstrap_requires_auth_when_empty() {
+        let parties = Arc::new(RwLock::new(Vec::new()));
+        let validator = TokenValidator::Jwt(Arc::new(JwtValidator::new(
+            None,
+            None,
+            parties,
+            reqwest::Client::new(),
+        )));
+        let state = build_app_state_with(Vec::new(), validator).await;
         let app = test::init_service(
             App::new()
                 .app_data(state)
@@ -498,6 +467,6 @@ mod tests {
 
         let req = TestRequest::put().uri("/party-config").to_request();
         let resp = test::call_service(&app, req).await;
-        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
     }
 }

--- a/crates/decman/src/server/mod.rs
+++ b/crates/decman/src/server/mod.rs
@@ -122,11 +122,6 @@ pub struct AppState {
     pub admin_role: Option<String>,
     /// Party credentials (mutable, hot-reloadable)
     pub party_credentials: Arc<RwLock<Vec<PartyCredentials>>>,
-    /// Serializes unauthenticated `PUT /party-config` bootstrap calls so two
-    /// concurrent first-run requests cannot both pass the empty-table auth
-    /// exemption and overwrite each other. Held by the auth middleware for
-    /// the lifetime of a bootstrap request.
-    pub bootstrap_mu: Arc<Mutex<()>>,
     /// Every in-flight workflow this node owns, keyed by `instance_name`.
     /// Replaces the single-tenant per-kind `HttpWorkflowState` singletons, the
     /// global in-flight gate, and the single `active_workflow` routing slot:
@@ -941,18 +936,17 @@ pub async fn start_server(
             admin_role.clone().unwrap_or_default(),
         )))
     } else {
-        let no_top_level_config = config.keycloak.is_none();
+        let no_top_level_config = config.keycloak.is_none() && config.auth0.is_none();
         let no_party_creds = party_credentials.read().await.is_empty();
         if no_top_level_config && no_party_creds {
             tracing::warn!(
-                "No top-level Keycloak config (--keycloak-url/realm/client-id) and no \
-                 party credentials yet. Inbound auth will reject every request except \
-                 the first-run PUT /party-config bootstrap. Configure the IdP and \
-                 provision a party to make the node usable."
+                "No top-level identity-provider config and no party credentials yet. \
+                 Inbound auth will reject every protected request. Configure the IdP \
+                 before provisioning a party."
             );
         } else if no_top_level_config {
             tracing::info!(
-                "No top-level Keycloak config; trusting only issuers from \
+                "No top-level identity-provider config; trusting only issuers from \
                  party_credentials ({} configured).",
                 party_credentials.read().await.len()
             );
@@ -992,7 +986,6 @@ pub async fn start_server(
         token_validator,
         admin_role,
         party_credentials: party_credentials.clone(),
-        bootstrap_mu: Arc::new(Mutex::new(())),
         workflows: workflows.clone(),
         // "test_mode" here means the permissive/wildcard-token mode; driven by
         // `--insecure` (or tests). See the `insecure` binding above.


### PR DESCRIPTION
## Summary

- require bearer authentication for the first `PUT /party-config`, not only later updates
- enforce the configured admin role in the handler on every write
- remove the unauthenticated bootstrap mutex/path
- account for Auth0 when reporting whether a top-level identity provider is configured
- document the authenticated bootstrap flow

## Security impact

A fresh node can no longer be claimed by the first unauthenticated caller. Operators must configure the top-level IdP and admin role before saving per-party credentials.

## Validation

- `cargo fmt --check`
- `DECMAN_SKIP_FRONTEND=1 cargo test -p decman --lib` (476 passed)