### PR TITLE
Publish a nonroot image alongside the root one

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,14 +51,28 @@ jobs:
 
       # Tiny build context: just the binary in ctx/ + the runtime Dockerfile, so
       # there's no repo upload to the buildkit daemon and nothing to compile.
+      #
+      # Both published variants are built here too, so a dev image can be
+      # deployed under the same pod security context as a release.
       - name: Build and push to ECR (private)
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           SHORT_SHA: ${{ steps.sha.outputs.short }}
         run: |
           cp Dockerfile ctx/Dockerfile
+          BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
           docker buildx build ctx \
             --build-arg DECPM_BUILD_VERSION=$SHORT_SHA \
-            --build-arg DECPM_BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
+            --build-arg DECPM_BUILD_TIME=$BUILD_TIME \
             -t $ECR_REGISTRY/decentralization-manager:$SHORT_SHA \
+            --push
+
+          docker buildx build ctx \
+            --build-arg DECPM_BUILD_VERSION=$SHORT_SHA \
+            --build-arg DECPM_BUILD_TIME=$BUILD_TIME \
+            --build-arg BASE_TAG=nonroot \
+            --build-arg RUNTIME_UID=65532 \
+            --build-arg DECPM_DIR_DEFAULT=/home/nonroot \
+            -t $ECR_REGISTRY/decentralization-manager:$SHORT_SHA-nonroot \
             --push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,13 +79,29 @@ jobs:
 
       # Tiny build context: just the binary in ctx/ + the runtime Dockerfile, so
       # there's no repo upload to the buildkit daemon and nothing to compile.
+      #
+      # Two images per release from the same binary and the same Dockerfile:
+      # `:<tag>` on the root base, and `:<tag>-nonroot` on the distroless
+      # `:nonroot` base, running as uid 65532. Both carry the same build stamp.
       - name: Build and push to ECR Public
         env:
           VERSION_TAG: ${{ steps.tag.outputs.version_tag }}
+          IMAGE: public.ecr.aws/dlc-link/decentralization-manager
         run: |
           cp Dockerfile ctx/Dockerfile
+          BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
           docker buildx build ctx \
             --build-arg DECPM_BUILD_VERSION=$VERSION_TAG \
-            --build-arg DECPM_BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
-            -t public.ecr.aws/dlc-link/decentralization-manager:$VERSION_TAG \
+            --build-arg DECPM_BUILD_TIME=$BUILD_TIME \
+            -t $IMAGE:$VERSION_TAG \
+            --push
+
+          docker buildx build ctx \
+            --build-arg DECPM_BUILD_VERSION=$VERSION_TAG \
+            --build-arg DECPM_BUILD_TIME=$BUILD_TIME \
+            --build-arg BASE_TAG=nonroot \
+            --build-arg RUNTIME_UID=65532 \
+            --build-arg DECPM_DIR_DEFAULT=/home/nonroot \
+            -t $IMAGE:$VERSION_TAG-nonroot \
             --push

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,17 @@
 # distroless/cc-debian12 already ships glibc, libgcc, libssl/libcrypto and
 # ca-certificates on Debian 12 (bookworm) — the same libs the binary is built
 # against in the rust:slim-bookworm CI job — so nothing needs to be copied in.
-FROM gcr.io/distroless/cc-debian12
+#
+# The `:nonroot` tag is the same image with uid/gid 65532 and a home directory
+# it owns. The binary needs no root: it binds 8080 and 9000, both above 1024,
+# and writes only under its data directory.
+FROM gcr.io/distroless/cc-debian12:nonroot
 
 COPY --chmod=0755 dec-party-manager /usr/local/bin/dec-party-manager
+
+# Stated explicitly rather than inherited, so the runtime identity is visible
+# here and survives a base-image change.
+USER 65532:65532
 
 EXPOSE 8080 9000
 
@@ -23,7 +31,13 @@ ARG DECPM_BUILD_VERSION=
 ARG DECPM_BUILD_TIME=
 
 # Image defaults; override via env at run time.
