### PR TITLE
Refresh the stale claims across the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,14 @@ The table below is a curated subset. A complete, interactive API reference is av
 | `/dars/distribute` | POST | Distributes DARs across all participants |
 | `/dars/distribute/status` | GET | Returns DARs distribution workflow progress |
 | `/packages/vetted` | GET | Returns packages uploaded on this node |
+| `/external-parties` | GET | Lists the external (co-validated) parties this node hosts |
+| `/v0/tenant/prepare` | POST | Wallet-facing: builds an external party's onboarding topology and returns the hash to sign |
+| `/v0/tenant/onboard` | POST | Wallet-facing: validates the wallet's signed topology, co-signs, and submits it |
+| `/v0/tenant/{party}/status` | GET | Wallet-facing: reports whether this host has the party hosted yet |
+
+The `/v0/tenant/*` endpoints are the tenant API. They authenticate with a
+separate tenant API key rather than the operator JWT, and are driven by
+[`decman-wallet`](crates/decman-wallet/README.md).
 
 ## Development
 
@@ -514,18 +522,20 @@ dec-party-manager INFO chatter and Canton/Noise convergence warnings.
 
 The suite is organised into two layers:
 
-- **Phases** — top-level workflow chunks, one file in `tests/common/phases/`
-  per phase (`create_dec_party`, `distribute_dars`, `deploy_gov_core`,
-  `token_custody`, `utility_onboarding`, `generic_vote`, `kick`). Each
-  phase corresponds 1:1 to one of the original bash scripts and is logged
-  as `INFO Phase: <name>`.
+- **Phases** — top-level workflow chunks, one file per phase in
+  [`crates/decman/tests/common/phases/`](crates/decman/tests/common/phases/).
+  [`crates/decman/tests/governance_workflows.rs`](crates/decman/tests/governance_workflows.rs)
+  runs them in order, and each is logged as `INFO Phase: <name>`. The set
+  covers the governance arc (`create_dec_party`, `distribute_dars`,
+  `deploy_gov_core`, `token_custody`, `utility_onboarding`, `generic_vote`,
+  `kick`), the add-party and external-party flows, and the chaos phases
+  (restart / resume, cancel cascades, concurrent workflows).
 - **Scenarios** — Given-When-Then story arcs built with the
-  [`Scenario`](tests/common/scenario.rs) DSL. Each scenario has its own
-  header, indented step trace, and completion line. A phase runs **one or
-  more scenarios**: six of the seven phases run a single scenario;
-  `utility_onboarding` runs eight (four propose-confirm-execute cycles —
-  ProvisionProviderService, SetupUtility, Mint, Burn — plus four
-  side-effect assertion scenarios), for **14 scenarios total**.
+  [`Scenario`](crates/decman/tests/common/scenario.rs) DSL. Each scenario has
+  its own header, indented step trace, and completion line. A phase runs one
+  or more scenarios: most run a single one, while `utility_onboarding` runs
+  eight (four propose-confirm-execute cycles — ProvisionProviderService,
+  SetupUtility, Mint, Burn — plus four side-effect assertion scenarios).
 
 A scenario may omit `Given` and/or `When` and contain only `Then`s.
 That happens when the action has already been taken by an earlier

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -110,10 +110,11 @@ The application communicates with Canton via gRPC using the following services:
 |---------|---------|
 | `TopologyManagerReadService` | Query DNS, P2P, and other topology mappings |
 | `TopologyManagerWriteService` | Submit topology proposals and authorize transactions |
-| `VaultManagerService` | Manage key vaults (generate keys, sign, export) |
+| `VaultService` | Manage key vaults (generate keys, sign, export) |
 | `IdentityInitializationService` | Query participant ID |
-| `SynchronizerConnectivityService` | Discover synchronizer IDs |
-| `PackageService` | Upload DAR files |
+| `SynchronizerConnectivityService` | Discover synchronizer IDs, disconnect and reconnect during ACS import |
+| `PackageService` | Upload DAR files, list vetted packages |
+| `PartyManagementService` (`canton.admin.participant.v30`) | Offline party replication: `ExportPartyAcs`, `ImportPartyAcs`, `GetHighestOffsetByTimestamp`, `ClearPartyOnboardingFlag` |
 
 **Ledger API services:**
 | Service | Purpose |
