### PR TITLE
fix(server): scope topology discovery to configured parties

### DIFF
--- a/crates/decman/src/db/sqlite.rs
+++ b/crates/decman/src/db/sqlite.rs
@@ -1205,6 +1205,7 @@ mod tests {
             InvitationType, PendingInvitation, WorkflowKind, WorkflowProgress, WorkflowRole,
             WorkflowRun,
         },
+        workflow::storage::WorkflowStorage,
     };
 
     use super::{MIGRATION_CHECKSUM_REPAIRS, MIGRATOR, repair_migration_checksums};
@@ -2296,6 +2297,13 @@ mod tests {
         assert_eq!(loaded.step_index, 3);
         assert_eq!(loaded.completed_peers, completed);
 
+        // Onboarding resolves its party ID during the workflow. Persisting it
+        // on the run must survive the terminal cleanup below so exact topology
+        // discovery can still include the newly-created party.
+        let dec_party_id = CantonId::parse(&format!("party-a::{TEST_NS}")).unwrap();
+        pool.write_run_party_id(&run.instance_name, &dec_party_id)
+            .await?;
+
         // Seed an artefact so we can verify the terminal-state cleanup wipes it.
         let mut tx = pool.begin_transaction().await?;
         tx.write_workflow_artifact(&run.instance_name, "dns_proto", None, b"some-bytes")
@@ -2320,6 +2328,7 @@ mod tests {
         let visible = pool.get_visible_workflow_runs().await?;
         assert_eq!(visible.len(), 1);
         assert_eq!(visible[0].status, WorkflowProgress::Completed);
+        assert_eq!(visible[0].dec_party_id.as_ref(), Some(&dec_party_id));
 
         // Dismiss → vanishes from feed.
         let mut tx = pool.begin_transaction().await?;

--- a/crates/decman/src/server/handlers/parties.rs
+++ b/crates/decman/src/server/handlers/parties.rs
@@ -712,12 +712,59 @@ fn build_party_to_participant_request(
     }
 }
 
+/// Build a decentralized-namespace query for one exact namespace.
+///
+/// An empty namespace enumerates the entire synchronizer. That is prohibitively
+/// expensive on mainnet, so callers must first discover the locally relevant
+/// party IDs and query their namespaces individually.
+fn build_decentralized_namespace_request(
+    synchronizer_id: &str,
+    namespace: &str,
+) -> ListDecentralizedNamespaceDefinitionRequest {
+    debug_assert!(!namespace.is_empty());
+    ListDecentralizedNamespaceDefinitionRequest {
+        base_query: Some(BaseQuery {
+            store: Some(StoreId {
+                store: Some(store_id::Store::Synchronizer(Synchronizer {
+                    kind: Some(synchronizer::Kind::PhysicalId(synchronizer_id.to_string())),
+                })),
+            }),
+            proposals: false,
+            operation: 0,
+            time_query: Some(base_query::TimeQuery::HeadState(())),
+            filter_signed_key: String::new(),
+            protocol_version: None,
+            client_version: None,
+        }),
+        filter_namespace: namespace.to_string(),
+    }
+}
+
+/// Return the configured decentralized party IDs matching the optional prefix.
+///
+/// Party credentials are authoritative for an initialized node and let us use
+/// exact party filters instead of asking Canton to scan every party hosted by
+/// this participant.
+fn configured_party_filters(
+    party_credentials: &[PartyCredentials],
+    prefix_filter: Option<&str>,
+) -> Vec<String> {
+    let mut parties: Vec<_> = party_credentials
+        .iter()
+        .map(|credentials| credentials.dec_party_id.to_string())
+        .filter(|party_id| prefix_filter.is_none_or(|prefix| party_id.starts_with(prefix)))
+        .collect();
+    parties.sort();
+    parties.dedup();
+    parties
+}
+
 /// Fetch decentralized parties from Canton topology and ledger APIs
 pub async fn fetch_decentralized_parties(
     config: &NodeConfig,
     prefix_filter: Option<&str>,
     auth: Option<WorkflowAuth>,
-    _party_credentials: &[PartyCredentials], // TODO: remove this parameter, packages are now hardcoded
+    party_credentials: &[PartyCredentials],
 ) -> Result<DecentralizedPartiesResponse> {
     let channel = config.admin_channel().await?;
 
@@ -728,7 +775,59 @@ pub async fn fetch_decentralized_parties(
 
     let synchronizer_id = utils::get_synchronizer_id(config).await?;
 
-    // Get all namespace keys from this participant
+    // Prefer exact configured party IDs. On an uninitialized node there are no
+    // credentials yet, so fall back to participant-scoped discovery.
+    let party_filters: Vec<Option<String>> = if party_credentials.is_empty() {
+        vec![prefix_filter.map(str::to_string)]
+    } else {
+        configured_party_filters(party_credentials, prefix_filter)
+            .into_iter()
+            .map(Some)
+            .collect()
+    };
+
+    let participant_id = config.participant_id().to_string();
+    let mut p2p_by_namespace = HashMap::new();
+    for party_filter in party_filters {
+        let response = topology_client
+            .list_party_to_participant(tonic::Request::new(build_party_to_participant_request(
+                &synchronizer_id,
+                party_filter.as_deref(),
+                &participant_id,
+            )))
+            .await?
+            .into_inner();
+
+        for result in response.results {
+            let Some(P2pItem::V30(party_mapping)) = result.item else {
+                continue;
+            };
+            let Some((_, namespace)) = party_mapping.party.rsplit_once("::") else {
+                continue;
+            };
+            if namespace.is_empty() {
+                continue;
+            }
+            p2p_by_namespace.insert(namespace.to_string(), party_mapping);
+        }
+    }
+
+    // Query only the exact decentralized namespaces belonging to locally
+    // hosted parties. Never issue an empty namespace filter on this path.
+    let mut namespaces: Vec<_> = p2p_by_namespace.keys().cloned().collect();
+    namespaces.sort();
+    let mut dns_results = Vec::new();
+    for namespace in namespaces {
+        let response = topology_client
+            .list_decentralized_namespace_definition(tonic::Request::new(
+                build_decentralized_namespace_request(&synchronizer_id, &namespace),
+            ))
+            .await?
+            .into_inner();
+        dns_results.extend(response.results);
+    }
+
+    // Get namespace keys only after completing the scoped topology lookup.
     let keys_response = vault_client
         .list_my_keys(tonic::Request::new(ListMyKeysRequest {
             filters: None,
@@ -751,56 +850,8 @@ pub async fn fetch_decentralized_parties(
         }
     }
 
-    // List all decentralized namespaces
-    let dns_response = topology_client
-        .list_decentralized_namespace_definition(tonic::Request::new(
-            ListDecentralizedNamespaceDefinitionRequest {
-                base_query: Some(BaseQuery {
-                    store: Some(StoreId {
-                        store: Some(store_id::Store::Synchronizer(Synchronizer {
-                            kind: Some(synchronizer::Kind::PhysicalId(synchronizer_id.clone())),
-                        })),
-                    }),
-                    proposals: false,
-                    operation: 0,
-                    time_query: Some(base_query::TimeQuery::HeadState(())),
-                    filter_signed_key: String::new(),
-                    protocol_version: None,
-                    client_version: None,
-                }),
-                filter_namespace: String::new(),
-            },
-        ))
-        .await?
-        .into_inner();
-
-    // Query P2P mappings, scoped to parties hosted on this participant — see
-    // `build_party_to_participant_request` for why the participant filter matters.
-    let p2p_response = topology_client
-        .list_party_to_participant(tonic::Request::new(build_party_to_participant_request(
-            &synchronizer_id,
-            prefix_filter,
-            &config.participant_id().to_string(),
-        )))
-        .await?
-        .into_inner();
-
-    // Build a map of namespace -> P2P item for quick lookup
-    let p2p_by_namespace: HashMap<String, _> = p2p_response
-        .results
-        .into_iter()
-        .filter_map(|r| {
-            let Some(P2pItem::V30(p)) = r.item else {
-                return None;
-            };
-            let ns = p.party.rsplit_once("::")?.1.to_string();
-            Some((ns, p))
-        })
-        .collect();
-
     // Filter to parties where this participant is a member
-    let my_parties: Vec<_> = dns_response
-        .results
+    let my_parties: Vec<_> = dns_results
         .into_iter()
         .filter_map(|result| {
             let item = result.item?;
@@ -1373,6 +1424,46 @@ mod tests {
 
         assert_eq!(request.filter_participant, "participant::abc123");
         assert_eq!(request.filter_party, "alice");
+    }
+
+    #[test]
+    fn decentralized_namespace_request_uses_exact_namespace_filter() {
+        let namespace = "1220c4010d6883f367c7f45d55b2449501620130f9b21e96379f17dea455ac7a5892";
+        let request = build_decentralized_namespace_request("sync::physical", namespace);
+
+        assert_eq!(request.filter_namespace, namespace);
+    }
+
+    #[test]
+    fn configured_party_filters_are_exact_deduplicated_and_prefix_scoped() -> anyhow::Result<()> {
+        let namespace_a = "1220c4010d6883f367c7f45d55b2449501620130f9b21e96379f17dea455ac7a5892";
+        let namespace_b = "1220d5010d6883f367c7f45d55b2449501620130f9b21e96379f17dea455ac7a5893";
+        let credentials = |party: &str, namespace: &str| -> anyhow::Result<PartyCredentials> {
+            Ok(PartyCredentials {
+                dec_party_id: CantonId::parse(&format!("{party}::{namespace}"))?,
+                member_party_id: CantonId::parse(&format!("member::{namespace}"))?,
+                user_id: "user".to_string(),
+                keycloak: Default::default(),
+                auth0: None,
+                packages: Default::default(),
+            })
+        };
+        let cbtc = credentials("cbtc-network", namespace_a)?;
+        let parties = vec![
+            credentials("other-network", namespace_b)?,
+            cbtc.clone(),
+            cbtc,
+        ];
+
+        assert_eq!(
+            configured_party_filters(&parties, Some("cbtc-network")),
+            vec![format!("cbtc-network::{namespace_a}")]
+        );
+        assert_eq!(
+            configured_party_filters(&parties, Some("missing")),
+            Vec::<String>::new()
+        );
+        Ok(())
     }
 
     /// Every hint must name something to go and look at. The failure this

--- a/crates/decman/src/server/handlers/parties.rs
+++ b/crates/decman/src/server/handlers/parties.rs
@@ -140,6 +140,7 @@ pub async fn get_decentralized_parties(
     let party_creds = data.party_credentials.read().await.clone();
     match fetch_decentralized_parties(
         &data.config,
+        &data.db,
         Some(prefix.as_str()).filter(|s| !s.is_empty()),
         auth,
         &party_creds,
@@ -186,6 +187,7 @@ async fn refresh_and_cache_parties(data: &web::Data<AppState>, prefix: &str) {
     let party_creds = data.party_credentials.read().await.clone();
     match fetch_decentralized_parties(
         &data.config,
+        &data.db,
         Some(prefix).filter(|s| !s.is_empty()),
         auth,
         &party_creds,
@@ -682,15 +684,15 @@ pub async fn store_parties_to_db(
 /// Build the `list_party_to_participant` request used to discover this node's
 /// decentralized parties.
 ///
-/// `filter_participant` is always set to this node's participant id so the query
-/// is scoped to parties hosted here. Without it the synchronizer returns every
-/// party-to-participant mapping on the whole network, which on mainnet exceeds
-/// the gRPC decode limit. We only ever care about decentralized parties this
-/// node hosts, and every party we co-own lists our participant as a host, so the
-/// scope loses nothing. An optional party-id `prefix_filter` narrows on top.
+/// Exact `filter_party` values are the scalable path. Canton 3.5.12 pushes that
+/// filter into the topology store, while `filter_participant` is applied only
+/// after the store query. The participant filter still protects correctness,
+/// but an empty or prefix-only party filter can load the synchronizer-wide
+/// result before post-filtering and is reserved for the no-local-knowledge
+/// onboarding fallback.
 fn build_party_to_participant_request(
     synchronizer_id: &str,
-    prefix_filter: Option<&str>,
+    party_filter: Option<&str>,
     participant_id: &str,
 ) -> ListPartyToParticipantRequest {
     ListPartyToParticipantRequest {
@@ -707,7 +709,7 @@ fn build_party_to_participant_request(
             protocol_version: None,
             client_version: None,
         }),
-        filter_party: prefix_filter.unwrap_or_default().to_string(),
+        filter_party: party_filter.unwrap_or_default().to_string(),
         filter_participant: participant_id.to_string(),
     }
 }
@@ -740,18 +742,24 @@ fn build_decentralized_namespace_request(
     }
 }
 
-/// Return the configured decentralized party IDs matching the optional prefix.
+/// Union every decentralized party ID the node already knows locally.
 ///
-/// Party credentials are authoritative for an initialized node and let us use
-/// exact party filters instead of asking Canton to scan every party hosted by
-/// this participant.
-fn configured_party_filters(
+/// Credentials cover configured parties, workflow runs cover a party while it
+/// is being onboarded (before credentials exist), and cached rows preserve
+/// discovery after the originating workflow has been dismissed. Keeping all
+/// three sources prevents exact-filter discovery from hiding a newly added
+/// party on a node that already has credentials for another party.
+fn known_party_filters(
     party_credentials: &[PartyCredentials],
+    workflow_party_ids: impl IntoIterator<Item = String>,
+    cached_party_ids: impl IntoIterator<Item = String>,
     prefix_filter: Option<&str>,
 ) -> Vec<String> {
     let mut parties: Vec<_> = party_credentials
         .iter()
         .map(|credentials| credentials.dec_party_id.to_string())
+        .chain(workflow_party_ids)
+        .chain(cached_party_ids)
         .filter(|party_id| prefix_filter.is_none_or(|prefix| party_id.starts_with(prefix)))
         .collect();
     parties.sort();
@@ -762,6 +770,7 @@ fn configured_party_filters(
 /// Fetch decentralized parties from Canton topology and ledger APIs
 pub async fn fetch_decentralized_parties(
     config: &NodeConfig,
+    db: &SqlitePool,
     prefix_filter: Option<&str>,
     auth: Option<WorkflowAuth>,
     party_credentials: &[PartyCredentials],
@@ -775,15 +784,30 @@ pub async fn fetch_decentralized_parties(
 
     let synchronizer_id = utils::get_synchronizer_id(config).await?;
 
-    // Prefer exact configured party IDs. On an uninitialized node there are no
-    // credentials yet, so fall back to participant-scoped discovery.
-    let party_filters: Vec<Option<String>> = if party_credentials.is_empty() {
+    let workflow_runs = db.get_visible_workflow_runs().await?;
+    let cached_parties = db.get_dec_parties_by_prefix("").await?;
+    let known_party_ids = known_party_filters(
+        party_credentials,
+        workflow_runs
+            .into_iter()
+            .filter_map(|run| run.dec_party_id.map(|party_id| party_id.to_string())),
+        cached_parties.into_iter().map(|party| party.party_id),
+        None,
+    );
+    let has_local_party_knowledge = !known_party_ids.is_empty();
+    let exact_party_filters: Vec<_> = known_party_ids
+        .into_iter()
+        .filter(|party_id| prefix_filter.is_none_or(|prefix| party_id.starts_with(prefix)))
+        .collect();
+
+    // Prefer exact IDs from every local source. Only a node that knows no
+    // matching party at all uses participant-scoped discovery; Canton applies
+    // that participant filter after loading topology rows, so this fallback is
+    // intentionally limited to bootstrap/onboarding.
+    let party_filters: Vec<Option<String>> = if !has_local_party_knowledge {
         vec![prefix_filter.map(str::to_string)]
     } else {
-        configured_party_filters(party_credentials, prefix_filter)
-            .into_iter()
-            .map(Some)
-            .collect()
+        exact_party_filters.into_iter().map(Some).collect()
     };
 
     let participant_id = config.participant_id().to_string();
@@ -1401,10 +1425,9 @@ mod tests {
     }
 
     #[test]
-    fn party_to_participant_request_scopes_to_local_participant() {
-        // The core of the mainnet fix: with no prefix filter the request must
-        // still be scoped to this participant, so it doesn't scan every party
-        // on the synchronizer and overflow the gRPC decode limit.
+    fn party_to_participant_fallback_scopes_to_local_participant() {
+        // The no-local-knowledge onboarding fallback has to use an empty party
+        // filter, but still post-filters the result to this participant.
         let request =
             build_party_to_participant_request("sync::physical", None, "participant::abc123");
 
@@ -1413,17 +1436,15 @@ mod tests {
     }
 
     #[test]
-    fn party_to_participant_request_composes_prefix_with_participant() {
-        // A caller-supplied party prefix must narrow on top of the participant
-        // scope, not replace it.
+    fn party_to_participant_request_uses_exact_party_and_participant() {
         let request = build_party_to_participant_request(
             "sync::physical",
-            Some("alice"),
+            Some("alice::namespace"),
             "participant::abc123",
         );
 
         assert_eq!(request.filter_participant, "participant::abc123");
-        assert_eq!(request.filter_party, "alice");
+        assert_eq!(request.filter_party, "alice::namespace");
     }
 
     #[test]
@@ -1435,9 +1456,10 @@ mod tests {
     }
 
     #[test]
-    fn configured_party_filters_are_exact_deduplicated_and_prefix_scoped() -> anyhow::Result<()> {
+    fn known_party_filters_union_all_sources_deduplicate_and_scope() -> anyhow::Result<()> {
         let namespace_a = "1220c4010d6883f367c7f45d55b2449501620130f9b21e96379f17dea455ac7a5892";
         let namespace_b = "1220d5010d6883f367c7f45d55b2449501620130f9b21e96379f17dea455ac7a5893";
+        let namespace_c = "1220e6010d6883f367c7f45d55b2449501620130f9b21e96379f17dea455ac7a5894";
         let credentials = |party: &str, namespace: &str| -> anyhow::Result<PartyCredentials> {
             Ok(PartyCredentials {
                 dec_party_id: CantonId::parse(&format!("{party}::{namespace}"))?,
@@ -1448,19 +1470,32 @@ mod tests {
                 packages: Default::default(),
             })
         };
-        let cbtc = credentials("cbtc-network", namespace_a)?;
-        let parties = vec![
-            credentials("other-network", namespace_b)?,
-            cbtc.clone(),
-            cbtc,
+        let configured = credentials("cbtc-configured", namespace_a)?;
+        let parties = vec![configured.clone(), configured];
+        let workflow_ids = vec![
+            format!("cbtc-workflow::{namespace_b}"),
+            format!("cbtc-configured::{namespace_a}"),
+        ];
+        let cached_ids = vec![
+            format!("cbtc-cached::{namespace_c}"),
+            format!("other-network::{namespace_b}"),
         ];
 
         assert_eq!(
-            configured_party_filters(&parties, Some("cbtc-network")),
-            vec![format!("cbtc-network::{namespace_a}")]
+            known_party_filters(
+                &parties,
+                workflow_ids.clone(),
+                cached_ids.clone(),
+                Some("cbtc-")
+            ),
+            vec![
+                format!("cbtc-cached::{namespace_c}"),
+                format!("cbtc-configured::{namespace_a}"),
+                format!("cbtc-workflow::{namespace_b}"),
+            ]
         );
         assert_eq!(
-            configured_party_filters(&parties, Some("missing")),
+            known_party_filters(&parties, workflow_ids, cached_ids, Some("missing")),
             Vec::<String>::new()
         );
         Ok(())

--- a/crates/decman/src/server/handlers/workflows.rs
+++ b/crates/decman/src/server/handlers/workflows.rs
@@ -1764,7 +1764,8 @@ pub async fn start_onboarding(
                 tokio::spawn(async move {
                     let auth = bg_auth.read().await.clone();
                     let creds = bg_creds.read().await.clone();
-                    match fetch_decentralized_parties(&bg_config, None, auth, &creds).await {
+                    match fetch_decentralized_parties(&bg_config, &bg_db, None, auth, &creds).await
+                    {
                         Ok(resp) => {
                             if let Err(e) = store_parties_to_db(&bg_db, "", &resp.parties).await {
                                 tracing::warn!("Failed to cache parties after onboarding: {e}");
@@ -2303,7 +2304,8 @@ pub async fn start_contracts(
                 tokio::spawn(async move {
                     let auth = bg_auth.read().await.clone();
                     let creds = bg_creds.read().await.clone();
-                    match fetch_decentralized_parties(&bg_config, None, auth, &creds).await {
+                    match fetch_decentralized_parties(&bg_config, &bg_db, None, auth, &creds).await
+                    {
                         Ok(resp) => {
                             if let Err(e) = store_parties_to_db(&bg_db, "", &resp.parties).await {
                                 tracing::warn!(

--- a/crates/decman/src/server/mod.rs
+++ b/crates/decman/src/server/mod.rs
@@ -1080,6 +1080,7 @@ pub async fn start_server(
 
         match handlers::fetch_decentralized_parties(
             &sync_config,
+            &sync_db,
             None,
             auth_snapshot,
             &creds_snapshot,

--- a/crates/decman/src/workflow/mod.rs
+++ b/crates/decman/src/workflow/mod.rs
@@ -489,6 +489,11 @@ pub async fn start_peer(
                 // by post-onboarding workflows on this node.
                 match extract_party_id_from_p2p_payload(&payload) {
                     Ok(dec_party_id) => {
+                        if let Err(e) = db.write_run_party_id(&instance_name, &dec_party_id).await {
+                            tracing::error!(
+                                "Failed to persist party id {dec_party_id} on peer run: {e}"
+                            );
+                        }
                         if let Err(e) = onboarding::peer::copy_self_identity_for_party(
                             &db,
                             &instance_name,

--- a/crates/decman/src/workflow/onboarding/steps/proposals/create.rs
+++ b/crates/decman/src/workflow/onboarding/steps/proposals/create.rs
@@ -177,6 +177,11 @@ pub async fn create_proposals(
     let party_id = CantonId::parse(&party_id_str)?;
     tracing::info!("Party ID: {party_id}");
 
+    // Keep the resolved ID on the long-lived workflow row before writing the
+    // transient PARTY_ID artefact. Completion deletes workflow_artifacts, but
+    // topology discovery still needs this ID to issue an exact party query.
+    storage.write_run_party_id(instance_name, &party_id).await?;
+
     // Persist the resolved party ID — the HTTP path reads this artefact after
     // the coordinator workflow finishes so it can return the new party id to
     // the UI.

--- a/crates/decman/src/workflow/storage.rs
+++ b/crates/decman/src/workflow/storage.rs
@@ -155,6 +155,11 @@ pub mod identity_kinds {
 /// code stays linear and doesn't have to thread a transaction through.
 #[allow(async_fn_in_trait)]
 pub trait WorkflowStorage: Send + Sync {
+    /// Persist the decentralized party resolved during onboarding on the
+    /// workflow run itself. Unlike runtime artefacts, this survives terminal
+    /// cleanup and lets topology refreshes discover newly-created parties.
+    async fn write_run_party_id(&self, instance_name: &str, dec_party_id: &CantonId) -> Result;
+
     /// Read a single artefact. Returns `None` if it doesn't exist (the step
     /// caller decides whether that's an error or a "haven't generated yet"
     /// signal).
@@ -215,6 +220,13 @@ pub trait WorkflowStorage: Send + Sync {
 }
 
 impl WorkflowStorage for SqlitePool {
+    async fn write_run_party_id(&self, instance_name: &str, dec_party_id: &CantonId) -> Result {
+        let mut tx = self.begin_transaction().await?;
+        tx.set_workflow_run_dec_party_id(instance_name, dec_party_id)
+            .await?;
+        Commitable::commit(tx).await
+    }
+
     async fn read_artifact(
         &self,
         instance_name: &str,


### PR DESCRIPTION
## Summary

- Use configured decentralized-party credentials as exact `ListPartyToParticipant` filters on initialized nodes.
- Query `ListDecentralizedNamespaceDefinition` once per discovered namespace instead of sending an empty filter that enumerates the whole synchronizer.
- Keep participant-scoped discovery as the onboarding fallback when no party credentials exist.

This prevents the decentralized-parties refresh from triggering synchronizer-wide topology scans on large networks such as MainNet.

## Related issues

N/A

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / maintenance

## Checklist

- [x] Code is formatted with `cargo fmt --all`
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test` passes
- [x] Tests cover exact configured-party filtering, deduplication, prefix scoping, and exact namespace filtering
- [x] No secrets or environment-specific identifiers are included

## Testing

- `DECMAN_SKIP_FRONTEND=1 cargo clippy --all-targets --all-features -- -D warnings`
- `DECMAN_SKIP_FRONTEND=1 cargo test`