-ENV DECPM_DIR=/ \
+#
+# DECPM_DIR is the ROOT dir; the app writes to `$DECPM_DIR/data`. It defaults to
+# the nonroot home directory because uid 65532 cannot write to `/`, so the old
+# `/` default would put the database at an unwritable `/data`. Deployments
+# override it anyway (the guide mounts a volume and passes `-d /app`), but a
+# plain `docker run` now works instead of failing on the first write.
+ENV DECPM_DIR=/home/nonroot \
     DECPM_HOST=0.0.0.0 \
     DECPM_PORT=8080 \
     DECPM_BUILD_VERSION=$DECPM_BUILD_VERSION \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,16 +10,23 @@
 # ca-certificates on Debian 12 (bookworm) — the same libs the binary is built
 # against in the rust:slim-bookworm CI job — so nothing needs to be copied in.
 #
-# The `:nonroot` tag is the same image with uid/gid 65532 and a home directory
-# it owns. The binary needs no root: it binds 8080 and 9000, both above 1024,
-# and writes only under its data directory.
-FROM gcr.io/distroless/cc-debian12:nonroot
+# Two variants are built from this one file. The defaults below produce the
+# root image published as `:<tag>`; CI overrides the three build args to
+# produce `:<tag>-nonroot`, which runs as uid 65532 on the `:nonroot` base:
+#
+#   --build-arg BASE_TAG=nonroot \
+#   --build-arg RUNTIME_UID=65532 \
+#   --build-arg DECPM_DIR_DEFAULT=/home/nonroot
+ARG BASE_TAG=latest
+FROM gcr.io/distroless/cc-debian12:${BASE_TAG}
 
 COPY --chmod=0755 dec-party-manager /usr/local/bin/dec-party-manager
 
-# Stated explicitly rather than inherited, so the runtime identity is visible
-# here and survives a base-image change.
-USER 65532:65532
+# Stated explicitly rather than inherited from the base, so the runtime
+# identity is visible here. The binary needs no root either way: it binds 8080
+# and 9000, both above 1024, and writes only under its data directory.
+ARG RUNTIME_UID=0
+USER ${RUNTIME_UID}:${RUNTIME_UID}
 
 EXPOSE 8080 9000
 
@@ -30,14 +37,14 @@ EXPOSE 8080 9000
 ARG DECPM_BUILD_VERSION=
 ARG DECPM_BUILD_TIME=
 
+# DECPM_DIR is the root dir; the app writes `$DECPM_DIR/data`. The nonroot
+# variant defaults it to the home directory uid 65532 owns, because that uid
+# cannot create `/data`. Deployments override it anyway (the guide mounts a
+# volume and passes `-d /app`).
+ARG DECPM_DIR_DEFAULT=/
+
 # Image defaults; override via env at run time.
-#
-# DECPM_DIR is the ROOT dir; the app writes to `$DECPM_DIR/data`. It defaults to
-# the nonroot home directory because uid 65532 cannot write to `/`, so the old
-# `/` default would put the database at an unwritable `/data`. Deployments
-# override it anyway (the guide mounts a volume and passes `-d /app`), but a
-# plain `docker run` now works instead of failing on the first write.
-ENV DECPM_DIR=/home/nonroot \
+ENV DECPM_DIR=$DECPM_DIR_DEFAULT \
     DECPM_HOST=0.0.0.0 \
     DECPM_PORT=8080 \
     DECPM_BUILD_VERSION=$DECPM_BUILD_VERSION \