@@ -121,8 +122,10 @@ The application communicates with Canton via gRPC using the following services:
 | `CommandService` | Submit and execute Daml commands |
 | `StateService` | Query active contracts |
 | `UserManagementService` | Query user rights |
-| `PartyManagementService` | Query party metadata and annotations |
+| `PartyManagementService` (`ledger.api.v2.admin`) | Query party metadata and annotations |
 | `InteractiveSubmissionService` | Prepare and execute multi-party interactive submissions |
+| `UpdateService` | Read transaction updates by offset |
+| `EventQueryService` | Look up create/archive events for a contract |
 
 ### Workflow Engine
 
@@ -190,7 +193,7 @@ Minimum message size: 6 bytes (type + length with zero payload).
 
 ### Message Categories
 
-**Commands (0x0001 - 0x000F):** Sent by coordinator to peers.
+**Commands (0x0001 - 0x000F, 0x0020 - 0x002F):** Sent by coordinator to peers.
 
 | Code | Name | Payload | Description |
 |------|------|---------|-------------|
@@ -209,6 +212,12 @@ Minimum message size: 6 bytes (type + length with zero payload).
 | 0x000D | ListPeers | (empty) | Request a peer's known-peer list |
 | 0x000E | RequestMemberParty | (empty) | Request a peer's member party |
 | 0x000F | Health | (empty) | Health probe |
+| 0x0020 | GenerateAddPartyKeys | JSON add-party config | New member generates its namespace + Daml keys (others skip) |
+| 0x0021 | SignAddParty | Config + add-party proposals | Sign the add-party DNS + P2P proposals |
+| 0x0022 | ImportAcs | ACS snapshot | New member imports the party's ACS (others skip) |
+| 0x0023 | ClearOnboardingFlag | JSON clear config | New member drives `ClearPartyOnboardingFlag` (others skip) |
+| 0x0024 | SignClearOnboarding | Clearing proposal or skip marker | Sign the onboarding-flag clearing proposal |
+| 0x0025 | SignChangeThreshold | Config + threshold proposals | Sign the change-threshold DNS + P2P proposals |
 
 **Invites (0x0010 - 0x001F):** Sent during heartbeat to invite peers.
 
