### PR TITLE
fix(packages): read vetted packages from the synchronizer store

### DIFF
--- a/crates/decman/src/server/handlers/parties.rs
+++ b/crates/decman/src/server/handlers/parties.rs
@@ -919,8 +919,9 @@ pub async fn fetch_decentralized_parties(
 )]
 #[get("/packages/vetted")]
 pub async fn get_vetted_packages(data: web::Data<AppState>) -> impl Responder {
-    // Reads topology vetting state: vetting is a strict subset of the uploaded
-    // DARs, and the admin `ListPackages` reports the larger set.
+    // Reads topology vetting state. Neither list contains the other: a DAR can
+    // be uploaded without being vetted, and a vetting can outlive its DAR
+    // (e.g. after a restore from backup).
     match fetch_vetted_packages(&data.config).await {
         Ok(packages) => HttpResponse::Ok().json(packages),
         Err(e) => {

--- a/crates/decman/src/server/package_inventory.rs
+++ b/crates/decman/src/server/package_inventory.rs
@@ -4,8 +4,8 @@ use anyhow::{Context, Result};
 use canton_proto_rs::com::digitalasset::canton::{
     admin::participant::v30::{ListPackagesRequest, package_service_client::PackageServiceClient},
     topology::admin::v30::{
-        BaseQuery, ListVettedPackagesRequest, StoreId, base_query, store_id,
-        topology_manager_read_service_client::TopologyManagerReadServiceClient,
+        BaseQuery, ListVettedPackagesRequest, StoreId, Synchronizer, base_query, store_id,
+        synchronizer, topology_manager_read_service_client::TopologyManagerReadServiceClient,
     },
 };
 
@@ -127,10 +127,16 @@ pub(crate) async fn fetch_package_id_to_name(
 /// without being vetted. The topology entries carry only package ids, so
 /// name/version are joined in from the Admin PackageService.
 ///
+/// Queries the synchronizer store, like every other topology read: a connected
+/// participant's vetting transactions land there, while the Authorized store
+/// only collects transactions issued while disconnected — on a live node it is
+/// empty or stale (#376).
+///
 /// Deliberately on the admin channel: the Ledger API has a paginated
 /// `ListVettedPackages`, but it needs a bearer token and tokens here are
 /// per-party — a participant-level endpoint has no party to borrow one from.
 pub(crate) async fn fetch_vetted_packages(config: &NodeConfig) -> Result<Vec<VettedPackageInfo>> {
+    let synchronizer_id = utils::get_synchronizer_id(config).await?;
     let channel = config
         .admin_channel()
         .await
@@ -142,7 +148,9 @@ pub(crate) async fn fetch_vetted_packages(config: &NodeConfig) -> Result<Vec<Vet
         .list_vetted_packages(tonic::Request::new(ListVettedPackagesRequest {
             base_query: Some(BaseQuery {
                 store: Some(StoreId {
-                    store: Some(store_id::Store::Authorized(store_id::Authorized {})),
+                    store: Some(store_id::Store::Synchronizer(Synchronizer {
+                        kind: Some(synchronizer::Kind::PhysicalId(synchronizer_id)),
+                    })),
                 }),
                 proposals: false,
                 operation: 0,

--- a/crates/decman/src/server/package_inventory.rs
+++ b/crates/decman/src/server/package_inventory.rs
@@ -1,15 +1,20 @@
-use std::collections::{BTreeSet, HashMap};
+use std::{
+    collections::{BTreeSet, HashMap},
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 use anyhow::{Context, Result};
 use canton_proto_rs::com::digitalasset::canton::{
     admin::participant::v30::{ListPackagesRequest, package_service_client::PackageServiceClient},
+    protocol::v30::{enums::TopologyChangeOp, vetted_packages::VettedPackage},
     topology::admin::v30::{
-        BaseQuery, ListVettedPackagesRequest, StoreId, Synchronizer, base_query, store_id,
-        synchronizer, topology_manager_read_service_client::TopologyManagerReadServiceClient,
+        BaseQuery, ListVettedPackagesRequest,
+        topology_manager_read_service_client::TopologyManagerReadServiceClient,
     },
 };
+use prost_types::Timestamp;
 
-use crate::{config::NodeConfig, utils};
+use crate::{config::NodeConfig, utils, workflow::topology};
 
 use super::{queries::compare_versions, types::VettedPackageInfo};
 
@@ -120,17 +125,22 @@ pub(crate) async fn fetch_package_id_to_name(
         .collect())
 }
 
-/// Packages this participant has actually vetted, with name and version.
+/// Packages this participant has vetted and that are in effect right now,
+/// with name and version.
 ///
-/// Reads topology vetting state — which is a strictly smaller set than the
-/// uploaded DARs `fetch_package_names` reports, since a DAR can be uploaded
-/// without being vetted. The topology entries carry only package ids, so
-/// name/version are joined in from the Admin PackageService.
+/// The topology entries carry only package ids, so name/version are joined in
+/// from the Admin PackageService. A vetted package can be missing there — a
+/// restore from backup keeps the vetting but not the DAR — and then name and
+/// version stay empty: vetting is topology state, not local package state.
 ///
-/// Queries the synchronizer store, like every other topology read: a connected
-/// participant's vetting transactions land there, while the Authorized store
-/// only collects transactions issued while disconnected — on a live node it is
-/// empty or stale (#376).
+/// Queries the synchronizer store: the DAR upload path registers vetting
+/// directly on the synchronizer, so on a live node the Authorized store holds
+/// an empty or stale copy (#376). Only `Replace` mappings are requested — at
+/// head state a `Remove` means "no longer vetted", and counting its package
+/// list would report a fully unvetted participant as vetted. Entries outside
+/// their validity window are dropped too: Splice schedules upgrades by vetting
+/// with a future `valid_from_inclusive`, which Canton rejects until that time
+/// arrives.
 ///
 /// Deliberately on the admin channel: the Ledger API has a paginated
 /// `ListVettedPackages`, but it needs a bearer token and tokens here are
@@ -147,17 +157,8 @@ pub(crate) async fn fetch_vetted_packages(config: &NodeConfig) -> Result<Vec<Vet
     let response = client
         .list_vetted_packages(tonic::Request::new(ListVettedPackagesRequest {
             base_query: Some(BaseQuery {
-                store: Some(StoreId {
-                    store: Some(store_id::Store::Synchronizer(Synchronizer {
-                        kind: Some(synchronizer::Kind::PhysicalId(synchronizer_id)),
-                    })),
-                }),
-                proposals: false,
-                operation: 0,
-                time_query: Some(base_query::TimeQuery::HeadState(())),
-                filter_signed_key: String::new(),
-                protocol_version: None,
-                client_version: None,
+                operation: TopologyChangeOp::AddReplace as i32,
+                ..topology::head_state_query(&synchronizer_id)
             }),
             filter_participant: config.participant_id().to_string(),
         }))
@@ -166,12 +167,16 @@ pub(crate) async fn fetch_vetted_packages(config: &NodeConfig) -> Result<Vec<Vet
         .into_inner();
 
     let descriptions = fetch_package_descriptions(config).await?;
+    let now = now_timestamp();
 
     let mut seen = std::collections::HashSet::new();
     let mut vetted = Vec::new();
     for result in response.results {
         let Some(item) = result.item else { continue };
         for package in item.packages {
+            if !package_valid_at(&package, &now) {
+                continue;
+            }
             if !seen.insert(package.package_id.clone()) {
                 continue;
             }
@@ -188,6 +193,31 @@ pub(crate) async fn fetch_vetted_packages(config: &NodeConfig) -> Result<Vec<Vet
     }
 
     Ok(vetted)
+}
+
+/// The current wall-clock time as a proto timestamp, for validity checks.
+fn now_timestamp() -> Timestamp {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
+    Timestamp {
+        seconds: i64::try_from(now.as_secs()).unwrap_or(i64::MAX),
+        nanos: i32::try_from(now.subsec_nanos()).unwrap_or(0),
+    }
+}
+
+/// Whether a vetting entry is in effect at `now`: `valid_from_inclusive` has
+/// passed (or is unset) and `valid_until_exclusive` has not (or is unset).
+fn package_valid_at(package: &VettedPackage, now: &Timestamp) -> bool {
+    let le = |a: &Timestamp, b: &Timestamp| (a.seconds, a.nanos) <= (b.seconds, b.nanos);
+    package
+        .valid_from_inclusive
+        .as_ref()
+        .is_none_or(|from| le(from, now))
+        && package
+            .valid_until_exclusive
+            .as_ref()
+            .is_none_or(|until| !le(until, now))
 }
 
 /// Load `(package_id → (name, version))` from the Admin PackageService.
@@ -291,6 +321,28 @@ mod tests {
         let ordered = newest_matching_names(&names, "governance-core");
 
         assert!(ordered.is_empty());
+    }
+
+    #[test]
+    fn test_package_valid_at() {
+        let ts = |seconds| Timestamp { seconds, nanos: 0 };
+        let pkg = |from: Option<i64>, until: Option<i64>| VettedPackage {
+            package_id: "pkg".to_string(),
+            valid_from_inclusive: from.map(ts),
+            valid_until_exclusive: until.map(ts),
+        };
+        let now = ts(100);
+
+        assert!(package_valid_at(&pkg(None, None), &now));
+        // `valid_from` is inclusive
+        assert!(package_valid_at(&pkg(Some(100), None), &now));
+        // scheduled for the future, e.g. a Splice upgrade vetting
+        assert!(!package_valid_at(&pkg(Some(101), None), &now));
+        assert!(package_valid_at(&pkg(None, Some(101)), &now));
+        // `valid_until` is exclusive
+        assert!(!package_valid_at(&pkg(None, Some(100)), &now));
+        // expired
+        assert!(!package_valid_at(&pkg(Some(0), Some(50)), &now));
     }
 
     #[test]

--- a/crates/decman/tests/common/phases/distribute_dars.rs
+++ b/crates/decman/tests/common/phases/distribute_dars.rs
@@ -235,10 +235,7 @@ pub async fn run(f: &mut Fixture) -> anyhow::Result<()> {
             |f, _| {
                 Box::pin(async move {
                     for port in [f.p1.http, f.p2.http, f.p3.http] {
-                        let vetted = match f.get_json::<Value>(port, "/packages/vetted").await {
-                            Ok(v) => v,
-                            Err(_) => return None,
-                        };
+                        let vetted = f.probe_get_json::<Value>(port, "/packages/vetted").await?;
                         let found = vetted.as_array().is_some_and(|packages| {
                             packages.iter().any(|p| {
                                 p["package_name"]

--- a/crates/decman/tests/common/phases/distribute_dars.rs
+++ b/crates/decman/tests/common/phases/distribute_dars.rs
@@ -66,12 +66,47 @@ async fn dar_present_on(f: &Fixture, port: u16, pkg: &str, module: &str, entity:
     f.get_json::<serde_json::Value>(port, &path).await.is_ok()
 }
 
+/// Daml package names of the distributed DARs — each filename is
+/// `<package-name>-<version>.dar`.
+fn distributed_package_names() -> Vec<&'static str> {
+    DAR_FILES
+        .iter()
+        .filter_map(|file| file.strip_suffix(".dar"))
+        .filter_map(|name| name.rsplit_once('-').map(|(package, _version)| package))
+        .collect()
+}
+
+/// Whether `/packages/vetted` on `port` reports every distributed package as
+/// vetted. Exact name match — a substring would also accept sibling families
+/// like `governance-core-test`.
+async fn dars_vetted_on(f: &Fixture, port: u16) -> bool {
+    let Some(vetted) = f.probe_get_json::<Value>(port, "/packages/vetted").await else {
+        return false;
+    };
+    let Some(packages) = vetted.as_array() else {
+        return false;
+    };
+    distributed_package_names().into_iter().all(|expected| {
+        packages
+            .iter()
+            .any(|p| p["package_name"].as_str() == Some(expected))
+    })
+}
+
 async fn all_dars_present(f: &Fixture) -> bool {
     for (pkg, module, entity) in DAR_PROBES {
         for port in [f.p1.http, f.p2.http, f.p3.http] {
             if !dar_present_on(f, port, pkg, module, entity).await {
                 return false;
             }
+        }
+    }
+    // The skip fast-path must confirm vetting too: on warm environments (the
+    // devnet target) the DARs persist from earlier runs, and skipping here
+    // would also skip the vetted probe below — the #376 regression gate.
+    for port in [f.p1.http, f.p2.http, f.p3.http] {
+        if !dars_vetted_on(f, port).await {
+            return false;
         }
     }
     true
@@ -230,20 +265,12 @@ pub async fn run(f: &mut Fixture) -> anyhow::Result<()> {
             },
         )
         .then(
-            "governance-core vetted per /packages/vetted on all participants",
+            "distributed DARs vetted per /packages/vetted on all participants",
             Duration::from_secs(60),
             |f, _| {
                 Box::pin(async move {
                     for port in [f.p1.http, f.p2.http, f.p3.http] {
-                        let vetted = f.probe_get_json::<Value>(port, "/packages/vetted").await?;
-                        let found = vetted.as_array().is_some_and(|packages| {
-                            packages.iter().any(|p| {
-                                p["package_name"]
-                                    .as_str()
-                                    .is_some_and(|name| name.contains("governance-core"))
-                            })
-                        });
-                        if !found {
+                        if !dars_vetted_on(f, port).await {
                             return None;
                         }
                     }

--- a/crates/decman/tests/common/phases/distribute_dars.rs
+++ b/crates/decman/tests/common/phases/distribute_dars.rs
@@ -229,6 +229,31 @@ pub async fn run(f: &mut Fixture) -> anyhow::Result<()> {
                 })
             },
         )
+        .then(
+            "governance-core vetted per /packages/vetted on all participants",
+            Duration::from_secs(60),
+            |f, _| {
+                Box::pin(async move {
+                    for port in [f.p1.http, f.p2.http, f.p3.http] {
+                        let vetted = match f.get_json::<Value>(port, "/packages/vetted").await {
+                            Ok(v) => v,
+                            Err(_) => return None,
+                        };
+                        let found = vetted.as_array().is_some_and(|packages| {
+                            packages.iter().any(|p| {
+                                p["package_name"]
+                                    .as_str()
+                                    .is_some_and(|name| name.contains("governance-core"))
+                            })
+                        });
+                        if !found {
+                            return None;
+                        }
+                    }
+                    Some(Ok(()))
+                })
+            },
+        )
         .run(f)
         .await
 }


### PR DESCRIPTION
## Summary

`GET /packages/vetted` read package vetting from the Authorized topology store. The DAR upload path registers vetting directly on the synchronizer store, so on a live node the Authorized copy is empty or a stale snapshot. The endpoint therefore under-reported vetting, and the UI kept the governance-core deploy gate closed on testnet even though every participant had vetted the DAR.

This PR points `fetch_vetted_packages` at the synchronizer store. It resolves the physical synchronizer id through the cached `utils::get_synchronizer_id` and builds the query with the shared `workflow::topology::head_state_query` helper. The name/version join and the dedupe logic are unchanged.

Two vetting semantics became load-bearing with the store switch, and the read now honors both:

- Only `Replace` mappings count. A head-state `Remove` means "no longer vetted"; without the filter its package list would report a fully unvetted participant as vetted. Canton's own console filters this listing the same way.
- Entries outside their validity window are dropped. Splice schedules upgrades by vetting with a future `valid_from_inclusive`, which Canton rejects until that time arrives, so reporting them as vetted misleads exactly during upgrade windows.

The PR also adds an integration probe to the `distribute_dars` phase: after DAR distribution, `/packages/vetted` must report every distributed package, by exact name, on all three participants. The probe also runs inside the warm-environment fast-path, so a devnet-target run with pre-existing DARs still exercises it. The endpoint had no coverage before, which is why the bug shipped.

## Related issues

Closes #376

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build / CI / chore

## Checklist

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` is clean
- [x] `cargo test` passes
- [x] Added/updated tests where appropriate
- [ ] Updated documentation where appropriate
- [x] Commits follow the `<type>(<scope>): <subject>` convention

## Notes for reviewers

The store switch was verified against live nodes. On devnet participant 1, the Authorized store holds 180 packages frozen at 2025-11-14, while the synchronizer store holds 257 packages current to 2026-08-25 and includes `governance-core-v1`. A build from `main` renders the stale 180; a build from this branch renders the 257 that match the Admin API ground truth. The testnet participants show the same split (empty / frozen 2025-11-26 vs. current), with the full evidence table in #376. The `Replace`-only query was also verified against devnet: it returns the same 257-package mapping, so the filter drops nothing legitimate.

One precision note: the Authorized store is not merely "what the node issued while disconnected", and one deliberate Authorized-store read remains in the codebase (`generate_keys.rs`, as a propagation-independent idempotency check). What holds specifically for vetting is that the upload path registers it directly on the synchronizer. The doc comments state the scoped claim.

One trade-off to note: the endpoint now requires a resolvable synchronizer id, so it fails on a participant that has never connected to a synchronizer. That state cannot vet against the network anyway, and a hard error beats silently reporting a stale list, so no Authorized-store fallback was added. The UI currently renders that error as an empty list; distinguishing the two is a follow-up.