--- a/README.md
+++ b/README.md
@@ -95,13 +95,10 @@ Open http://localhost:8081 in your browser.
 ```bash
 # Build the image (forward an SSH key registered on a GitHub account;
 # replace the key path with your own)
-docker build --ssh default=$HOME/.ssh/id_ed25519 -t dec-party-manager .
+docker build --ssh default=$HOME/.ssh/id_ed25519 -f development/Dockerfile -t dec-party-manager .
 
-# Run a single instance. The image runs as uid 65532, so the host directory
-# must be writable by it, and the mount goes at the image's DECPM_DIR/data.
-mkdir -p ./data && sudo chown 65532:65532 ./data
-
-docker run -p 8080:8080 -v ./data:/home/nonroot/data \
+# Run a single instance
+docker run -p 8080:8080 -v ./data:/data \
   -e DECPM_CANTON_ADMIN_HOST=canton-node \
   -e DECPM_CANTON_ADMIN_PORT=5002 \
   -e DECPM_CANTON_LEDGER_HOST=canton-node \
@@ -110,6 +107,17 @@ docker run -p 8080:8080 -v ./data:/home/nonroot/data \
   -e DECPM_CANTON_SYNCHRONIZER=global \
   -e DECPM_CANTON_NETWORK=devnet \
   dec-party-manager
+```
+
+Published releases ship that same binary as two images, `…:<tag>` and
+`…:<tag>-nonroot`; the second runs as uid 65532 and defaults `DECPM_DIR` to
+`/home/nonroot`, so its mount goes at `/home/nonroot/data` and the host
+directory has to belong to that uid:
+
+```bash
+mkdir -p ./data && sudo chown 65532:65532 ./data
+docker run -p 8080:8080 -v ./data:/home/nonroot/data \
+  ... public.ecr.aws/dlc-link/decentralization-manager:<tag>-nonroot
 ```
 
 ### Running Multiple Participants (Development)
@@ -774,8 +782,13 @@ TypeScript imports won't resolve.
 
 Release images are built and published by CI: pushing a `v<version>` tag (which
 must match the crate version in `crates/decman/Cargo.toml`) runs the release
-workflow, which builds the binary and pushes
-`public.ecr.aws/dlc-link/decentralization-manager:v<version>`. The root
+workflow, which builds the binary and pushes two images:
+`public.ecr.aws/dlc-link/decentralization-manager:v<version>` and
+`…:v<version>-nonroot`. They hold the same binary and differ only in runtime
+identity — uid 0 versus uid 65532, with `DECPM_DIR` defaulting to `/` and
+`/home/nonroot` respectively. One `Dockerfile` builds both; the nonroot job
+overrides `BASE_TAG`, `RUNTIME_UID` and `DECPM_DIR_DEFAULT`. See the
+[Deployment Guide](docs/DEPLOYMENT_GUIDE.md) for which to pick. The root
 `Dockerfile` is that workflow's runtime wrapper — it copies in the CI-built
 binary and does no compilation, so it is not useful for a local build.
 

--- a/README.md
+++ b/README.md
@@ -97,8 +97,11 @@ Open http://localhost:8081 in your browser.
 # replace the key path with your own)
 docker build --ssh default=$HOME/.ssh/id_ed25519 -t dec-party-manager .
 
-# Run a single instance
-docker run -p 8080:8080 -v ./data:/data \
+# Run a single instance. The image runs as uid 65532, so the host directory
+# must be writable by it, and the mount goes at the image's DECPM_DIR/data.
+mkdir -p ./data && sudo chown 65532:65532 ./data
+
+docker run -p 8080:8080 -v ./data:/home/nonroot/data \
   -e DECPM_CANTON_ADMIN_HOST=canton-node \
   -e DECPM_CANTON_ADMIN_PORT=5002 \
   -e DECPM_CANTON_LEDGER_HOST=canton-node \

--- a/README.md
+++ b/README.md
@@ -112,10 +112,12 @@ docker run -p 8080:8080 -v ./data:/data \
 Published releases ship that same binary as two images, `…:<tag>` and
 `…:<tag>-nonroot`; the second runs as uid 65532 and defaults `DECPM_DIR` to
 `/home/nonroot`, so its mount goes at `/home/nonroot/data` and the host