@@ -221,6 +230,8 @@ Minimum message size: 6 bytes (type + length with zero payload).
 | 0x0014 | CancelInvite | Cancel a previously sent invitation |
 | 0x0015 | RetryWorkflow | Coordinator tells peers to retry a failed run |
 | 0x0016 | DeclineInvitation | Peer declines an invitation (frees coordinator's run) |
+| 0x0017 | InviteAddParty | Invite to add a new member to a decentralized party |
+| 0x0018 | InviteChangeThreshold | Invite to change a decentralized party's threshold |
 
 **Responses (0x0100 - 0x01FF):** Replies from coordinator or peer.
 
@@ -247,8 +258,13 @@ Minimum message size: 6 bytes (type + length with zero payload).
 | 0x0203 | P2pSignatures | Signed P2P proposals |
 | 0x0204 | SubmissionSignatures | Signed ledger submissions |
 | 0x0205 | KickSignatures | Signed kick proposals |
+| 0x0206 | AddPartyKeysUpload | New member's generated keys + participant id |
+| 0x0207 | AddPartySignatures | Signed add-party DNS + P2P pair |
+| 0x0208 | AddPartyClearSignatures | Signed onboarding-flag clearing proposal |
+| 0x0209 | AddPartyClearProposal | The clearing proposal the new member authored |
+| 0x020A | ChangeThresholdSignatures | Signed change-threshold DNS + P2P pair |
 
-**Chunked Transfer (0x0300 - 0x03FF):** For payloads exceeding 1 KB.
+**Chunked Transfer (0x0300 - 0x03FF):** For payloads exceeding 1 MiB.
 
 | Code | Name | Payload | Description |
 |------|------|---------|-------------|
@@ -256,7 +272,7 @@ Minimum message size: 6 bytes (type + length with zero payload).
 | 0x0301 | GetChunk | chunk_index(4B) | Request specific chunk |
 | 0x0302 | Chunk | chunk_index(4B) + chunk_data(var) | Chunk data response |
 
-Chunk size: 1024 bytes. Chunking is required for payloads exceeding `MAX_PAYLOAD_SIZE` (1024 bytes).
+Chunk size: 1 MiB (`CHUNK_SIZE`). Chunking is required for payloads exceeding `MAX_PAYLOAD_SIZE` (1 MiB). An assembled chunked response is capped at 16 MiB (`MAX_CHUNKED_TOTAL_SIZE`).
 
 ### Security
 
@@ -284,8 +300,8 @@ Creates a new decentralized party with multiple hosting participants.
 | 8 | Complete | All | Disconnect peers, workflow finished |
 
 **Canton API calls:**
-- `VaultManagerService.GenerateKey` -- Generate namespace and signing keys (step 2)
-- `VaultManagerService.ExportKeyPair` -- Export public keys for proposal creation (step 2)
+- `VaultService.GenerateKey` -- Generate namespace and signing keys (step 2)
+- `VaultService.ExportKeyPair` -- Export public keys for proposal creation (step 2)
 - `TopologyManagerWriteService.Authorize` -- Sign topology proposals (steps 4, 6)
 - `TopologyManagerWriteService.AddTransactions` -- Submit signed proposals (steps 5, 7)
 
@@ -352,6 +368,97 @@ Uploads DAR packages to all participants without deploying contracts.
 - `PackageService.UploadDarFile` -- Upload DAR packages (step 2)
 
 **Minimum participants:** 2
+
+### Add Party (Add a Host to an Existing Decentralized Party)
+
+Adds a hosting participant to a decentralized party that already exists, and
+replicates the party's active contracts to it. The party keeps transacting on
+its existing hosts throughout: Canton's `HostingParticipant.Onboarding` marker
+suspends it only on the joining node.
+
+**Steps:**
+
+| # | Step | Actor | Description |
+|---|------|-------|-------------|
+| 1 | WaitingForPeers | Coordinator | Wait for the existing members and the joiner to connect |
+| 2 | GenerateNewMemberKeys | New member | Generate namespace + Daml signing keys and upload the public halves |
+| 3 | ExportState | Coordinator | Read the current DNS + P2P state, validate the add, capture the ledger offset |
+| 4 | CreateProposals | Coordinator | Build the updated DNS + P2P proposals, with the joiner marked `Onboarding` |
+| 5 | SignProposals | All | Every member signs both proposals with its namespace key |
+| 6 | SubmitProposals | Coordinator | Submit DNS then P2P, then export the party's ACS |
+| 7 | SyncAcs | New member | Disconnect from the synchronizer, import the ACS, reconnect (skipped when the ACS is empty) |
+| 8 | PrepareClearOnboarding | Coordinator | Swap the command payload for the clear-flag phase |
+| 9 | ProposeClearOnboarding | New member | Author the `ClearPartyOnboardingFlag` transaction past Canton's safe time |
+| 10 | PrepareClearSign | Coordinator | Turn the authored proposal into a signing round (or a skip marker) |
+| 11 | SignClearOnboarding | All | Every member signs the clearing proposal |
+| 12 | SubmitClearOnboarding | Coordinator | Submit it and wait for the marker to drop |
+| 13 | Complete | All | Disconnect peers, workflow finished |
+
+**Canton API calls:**
+- `VaultService.GenerateKey` / `ExportKeyPair` -- New member's keys (step 2)
+- `TopologyManagerWriteService.Authorize` / `AddTransactions` -- Proposals (steps 5, 6, 11, 12)
+- `PartyManagementService.GetHighestOffsetByTimestamp` -- Capture the export offset (step 3)
+- `PartyManagementService.ExportPartyAcs` -- Export the snapshot, scoped to the joiner (step 6)
+- `SynchronizerConnectivityService.DisconnectSynchronizer` / `ReconnectSynchronizers` -- Bracket the import (step 7)
+- `PartyManagementService.ImportPartyAcs` -- Import the snapshot (step 7)
+- `PackageService.ListPackages` -- Preflight the joiner's vetted packages before the import (step 7)
+- `PartyManagementService.ClearPartyOnboardingFlag` -- Clear the marker (steps 9, 12)
+
+**Minimum participants:** 2 (an existing member + the joiner)
+
+**Restriction:** the workflow requires a `DecentralizedNamespaceDefinition` and a
+Noise quorum of member nodes. It cannot add a host to a local party or to an
+external party. It fails at `ExportState` for any other party type.
+
+### Change Threshold
+
+Changes the signing threshold of an existing decentralized party's namespace.
+
+**Steps:**
+
+| # | Step | Actor | Description |
+|---|------|-------|-------------|
+| 1 | WaitingForPeers | Coordinator | Wait for the party's members to connect |
+| 2 | ExportState | Coordinator | Read the current DNS state and validate the new threshold |
+| 3 | CreateProposals | Coordinator | Build the new-threshold DNS + P2P proposals |
+| 4 | SignProposals | All | Every member signs the proposals |
+| 5 | Submit | Coordinator | Submit the change and wait for propagation |
+| 6 | Complete | All | Disconnect peers |
+
+**Canton API calls:**
+- `TopologyManagerWriteService.Authorize` -- Sign the proposals (step 4)
+- `TopologyManagerWriteService.AddTransactions` -- Submit the change (step 5)
+
+**Minimum participants:** 2 (party members)
+
+### External Party Onboarding (Tenant API)
+
+Creates a **co-validated** party: hosted on several participants at once but
+controlled by a single Ed25519 key its owner holds. This is not a Noise
+workflow. It is stateless HTTP, driven by the wallet, with Canton itself as the
+only coordination store.
+
+**Steps:**
+
+| # | Step | Actor | Description |
+|---|------|-------|-------------|
+| 1 | prepare | Wallet -> every host | `POST /v0/tenant/prepare`. Each host independently builds the serial-1 `PartyToParticipant` and returns it with the hash to sign |
+| 2 | compare | Wallet | Require every host's bytes to be identical; reject the onboarding otherwise |
+| 3 | sign | Wallet | Sign the hashes locally. The private key never leaves the wallet process |
+| 4 | onboard | Wallet -> every host | `POST /v0/tenant/onboard`. Each host re-validates the bytes, co-signs with its own topology key, and submits |
+| 5 | poll | Wallet | `GET /v0/tenant/{party}/status` on every host until each reports the party hosted |
+
+Canton promotes the mapping once every host has authorized. The party's signing
+key rides inside the mapping as `party_signing_keys`, so the party transacts
+through `InteractiveSubmissionService` rather than plain submission.
+
+**Authentication:** the `/v0/tenant/` prefix uses a separate tenant API key and
+bypasses the operator JWT. Read-only `/external-parties` lists the external
+parties a node hosts.
+
+**Scope:** this flow replicates identity only, never state. It creates a new
+party; it cannot decentralize a party that already holds contracts. See
+[crates/decman-wallet/README.md](../crates/decman-wallet/README.md).
 
 ## Governance System
 
@@ -668,7 +775,7 @@ FAR configuration is used in:
 ### Infrastructure Requirements
 
 - **Canton Admin API access required**: The application needs access to privileged Admin API endpoints (topology management, key vaults, package upload). This is not the public Ledger API -- it requires high node-level privileges.
-- **6 Admin API services used**: TopologyManagerRead, TopologyManagerWrite, VaultManager, IdentityInitialization, SynchronizerConnectivity, PackageService
+- **7 Admin API services used**: TopologyManagerRead, TopologyManagerWrite, Vault, IdentityInitialization, SynchronizerConnectivity, PackageService, PartyManagement
 - **Canton protocol version**: 35 (hardcoded for key export and topology operations)
 - **Network ports**: TCP 8080 (HTTP server) + TCP 9000 (Noise P2P)
 
@@ -677,7 +784,7 @@ FAR configuration is used in:
 - **Topology propagation delay**: 30 seconds after the effective time of a topology change before it can be used. Without this wait, transactions may be rejected with `LOCAL_VERDICT_TIMEOUT`.
 - **Topology retry settings**: 30 attempts with 2-second delays when polling for topology state changes
 - **Heartbeat interval**: 5-second ping cycle for peer connectivity monitoring
-- **Noise timeouts**: 10-second request timeout, 30-second handshake timeout (configurable), 120-second message timeout (configurable)
+- **Noise timeouts**: 10-second request timeout, 25-second chunk-fetch timeout, 45-second handler timeout, 30-second handshake timeout (configurable), 120-second message timeout (configurable)
 
 ### Participant Minimums
 
@@ -687,13 +794,16 @@ FAR configuration is used in:
 | Kick | 2 (remaining members) |
 | Contracts | 3 |
 | DARs | 2 |
+| Add Party | 2 (an existing member + the joiner) |
+| Change Threshold | 2 (party members) |
 
 ### Known Limitations
 
-- **ACS sync for existing contracts**: Adding a new member to a party that already has active contracts requires Active Contract Set (ACS) export/import. This operation requires Canton's repair mode, which necessitates a participant restart. If the party has no active contracts, ACS sync is not needed.
-- **No external party support**: All members must run the DecMan application on their own Canton participant node. There is no API for external parties to join without running the software.
-- **Single workflow at a time**: The Noise listener is paused during active workflows. Only one workflow can run concurrently per node.
-- **Coordinator single point of progress**: If the coordinator goes offline during a workflow, the workflow cannot continue. Peers will retry 3 times before aborting.
+- **ACS sync for existing contracts**: Adding a new member to a party that already has active contracts requires Active Contract Set (ACS) export/import. The add-party workflow does this with Canton offline party replication (`ExportPartyAcs` / `ImportPartyAcs` plus the `HostingParticipant.Onboarding` marker), so no repair mode and no participant restart are needed. The importing node does disconnect from the synchronizer for the duration of the import, which briefly pauses that node; the party keeps transacting on its other hosts. If the party has no active contracts, the workflow skips the sync.
+- **Add-party is decentralized-party only**: The workflow requires a `DecentralizedNamespaceDefinition` and a Noise quorum of member nodes. It cannot add a host to a local or an already-onboarded external party. See [Canton Party Replication](CANTON_PARTY_REPLICATION.md).
+- **External parties are onboarded fresh, not decentralized in place**: The tenant API creates a co-validated party from a key the wallet already holds. It replicates identity only, never state, so it cannot take over a party that already holds contracts.
+- **ACS transfer size**: The snapshot travels over the Noise chunked-transfer path, which caps an assembled response at 16 MiB (`MAX_CHUNKED_TOTAL_SIZE`). A party with a large ACS exceeds this.
+- **Coordinator single point of progress**: A workflow makes no progress while its coordinator is offline. The run is persisted, so the coordinator resumes it on restart; peers retry 3 times before aborting.
 
 ### Daml Package Dependencies
 

--- a/docs/CANTON_PARTY_REPLICATION.md
+++ b/docs/CANTON_PARTY_REPLICATION.md
@@ -4,15 +4,18 @@
 > PR #27 (February 2026) and reflects the Canton 3.3-era guidance, under
 > which ACS import required repair mode, a participant restart, and a
 > synchronizer disconnect. **The add-party workflow implemented in this
-> repository does NOT work that way**: it uses Canton 3.4 offline party
-> replication (`PartyManagementService.ExportPartyAcs` / `ImportPartyAcs`)
-> with the `HostingParticipant.Onboarding` marker and
-> `ClearPartyOnboardingFlag` — no repair mode, no restart, and the brief
-> synchronizer disconnect the import still requires is automated by the
-> workflow. See
-> [ADD_PARTY_REDEVELOPMENT.md](ADD_PARTY_REDEVELOPMENT.md) §6 for the
-> implemented design; keep this document only as background on the
-> replication problem space.
+> repository does NOT work that way**: it uses Canton offline party
+> replication (`PartyManagementService.ExportPartyAcs` / `ImportPartyAcs`),
+> stable at protocol version 35, with the `HostingParticipant.Onboarding`
+> marker and `ClearPartyOnboardingFlag` — no repair mode, no restart, and
+> the brief synchronizer disconnect the import still requires is automated
+> by the workflow. Every procedure below is therefore superseded; keep this
+> document only as background on the replication problem space.
+>
+> For the implemented design see
+> [ARCHITECTURE.md](ARCHITECTURE.md#add-party-add-a-host-to-an-existing-decentralized-party),
+> and for the code
+> [`crates/decman/src/workflow/add_party/`](../crates/decman/src/workflow/add_party/).
 
 ## Overview
 
@@ -392,48 +395,28 @@ struct GetAddPartyStatusRequest {
 > used. An earlier draft of this section listed those steps as "missing"; the
 > offline-replication flow above superseded them.
 
-### Recommended Approach
+### Shipped Approach
 
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                    Add Party Workflow                           │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                 │
-│  1. Check if party has active contracts                         │
-│     │                                                           │
-│     ├─── NO contracts ──► Simple Replication (current impl)     │
-│     │                                                           │
-│     └─── HAS contracts ──► ACS Replication Flow:                │
-│                            │                                    │
-│                            ├── a) New member enables repair     │
-│                            │      mode and restarts             │
-│                            │                                    │
-│                            ├── b) Topology transactions         │
-│                            │      (Observation permission)      │
-│                            │                                    │
-│                            ├── c) Wait for activation           │
-│                            │                                    │
-│                            ├── d) Export ACS from coordinator   │
-│                            │                                    │
-│                            ├── e) Transfer via Noise protocol   │
-│                            │                                    │
-│                            ├── f) New member disconnects        │
-│                            │                                    │
-│                            ├── g) Import ACS                    │
-│                            │                                    │
-│                            ├── h) Reconnect                     │
-│                            │                                    │
-│                            └── i) Upgrade to Confirmation       │
-│                                                                 │
-└─────────────────────────────────────────────────────────────────┘
-```
+The implemented flow is the one listed above, and it does not branch on repair
+mode. Step by step it is documented in
+[ARCHITECTURE.md](ARCHITECTURE.md#add-party-add-a-host-to-an-existing-decentralized-party);
+the code lives in
+[`crates/decman/src/workflow/add_party/`](../crates/decman/src/workflow/add_party/).
 
-### User Experience Implications
+The `Recommended Approach` diagram and `User Experience Implications` list that
+stood here described the repair-mode design and were removed. What still holds
+of them:
 
-1. **Restart Required**: New member must restart with repair mode
-2. **Coordination**: Must coordinate timing of ACS export/import
-3. **Downtime**: New member experiences brief downtime during import
-4. **File Transfer**: ACS snapshot must be securely transferred
+1. **Coordination**: the export and the import must be sequenced against a
+   captured ledger offset. The workflow does this itself.
+2. **Downtime**: the joining node disconnects from the synchronizer for the
+   duration of the import, which briefly pauses that whole node. The party
+   keeps transacting on its other hosts.
+3. **File transfer**: the ACS snapshot travels over the authenticated Noise
+   channel between member nodes, capped at 16 MiB assembled.
+
+What no longer holds: no participant restarts, and no participant enters repair
+mode.
 
 ---
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -49,10 +49,13 @@ process in [SECURITY.md](SECURITY.md).
   - `crates/decman/src/` — server source.
   - `crates/decman/frontend/` — React + Vite UI (embedded into the binary at build time).
   - `crates/decman/migrations/` — SQLx database migrations.
-- `crates/common/` — shared wire DTOs + Canton-ID helpers (used by `decman` and `decman-cli`).
+- `crates/common/` — shared wire DTOs, Canton-ID helpers, and external-party
+  fingerprint derivation (used by every other crate).
 - `crates/decman-cli/` — terminal UI client.
+- `crates/decman-wallet/` — wallet-side client library for the tenant API.
 - `daml/` — Daml governance packages and tests.
 - `integration-tests/` — end-to-end test harness and scripts.
+- `e2e/` — Playwright UI tests.
 - `docs/` — architecture, integration, and use-case documentation.
 
 ## Building, testing, and linting

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -280,7 +280,23 @@ Adding a 4th custodian involves both governance and topology:
     }
     ```
 
