### PR TITLE
fix(auth): accepted configurable JWT role claims

### DIFF
--- a/crates/decman/src/auth/validators/jwt.rs
+++ b/crates/decman/src/auth/validators/jwt.rs
@@ -238,22 +238,21 @@ impl JwtValidator {
         }
 
         let mut flat_roles = claims.roles.unwrap_or_default();
-        if let Some(claim_name) = self.role_claim.as_deref()
-            && claim_name != "roles"
-            && let Some(value) = claims.additional.get(claim_name)
-        {
-            match serde_json::from_value::<Vec<String>>(value.clone()) {
-                Ok(roles) => {
-                    for role in roles {
-                        if !flat_roles.contains(&role) {
-                            flat_roles.push(role);
-                        }
-                    }
+        if let Some(claim_name) = self.role_claim.as_deref() {
+            match claims.additional.get(claim_name) {
+                Some(value) => match serde_json::from_value::<Vec<String>>(value.clone()) {
+                    Ok(roles) => flat_roles.extend(roles),
+                    Err(_) => tracing::warn!(
+                        "configured JWT role claim '{claim_name}' is not an array of strings; \
+                         ignoring it"
+                    ),
+                },
+                None => {
+                    tracing::warn!(
+                        "configured JWT role claim '{claim_name}' is absent from token; \
+                         ignoring it"
+                    );
                 }
-                Err(_) => tracing::warn!(
-                    "configured JWT role claim '{claim_name}' is not an array of strings; \
-                     ignoring it"
-                ),
             }
         }
         let roles = collect_roles(
@@ -688,6 +687,56 @@ mod tests {
             .map_err(|e| anyhow::anyhow!("expected Auth0 token to verify: {e:?}"))?;
         assert!(principal.has_role("decentralization-manager-admin"));
         assert!(principal.has_role("viewer"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn malformed_configured_role_claim_contributes_no_roles() -> anyhow::Result<()> {
+        let role_claim = "https://idp.example/roles";
+        let (_server, validator, issuer) = setup_with_role_claim(Some(role_claim)).await;
+        let mut header = Header::new(Algorithm::RS256);
+        header.kid = Some(TEST_KID.to_string());
+        let token = sign(
+            &header,
+            &json!({
+                "iss": issuer,
+                "sub": "auth0|operator",
+                "azp": "decman",
+                "exp": unix_now()? + 3600,
+                "https://idp.example/roles": "decentralization-manager-admin",
+            }),
+        )?;
+
+        let principal = validator
+            .validate(&token)
+            .await
+            .map_err(|e| anyhow::anyhow!("expected token with malformed roles to verify: {e:?}"))?;
+        assert!(!principal.has_role("decentralization-manager-admin"));
+        assert!(principal.roles.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn absent_configured_role_claim_contributes_no_roles() -> anyhow::Result<()> {
+        let role_claim = "https://idp.example/roles";
+        let (_server, validator, issuer) = setup_with_role_claim(Some(role_claim)).await;
+        let mut header = Header::new(Algorithm::RS256);
+        header.kid = Some(TEST_KID.to_string());
+        let token = sign(
+            &header,
+            &json!({
+                "iss": issuer,
+                "sub": "auth0|operator",
+                "azp": "decman",
+                "exp": unix_now()? + 3600,
+            }),
+        )?;
+
+        let principal = validator.validate(&token).await.map_err(|e| {
+            anyhow::anyhow!("expected token without configured roles to verify: {e:?}")
+        })?;
+        assert!(!principal.has_role("decentralization-manager-admin"));
+        assert!(principal.roles.is_empty());
         Ok(())
     }
 

--- a/crates/decman/src/auth/validators/jwt.rs
+++ b/crates/decman/src/auth/validators/jwt.rs
@@ -37,6 +37,10 @@ const JWKS_TTL: Duration = Duration::from_secs(3600);
 pub struct JwtValidator {
     inbound: Option<KeycloakConfig>,
     auth0: Option<Auth0Config>,
+    /// Optional provider-specific claim that carries an array of role names.
+    /// Standard `realm_access.roles`, `roles`, and `scope` carriers remain
+    /// supported without configuration.
+    role_claim: Option<String>,
     party_credentials: Arc<RwLock<Vec<PartyCredentials>>>,
     /// JWKS cache keyed by issuer.
     jwks_cache: RwLock<HashMap<String, CachedJwks>>,
@@ -127,18 +131,24 @@ struct Claims {
     scope: Option<String>,
     #[serde(default)]
     roles: Option<Vec<String>>,
+    /// Preserve provider-specific claims so an operator-configured role claim
+    /// can be read without baking an IdP or deployment namespace into DecMan.
+    #[serde(flatten)]
+    additional: HashMap<String, serde_json::Value>,
 }
 
 impl JwtValidator {
     pub fn new(
         inbound: Option<KeycloakConfig>,
         auth0: Option<Auth0Config>,
+        role_claim: Option<String>,
         party_credentials: Arc<RwLock<Vec<PartyCredentials>>>,
         http: reqwest::Client,
     ) -> Self {
         Self {
             inbound,
             auth0,
+            role_claim: role_claim.filter(|claim| !claim.is_empty()),
             party_credentials,
             jwks_cache: RwLock::new(HashMap::new()),
             http,
@@ -227,9 +237,28 @@ impl JwtValidator {
             }
         }
 
+        let mut flat_roles = claims.roles.unwrap_or_default();
+        if let Some(claim_name) = self.role_claim.as_deref()
+            && claim_name != "roles"
+            && let Some(value) = claims.additional.get(claim_name)
+        {
+            match serde_json::from_value::<Vec<String>>(value.clone()) {
+                Ok(roles) => {
+                    for role in roles {
+                        if !flat_roles.contains(&role) {
+                            flat_roles.push(role);
+                        }
+                    }
+                }
+                Err(_) => tracing::warn!(
+                    "configured JWT role claim '{claim_name}' is not an array of strings; \
+                     ignoring it"
+                ),
+            }
+        }
         let roles = collect_roles(
             claims.realm_access.as_ref(),
-            claims.roles.as_deref(),
+            Some(&flat_roles),
             claims.scope.as_deref(),
         );
         Ok(Principal {
@@ -541,6 +570,10 @@ mod tests {
     /// `JwtValidator` that trusts it. Returns `(server, validator, issuer)`;
     /// keep `server` alive for the duration of the call.
     async fn setup() -> (MockServer, JwtValidator, String) {
+        setup_with_role_claim(None).await
+    }
+
+    async fn setup_with_role_claim(role_claim: Option<&str>) -> (MockServer, JwtValidator, String) {
         let server = MockServer::start().await;
         let issuer = format!("{}/realms/test", server.uri());
 
@@ -578,6 +611,7 @@ mod tests {
         let validator = JwtValidator::new(
             Some(inbound),
             None,
+            role_claim.map(str::to_string),
             std::sync::Arc::new(tokio::sync::RwLock::new(Vec::new())),
             reqwest::Client::new(),
         );
@@ -629,6 +663,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn accepts_configured_role_claim() -> anyhow::Result<()> {
+        let role_claim = "https://idp.example/roles";
+        let (_server, validator, issuer) = setup_with_role_claim(Some(role_claim)).await;
+        let mut header = Header::new(Algorithm::RS256);
+        header.kid = Some(TEST_KID.to_string());
+        let token = sign(
+            &header,
+            &json!({
+                "iss": issuer,
+                "sub": "auth0|operator",
+                "azp": "decman",
+                "exp": unix_now()? + 3600,
+                "https://idp.example/roles": [
+                    "decentralization-manager-admin",
+                    "viewer"
+                ],
+            }),
+        )?;
+
+        let principal = validator
+            .validate(&token)
+            .await
+            .map_err(|e| anyhow::anyhow!("expected Auth0 token to verify: {e:?}"))?;
+        assert!(principal.has_role("decentralization-manager-admin"));
+        assert!(principal.has_role("viewer"));
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn fetches_metadata_from_internal_url_while_trusting_public_issuer() -> anyhow::Result<()>
     {
         // The server cannot reach the public `url` (an unreachable host), but
@@ -675,6 +738,7 @@ mod tests {
         };
         let validator = JwtValidator::new(
             Some(inbound),
+            None,
             None,
             std::sync::Arc::new(tokio::sync::RwLock::new(Vec::new())),
             reqwest::Client::new(),

--- a/crates/decman/src/auth/validators/jwt.rs
+++ b/crates/decman/src/auth/validators/jwt.rs
@@ -684,7 +684,7 @@ mod tests {
         let principal = validator
             .validate(&token)
             .await
-            .map_err(|e| anyhow::anyhow!("expected Auth0 token to verify: {e:?}"))?;
+            .map_err(|e| anyhow::anyhow!("expected token with configured role claim to verify: {e:?}"))?;
         assert!(principal.has_role("decentralization-manager-admin"));
         assert!(principal.has_role("viewer"));
         Ok(())

--- a/crates/decman/src/auth/validators/jwt.rs
+++ b/crates/decman/src/auth/validators/jwt.rs
@@ -681,10 +681,9 @@ mod tests {
             }),
         )?;
 
-        let principal = validator
-            .validate(&token)
-            .await
-            .map_err(|e| anyhow::anyhow!("expected token with configured role claim to verify: {e:?}"))?;
+        let principal = validator.validate(&token).await.map_err(|e| {
+            anyhow::anyhow!("expected token with configured role claim to verify: {e:?}")
+        })?;
         assert!(principal.has_role("decentralization-manager-admin"));
         assert!(principal.has_role("viewer"));
         Ok(())

--- a/crates/decman/src/cli.rs
+++ b/crates/decman/src/cli.rs
@@ -172,6 +172,12 @@ pub enum Commands {
         #[arg(long, env = "DECPM_AUTH0_AUDIENCE", hide = true)]
         auth0_audience: Option<String>,
 
+        /// Optional JWT claim containing an array of role names. Use this for
+        /// provider-required namespaced custom claims; standard role carriers
+        /// remain enabled when this is unset.
+        #[arg(long, env = "DECPM_JWT_ROLE_CLAIM")]
+        jwt_role_claim: Option<String>,
+
         /// Role name that gates sensitive endpoints (PUT /party-config,
         /// POST /kick, etc.). Unset (default) skips the role check —
         /// every authenticated caller is treated as admin. Set this to

--- a/crates/decman/src/main.rs
+++ b/crates/decman/src/main.rs
@@ -163,6 +163,7 @@ async fn run() -> Result {
             auth0_domain,
             auth0_client_id,
             auth0_audience,
+            jwt_role_claim: _,
             timeout_handshake,
             timeout_message,
             timeout_retry_attempts,
@@ -353,6 +354,7 @@ async fn run() -> Result {
             ref host,
             port,
             ref admin_role,
+            ref jwt_role_claim,
             ref allowed_origin,
             ..
         } => {
@@ -362,6 +364,7 @@ async fn run() -> Result {
                 config,
                 pool,
                 admin_role.clone(),
+                jwt_role_claim.clone(),
                 allowed_origin.clone(),
             )
             .await?;

--- a/crates/decman/src/server/middleware/auth.rs
+++ b/crates/decman/src/server/middleware/auth.rs
@@ -429,6 +429,7 @@ mod tests {
         let validator = TokenValidator::Jwt(Arc::new(JwtValidator::new(
             None,
             None,
+            None,
             parties.clone(),
             reqwest::Client::new(),
         )));

--- a/crates/decman/src/server/mod.rs
+++ b/crates/decman/src/server/mod.rs
@@ -854,6 +854,7 @@ pub async fn start_server(
     config: NodeConfig,
     db: SqlitePool,
     admin_role: Option<String>,
+    jwt_role_claim: Option<String>,
     allowed_origin: Option<String>,
 ) -> Result {
     // Fail fast before any setup: the runtime `--insecure` flag must never be
@@ -960,6 +961,7 @@ pub async fn start_server(
         TokenValidator::Jwt(Arc::new(JwtValidator::new(
             config.keycloak.clone(),
             config.auth0.clone(),
+            jwt_role_claim,
             party_credentials.clone(),
             http_client.clone(),
         )))

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -115,6 +115,7 @@ In the application's **APIs** tab, **authorize** it against the API you just cre
 - `DECPM_AUTH0_DOMAIN` = the tenant domain shown on the application page (for example `your-tenant.us.auth0.com` — no scheme).
 - `DECPM_AUTH0_CLIENT_ID` = the application's **Client ID**.
 - `DECPM_AUTH0_AUDIENCE` = the API **Identifier** from step 1.
+- `DECPM_JWT_ROLE_CLAIM` = a URI-namespaced claim owned by your deployment (for example `https://example.com/decman/roles`) when using the admin-role gate.
 
 **Allowed Web Origins** plays the same role as Keycloak's Web Origins — without it the browser blocks the SPA's token requests with CORS errors. Set it to your UI host; do not rely on Auth0 deriving it from callback URLs.
 
@@ -123,11 +124,15 @@ In the application's **APIs** tab, **authorize** it against the API you just cre
 ```js
 exports.onExecutePostLogin = async (event, api) => {
   const roles = event.authorization?.roles || [];
-  api.accessToken.setCustomClaim("roles", roles);
+  api.accessToken.setCustomClaim("https://example.com/decman/roles", roles);
 };
 ```
 
-Attach the Action to the Login flow, then create the matching role under **User Management → Roles** and assign it to the appropriate users.
+Set `DECPM_JWT_ROLE_CLAIM=https://example.com/decman/roles`, replacing the
+example namespace with one controlled by your deployment. Attach the Action to
+the Login flow, then create the matching role under **User Management → Roles**
+and assign it to the appropriate users. DecMan also supports the standard flat
+`roles`, `realm_access.roles`, and `scope` carriers without this setting.
 
 ## 3 — Apply the manifests
 
@@ -408,6 +413,7 @@ Most variables have a default that's only useful for local development (loopback
 | `DECPM_AUTH0_DOMAIN` | unset | **yes**¹ | Auth0 tenant domain for frontend auth (mutually exclusive with `DECPM_KEYCLOAK_*`) |
 | `DECPM_AUTH0_CLIENT_ID` | unset | **yes**¹ | Auth0 SPA client ID |
 | `DECPM_AUTH0_AUDIENCE` | unset | **yes**¹ | Auth0 API audience targeted by SPA tokens |
+| `DECPM_JWT_ROLE_CLAIM` | unset | optional | Provider-specific JWT claim containing a role-name array; typically required for Auth0's namespaced custom claim |
 | `DECPM_ADMIN_ROLE` | unset | recommended | IdP role required for privileged endpoints. If unset, every authenticated caller is treated as admin. |
 | `DECPM_ALLOWED_ORIGIN` | same-origin | optional | CORS origin if UI host ≠ API host |
 | `DECPM_DB_ENCRYPTION_KEY` | unset | recommended | Random passphrase (hashed via SHA-256) protecting party secrets at rest. If unset, secrets are stored in plaintext in the SQLite DB. |
@@ -464,4 +470,4 @@ or dismiss them first).
 - **UI loads but login fails**: confirm `<your-ui-host>` is registered as a valid redirect URI on your IdP client, and that the `DECPM_KEYCLOAK_*` (or `DECPM_AUTH0_*`) env vars match the IdP. For Auth0, the SPA application must also have the configured audience listed in its Allowed Callback / API Authorization.
 - **Peers shown as unreachable**: check that the Noise port (9000) is exposed publicly, that `DECPM_PUBLIC_ADDRESS` resolves to that endpoint, and that the peer has your current public key.
 - **Every Canton call fails with `transport error` / `BrokenPipe`, immediately and permanently**: the channel's TLS setting does not match what the endpoint speaks. A plaintext client against a TLS listener has its connection closed on the first bytes, which looks identical to the participant being down. Confirm with `grpcurl -plaintext <host>:<port> list` — if that fails but `grpcurl <host>:<port> list` succeeds, the endpoint is TLS: set `DECPM_CANTON_ADMIN_TLS=true` (and `DECPM_CANTON_LEDGER_TLS=true` for the ledger API), plus `..._TLS_CA_CERT` when a private CA issued the certificate. The connect error message names the variable to change in either direction.
-- **Privileged endpoints return 403**: you have `DECPM_ADMIN_ROLE` set but the calling user doesn't have that role assigned in the IdP. Either grant the role or unset the variable.
+- **Privileged endpoints return 403**: you have `DECPM_ADMIN_ROLE` set but the calling user doesn't have that role assigned in the IdP, or `DECPM_JWT_ROLE_CLAIM` does not match the claim emitted by the IdP. Correct the claim configuration, grant the role, or unset the admin-role gate.


### PR DESCRIPTION
## Summary

Allow operators to configure a provider-specific JWT role claim with `DECPM_JWT_ROLE_CLAIM`. DecMan reads the configured signed claim as a string array while retaining support for the standard flat `roles`, `realm_access.roles`, and `scope` carriers.

This supports IdPs such as Auth0 that require URI-namespaced custom claims without embedding any vendor or deployment namespace in DecMan.

## Related issues

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Build / CI / chore

## Checklist

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` is clean
- [ ] `cargo test` passes
- [x] Added/updated tests where appropriate
- [x] Updated documentation where appropriate
- [x] Commits follow the `<type>(<scope>): <subject>` convention

## Notes for reviewers

The JWT validator uses `serde(flatten)` to retain provider-specific signed claims and reads only the exact operator-configured key. A missing or malformed custom claim contributes no roles, so an enabled admin gate fails closed. All 12 JWT-validator tests pass.