-directory has to belong to that uid:
+directory has to belong to that uid. The `chown` is recursive because a `./data`
+left behind by the root image holds root-owned files — the SQLite database and
+the mode-0600 Noise key — that uid 65532 could otherwise not open:
 
 ```bash
-mkdir -p ./data && sudo chown 65532:65532 ./data
+mkdir -p ./data && sudo chown -R 65532:65532 ./data
 docker run -p 8080:8080 -v ./data:/home/nonroot/data \
   ... public.ecr.aws/dlc-link/decentralization-manager:<tag>-nonroot
 ```

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -17,13 +17,10 @@ public, so no special repository access is needed):
 
 ```bash
 # Build the image (replace the key path with your own GitHub-registered key)
-docker build --ssh default=$HOME/.ssh/id_ed25519 -t dec-party-manager .
+docker build --ssh default=$HOME/.ssh/id_ed25519 -f development/Dockerfile -t dec-party-manager .
 
 # Run
-# The image runs as uid 65532, so the host directory must be writable by it.
-mkdir -p ./data && sudo chown 65532:65532 ./data
-
-docker run -p 8080:8080 -p 9000:9000 -v ./data:/home/nonroot/data \
+docker run -p 8080:8080 -p 9000:9000 -v ./data:/data \
   -e DECPM_PORT=8080 \
   -e DECPM_NOISE_PORT=9000 \
   -e DECPM_CANTON_ADMIN_HOST=canton-node \
@@ -37,16 +34,33 @@ docker run -p 8080:8080 -p 9000:9000 -v ./data:/home/nonroot/data \
 
 Then open the web UI at `http://localhost:8080`.
 
-The `-v ./data:/home/nonroot/data` mount persists the SQLite database (peers,
-party credentials) and the auto-generated Noise keypair across restarts.
+The `-v ./data:/data` mount persists the SQLite database (peers, party
+credentials) and the auto-generated Noise keypair across restarts.
 
-`/home/nonroot` is the image's default `DECPM_DIR`, and the app writes
-`$DECPM_DIR/data` — so that is the directory to mount. Point the mount
-somewhere else and pass `-e DECPM_DIR=<parent>` to match, or the container
-writes inside its own filesystem and the data disappears with it.
+`/` is the image's default `DECPM_DIR`, and the app writes `$DECPM_DIR/data` —
+so that is the directory to mount. Point the mount somewhere else and pass
+`-e DECPM_DIR=<parent>` to match, or the container writes inside its own
+filesystem and the data disappears with it.
 
-The `chown` is needed because the image runs as uid 65532 rather than root. A
-bind mount keeps the host's ownership, so without it the first write fails.
+### Nonroot image
+
+Every release is published twice — `…:<tag>` and `…:<tag>-nonroot`. Both hold
+the same binary; the second runs as uid 65532 rather than root, which is the
+one to deploy where a policy forbids root containers.
+
+Its `DECPM_DIR` defaults to `/home/nonroot`, because uid 65532 cannot create
+`/data`. So the mount moves with it, and the host directory has to belong to
+that uid — a bind mount keeps the host's ownership, and without the `chown` the
+first write fails:
+
+```bash
+mkdir -p ./data && sudo chown 65532:65532 ./data
+docker run -p 8080:8080 -p 9000:9000 -v ./data:/home/nonroot/data \
+  ... public.ecr.aws/dlc-link/decentralization-manager:<tag>-nonroot
+```
+
+Nothing else changes: same ports, same env vars, same entrypoint. For
+Kubernetes, see the [Deployment Guide](docs/DEPLOYMENT_GUIDE.md).
 
 ## Configuration
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -51,10 +51,15 @@ one to deploy where a policy forbids root containers.
 Its `DECPM_DIR` defaults to `/home/nonroot`, because uid 65532 cannot create
 `/data`. So the mount moves with it, and the host directory has to belong to
 that uid — a bind mount keeps the host's ownership, and without the `chown` the
-first write fails:
+first write fails.
+
+Make it recursive. A `./data` carried over from the root image holds root-owned
+files — the SQLite database and the mode-0600 Noise key — and uid 65532 cannot
+open those, so a non-recursive `chown` fixes the first write and then fails on
+the second start:
 
 ```bash
-mkdir -p ./data && sudo chown 65532:65532 ./data
+mkdir -p ./data && sudo chown -R 65532:65532 ./data
 docker run -p 8080:8080 -p 9000:9000 -v ./data:/home/nonroot/data \
   ... public.ecr.aws/dlc-link/decentralization-manager:<tag>-nonroot
 ```

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -20,7 +20,10 @@ public, so no special repository access is needed):
 docker build --ssh default=$HOME/.ssh/id_ed25519 -t dec-party-manager .
 
 # Run