-2. **Topology**: Run the onboarding workflow to add the new participant to the `PartyToParticipant` mapping. If the party has active contracts, ACS sync (export/import) will be required.
+2. **Topology**: Run the add-party workflow to add the new participant to the
+   `DecentralizedNamespaceDefinition` and `PartyToParticipant` mappings:
+
+    ```bash
+    curl -X POST http://custodian-a:8080/add-party \
+      -H "Content-Type: application/json" \
+      -d '{
+        "decentralized_party_id": "joint-vault::1220...",
+        "new_participant_id": "custodian-d::1220...",
+        "new_threshold": 3,
+        "previous_threshold": 2
+      }'
+    ```
+
+   If the party has active contracts, the workflow replicates them to the new
+   custodian itself (ACS export/import around a brief synchronizer disconnect on
+   the joining node only). No participant restart is needed.
 
 #### Remove a Custodian
 


### PR DESCRIPTION
Swept every markdown file in the repo for claims the code no longer supports — greps for superseded terms, a scanner for referenced paths that no longer exist, and a link/anchor validator, then verified each hit against the source.

Five files were stale. `DEPLOYMENT_GUIDE.md`, `KMS_SIGNING.md`, `USER_GUIDE.md`, `CUSTOM_DAML_TEMPLATES.md`, `e2e/README.md` and the Daml README check out.