-docker run -p 8080:8080 -p 9000:9000 -v ./data:/data \
+# The image runs as uid 65532, so the host directory must be writable by it.
+mkdir -p ./data && sudo chown 65532:65532 ./data
+
+docker run -p 8080:8080 -p 9000:9000 -v ./data:/home/nonroot/data \
   -e DECPM_PORT=8080 \
   -e DECPM_NOISE_PORT=9000 \
   -e DECPM_CANTON_ADMIN_HOST=canton-node \
@@ -34,8 +37,16 @@ docker run -p 8080:8080 -p 9000:9000 -v ./data:/data \
 
 Then open the web UI at `http://localhost:8080`.
 
-The `-v ./data:/data` mount persists the SQLite database (peers, party
-credentials) and the auto-generated Noise keypair across restarts.
+The `-v ./data:/home/nonroot/data` mount persists the SQLite database (peers,
+party credentials) and the auto-generated Noise keypair across restarts.
+
+`/home/nonroot` is the image's default `DECPM_DIR`, and the app writes
+`$DECPM_DIR/data` — so that is the directory to mount. Point the mount
+somewhere else and pass `-e DECPM_DIR=<parent>` to match, or the container
+writes inside its own filesystem and the data disappears with it.
+
+The `chown` is needed because the image runs as uid 65532 rather than root. A
+bind mount keeps the host's ownership, so without it the first write fails.
 
 ## Configuration
 

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -62,9 +62,41 @@ writes only under its data directory. Give the data volume an `fsGroup` so uid
 65532 can write to it — the Deployment example does, and that example runs
 either tag as 65532 because it pins `runAsUser` itself.
 
+### Moving an existing node to uid 65532
+
+A volume written by the root image holds root-owned files, and `fsGroup` does
+not fix that on its own: it re-owns the contents to the **group** and adds group
+write, but the user owner stays root. `data/noise.key` is the one that bites.
+The node re-asserts mode 0600 on it at every start, and uid 65532 cannot chmod a
+file it does not own, so the pod fails with `Failed to chmod key file`. Without
+`fsGroup` it fails one step earlier, on the read.
+
+Chown the volume once, with a throwaway root init container ahead of the
+existing one:
+
+```yaml
+initContainers:
+  - name: chown-data
+    image: busybox:latest
+    command: ["sh", "-c", "chown -R 65532:65532 /app"]
+    securityContext:
+      runAsUser: 0
+      runAsNonRoot: false
+    volumeMounts:
+      - name: data
+        mountPath: /app
+```
+
+Drop it again after one successful start — from then on the node owns
+everything it writes. A namespace under the `restricted` Pod Security Standard
+rejects that container; run the same `chown -R` from a one-off root pod that
+mounts the PVC instead. A bind-mounted `docker run` has the same requirement and
+the same fix.
+
 > Releases up to and including **v1.6.2** shipped only the root image. To
-> harden one of those without upgrading, set `runAsUser: 65532` and the same
-> `fsGroup` on the pod; the binary never needed the privileges it had.
+> harden one of those without upgrading, do the one-time chown above, then set
+> `runAsUser: 65532` and the same `fsGroup` on the pod; the binary never needed
+> the privileges it had.
 
 To check the version of a running pod:
 

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -42,13 +42,29 @@ anything that needs `sh` — init containers, `kubectl exec` debugging, exec
 probes — on a utility image such as `busybox`, not on this image. The
 Deployment example below shows the pattern.
 
-It runs as **uid 65532** and needs no root: it binds 8080 and 9000, both above
-1024, and writes only under its data directory. Give the data volume an
-`fsGroup` so that uid can write to it — the Deployment example does.
+### Root or nonroot
 