### ARCHITECTURE.md

Three of the four Known Limitations were false:

- ACS sync claimed repair mode and a participant restart. It has used offline party replication (`ExportPartyAcs` / `ImportPartyAcs` + the `Onboarding` marker) since #249.
- "No external party support" — the tenant API shipped in #318.
- "Single workflow at a time" — the `WorkflowRegistry` runs any number side by side, and the listener is always on.

Coordinator failure also said the workflow "cannot continue"; runs are persisted and resume on restart (`restart_coordinator_resume` covers it).

Add-party, change-threshold and external-party onboarding had no sections at all. Added, with their step tables and Canton calls.

The wire protocol tables were missing 13 message types (`0x0017`, `0x0018`, `0x0020`–`0x0025`, `0x0206`–`0x020A`), and gave the chunk size as 1024 bytes — it is 1 MiB. The gRPC tables named `VaultManagerService`, which does not exist, and omitted the admin `PartyManagementService`, `UpdateService` and `EventQueryService`. The two different `PartyManagementService`s are now disambiguated by proto package.

### CANTON_PARTY_REPLICATION.md

Its banner linked to `ADD_PARTY_REDEVELOPMENT.md`, which is not in the repo — now points at the new ARCHITECTURE section and the code. Dropped the "Recommended Approach" diagram and "User Experience Implications" list: both described the repair-mode design and sat directly under a "Current Implementation" heading. Everything else stays as historical background.

### README.md

Added the four external-party endpoints (`/external-parties`, `/v0/tenant/*`). The integration-test section used pre-workspace paths (`tests/common/…`) and claimed 7 phases / 14 scenarios; there are 38 phase files, so the counts are gone rather than re-pinned.

### USE_CASES.md

"Add a custodian" pointed at the onboarding workflow and warned ACS sync "will be required". Now shows the `/add-party` call and notes the workflow replicates the contracts itself.

### CONTRIBUTING.md

Repo layout was missing `crates/decman-wallet/` and `e2e/`.

---

Docs only, no code touched. Link and anchor checks pass clean.

Left alone: `docs/coupon-reassignment/design.md` says reward automation is a directory where it shipped as `reward_automation.rs`. That doc is a dated design snapshot, so the mismatch is a record rather than an error.