-> Releases up to and including **v1.6.2** ran as uid 0. To harden one of those
-> without upgrading, set `runAsUser: 65532` and the same `fsGroup` on the pod;
-> the binary never needed the privileges it had.
+Each release is published as two images:
+
+| Tag | Runs as | `DECPM_DIR` default |
+|---|---|---|
+| `…:<tag>` | uid 0 (root) | `/` |
+| `…:<tag>-nonroot` | uid 65532 | `/home/nonroot` |
+
+They hold the same binary and take the same configuration; only the runtime
+identity differs. **Prefer `-nonroot`.** It is what an admission policy that
+inspects the image expects — a bare `runAsNonRoot: true` with no `runAsUser`
+rejects the plain tag, because the image itself declares uid 0. The plain tag
+stays for existing pins and for clusters that set `runAsUser` in the pod spec.
+
+Neither one needs root: the binary binds 8080 and 9000, both above 1024, and
+writes only under its data directory. Give the data volume an `fsGroup` so uid
+65532 can write to it — the Deployment example does, and that example runs
+either tag as 65532 because it pins `runAsUser` itself.
+
+> Releases up to and including **v1.6.2** shipped only the root image. To
+> harden one of those without upgrading, set `runAsUser: 65532` and the same
+> `fsGroup` on the pod; the binary never needed the privileges it had.
 
 To check the version of a running pod:
 
@@ -243,9 +259,10 @@ spec:
       labels:
         app.kubernetes.io/name: dec-party-manager
     spec:
-      # The image runs as uid 65532 and needs no root. fsGroup makes the
-      # mounted PVC group-writable by that uid, which is what lets both the
-      # init container and the app create files under /app.
+      # The app needs no root. Pinning runAsUser here means this works with
+      # either published tag; with `-nonroot` it matches the image default.
+      # fsGroup makes the mounted PVC group-writable by that uid, which is what
+      # lets both the init container and the app create files under /app.
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532
@@ -263,6 +280,7 @@ spec:
               mountPath: /app
       containers:
         - name: dec-party-manager
+          # Append `-nonroot` for the image that runs as 65532 by itself.
           image: public.ecr.aws/dlc-link/decentralization-manager:<tag>
           imagePullPolicy: Always
           securityContext:

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -42,6 +42,14 @@ anything that needs `sh` — init containers, `kubectl exec` debugging, exec
 probes — on a utility image such as `busybox`, not on this image. The
 Deployment example below shows the pattern.
 
+It runs as **uid 65532** and needs no root: it binds 8080 and 9000, both above
+1024, and writes only under its data directory. Give the data volume an
+`fsGroup` so that uid can write to it — the Deployment example does.
+
+> Releases up to and including **v1.6.2** ran as uid 0. To harden one of those
+> without upgrading, set `runAsUser: 65532` and the same `fsGroup` on the pod;
+> the binary never needed the privileges it had.
+
 To check the version of a running pod:
 
 ```bash
@@ -235,10 +243,21 @@ spec:
       labels:
         app.kubernetes.io/name: dec-party-manager
     spec:
+      # The image runs as uid 65532 and needs no root. fsGroup makes the
+      # mounted PVC group-writable by that uid, which is what lets both the
+      # init container and the app create files under /app.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
       initContainers:
         - name: init-data
           image: busybox:latest
           command: ["sh", "-c", "mkdir -p /app/data"]
+          # Inherits the pod securityContext above, so it runs as 65532 too.
+          # busybox defaults to root, and with runAsNonRoot set the pod would
+          # refuse to start if this container were left to that default.
           volumeMounts:
             - name: data
               mountPath: /app
@@ -246,6 +265,15 @@ spec:
         - name: dec-party-manager
           image: public.ecr.aws/dlc-link/decentralization-manager:<tag>
           imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            # The server writes only under its data directory, so a read-only
+            # root filesystem should hold. Left commented because it has not
+            # been proven against a live deploy: a dependency writing to /tmp
+            # would surface only at runtime. Enable it, then watch one restart.
+            # readOnlyRootFilesystem: true
           command:
             - dec-party-manager
             - -d


### PR DESCRIPTION
The runtime image had no `USER`, so the container ran as uid 0. The binary never needed it: it binds 8080 and 9000, both above 1024, and writes only under its data directory.

Rather than move the published image to nonroot and break every deployment that assumes uid 0 or `DECPM_DIR=/`, this publishes both. The existing tag keeps its base, its user and its defaults. A second tag, `-nonroot`, is the same binary running as uid 65532.

### One Dockerfile, three build args

| arg | root (default) | nonroot |
|---|---|---|
| `BASE_TAG` | `latest` | `nonroot` |
| `RUNTIME_UID` | `0` | `65532` |
| `DECPM_DIR_DEFAULT` | `/` | `/home/nonroot` |

I read both base configs from the registry rather than trusting the tag names:

```
latest   User: '0'      WorkingDir: '/'
nonroot  User: '65532'  WorkingDir: '/home/nonroot'
```

`DECPM_DIR` has to move with the user. It is the root dir and the app writes `$DECPM_DIR/data`, so leaving the nonroot image on `/` would put the database at `/data`, which uid 65532 cannot create, and a plain `docker run` would fail on its first write. Deployments are unaffected either way: the guide mounts a volume and passes `-d /app`, and `development/docker-compose.yml` builds from a different Dockerfile and sets `DECPM_DIR: /app` itself.

`release.yml` and `build.yml` each push both tags from one binary, one Dockerfile and one build stamp, so a dev image can be deployed under the same pod security context as a release.

### The deployment guide

New "Root or nonroot" section: what the two tags are, and that `-nonroot` is the one to prefer. A bare `runAsNonRoot: true` with no `runAsUser` rejects the plain tag, because the image declares uid 0.

The Deployment example gains a pod-level context:

```yaml
securityContext:
  runAsNonRoot: true
  runAsUser: 65532
  runAsGroup: 65532
  fsGroup: 65532
```

plus `allowPrivilegeEscalation: false` and `capabilities: drop: ["ALL"]` on the container. Because it pins `runAsUser` itself, that example runs either tag as 65532.

Two details worth a reviewer's eye:

- **The init container matters.** `busybox` defaults to root, and with `runAsNonRoot: true` at pod level the pod refuses to start unless that container also runs nonroot. It inherits the pod context, and `fsGroup` is what then lets both it and the app write to the mounted PVC. Without `fsGroup` this breaks the deploy.
- **`readOnlyRootFilesystem` is left commented, not set.** It should hold, since every `/tmp` and `tempfile` use I found is test code or the `gen-types` binary, not the server, but I cannot prove it without a live deploy and a dependency writing to `/tmp` would surface only at runtime. The guide says to enable it and watch one restart.

### Migrating an existing volume

Copilot flagged that `chown 65532:65532 ./data` only touches the directory entry. It is right, and the failure is worse than it looks: `from_file` re-asserts mode 0600 on `data/noise.key` before every read, and uid 65532 cannot chmod a file root owns, so a half-chowned volume fails startup with `Failed to chmod key file`.

`fsGroup` does not cover this either. It re-owns volume contents to the group and adds group write, but the user owner stays root, so the chmod is still denied. I had claimed the opposite in an earlier revision of the guide. The guide now has a "Moving an existing node to uid 65532" section: a one-time root init container that chowns the PVC, dropped again after the first successful start. Both docker quick-starts use `chown -R`.

Also documented: the v1.6.2-and-earlier workaround, which is the same one-time chown plus `runAsUser: 65532` and `fsGroup` on the existing image.

### Drive-by

README and USER_GUIDE told you to build the image with `docker build --ssh ... -t dec-party-manager .`, which cannot work: the root Dockerfile copies in a CI-built binary and compiles nothing, so a fresh clone fails on the `COPY`. Both now point at `development/Dockerfile`, which is what the README already says further down.

### Verification

No docker daemon in this environment, so no local build. What I did check:

- Both base image configs, pulled from `gcr.io` (above).
- The guide's Deployment manifest parses as YAML, and the resulting security contexts and command are the intended ones.
- CI builds both variants on every push, so the `Build & Push Private Image` job on this PR exercises the root and the nonroot build.

**Neither image is runtime-verified.** The remaining risk is the nonroot variant's first write under a real volume.

### Follow-up the issue asks for and this does not do

> Cut a new release so the rebuilt image picks up the current Debian 12 package versions.

That is a tag push, not a code change, so it stays with whoever cuts releases. The OS-level CVEs the scanners report come from the base image and clear on a rebuild.

Closes #372
