### PR TITLE
Extract a party-type-agnostic replication core from add-party

### DIFF
--- a/crates/decman/src/workflow/add_party/config.rs
+++ b/crates/decman/src/workflow/add_party/config.rs
@@ -2,7 +2,23 @@ use std::marker::PhantomData;
 
 use serde::{Deserialize, Serialize};
 
-use crate::canton_id::CantonId;
+use crate::{
+    canton_id::CantonId,
+    workflow::{
+        party_replication::{ReplicationArtifacts, ReplicationTarget},
+        storage::artifact_kinds,
+    },
+};
+
+/// The artifact keys the add-party run's replication has always used. Named
+/// here rather than inside the replication core so the core stays free of any
+/// one workflow's key namespace — and so these strings keep their exact values,
+/// which is what lets a run interrupted before the extraction resume after it.
+pub const ADD_PARTY_REPLICATION_ARTIFACTS: ReplicationArtifacts = ReplicationArtifacts {
+    export_offset: artifact_kinds::ADD_PARTY_EXPORT_OFFSET,
+    pre_activation_offset: artifact_kinds::ADD_PARTY_PRE_ACTIVATION_OFFSET,
+    import_inflight: artifact_kinds::ADD_PARTY_ACS_IMPORT_INFLIGHT,
+};
 
 /// Configuration for the add-party workflow (adding a new member to an
 /// existing decentralized party)
@@ -56,5 +72,19 @@ impl AddPartyConfig {
     /// Daml signing key name for the new member (see `namespace_key_name`).
     pub fn daml_key_name(&self) -> String {
         format!("{}-daml-transactions", self.decentralized_party_id.prefix)
+    }
+
+    /// This run's replication, addressed the way the party-type-agnostic core
+    /// expects: the decentralized party moving onto the new member.
+    ///
+    /// `instance_name` is passed rather than read off `self` because the step
+    /// callers already carry it, and the two must not be allowed to disagree.
+    pub fn replication_target(&self, instance_name: &str) -> ReplicationTarget {
+        ReplicationTarget::new(
+            self.decentralized_party_id.clone(),
+            self.new_participant_id.clone(),
+            instance_name.to_string(),
+            ADD_PARTY_REPLICATION_ARTIFACTS,
+        )
     }
 }

--- a/crates/decman/src/workflow/add_party/coordinator.rs
+++ b/crates/decman/src/workflow/add_party/coordinator.rs
@@ -12,6 +12,7 @@ use crate::{
     utils,
     workflow::{
         kick::coordinator::split_signed_kick_pair,
+        party_replication::{collect_party_package_ids, export_party_acs, wait_for_flag_cleared},
         state::WorkflowState,
         storage::{WorkflowStorage, artifact_kinds, identity_kinds},
     },
@@ -19,10 +20,7 @@ use crate::{
 
 use super::{
     AddPartyConfig, AddPartyStep, resolve_ledger_token,
-    steps::{
-        clear_onboarding::wait_for_flag_cleared, collect_party_package_ids, create_proposals,
-        export_party_acs, export_state, submit_clear_proposal, submit_proposals,
-    },
+    steps::{create_proposals, export_state, submit_clear_proposal, submit_proposals},
 };
 
 pub async fn start_coordinator(
@@ -154,8 +152,12 @@ async fn run_workflow(
                 // The topology is live; export the party's ACS for the new
                 // member and ship it with the ImportAcs command. Empty when
                 // the party has no active contracts — the new member skips.
-                let snapshot =
-                    export_party_acs(&node_config, &db, &instance_name, &add_party_config).await?;
+                let snapshot = export_party_acs(
+                    &node_config,
+                    &db,
+                    &add_party_config.replication_target(&instance_name),
+                )
+                .await?;
                 // Package ids the new member must have to validate the imported
                 // ACS — its import preflight fails fast (before disconnecting) if
                 // any are missing, instead of the import dying mid-window. Skip the

--- a/crates/decman/src/workflow/add_party/mod.rs
+++ b/crates/decman/src/workflow/add_party/mod.rs
@@ -4,10 +4,7 @@ pub mod peer;
 pub mod steps;
 
 pub use config::AddPartyConfig;
-pub use steps::{
-    ClearOutcome, author_clear_proposal, clear_onboarding_flag, generate_keys, import_party_acs,
-    sign_clear_proposal, sign_proposals,
-};
+pub use steps::{author_clear_proposal, generate_keys, sign_clear_proposal, sign_proposals};
 
 use crate::{
     auth::WorkflowAuth, canton_id::CantonId, noise::MessageType, server::WorkflowKind,

--- a/crates/decman/src/workflow/add_party/steps/clear_onboarding.rs
+++ b/crates/decman/src/workflow/add_party/steps/clear_onboarding.rs
@@ -1,26 +1,19 @@
-use std::time::SystemTime;
-
 use canton_proto_rs::com::digitalasset::canton::{
-    admin::participant::v30::{
-        ClearPartyOnboardingFlagRequest,
-        party_management_service_client::PartyManagementServiceClient,
-    },
-    protocol::v30::{PartyToParticipant, SignedTopologyTransaction, topology_mapping},
+    protocol::v30::{SignedTopologyTransaction, topology_mapping},
     topology::admin::v30::{
         SignTransactionsRequest,
         topology_manager_write_service_client::TopologyManagerWriteServiceClient,
     },
 };
 use sqlx::SqlitePool;
-use tokio::time;
 
 use crate::{
-    canton_id::CantonId,
     config::NodeConfig,
     error::Result,
     utils,
     workflow::{
         add_party::{AddPartyConfig, steps::proposals::create::proposal_request},
+        party_replication::{has_onboarding_marker, wait_for_flag_cleared},
         storage::{WorkflowStorage, artifact_kinds},
         topology::{
             add_transactions_request, authorize_with_topology_retry, dedupe_signatures,
@@ -33,119 +26,6 @@ use crate::{
 /// time to clear the onboarding flag" to arrive. The safe time is normally
 /// seconds away (decision timeouts); ten minutes flags a genuinely stuck
 /// synchronizer instead of hanging the workflow forever.
-const MAX_SAFE_TIME_WAIT_SECS: u64 = 600;
-
-/// Outcome of the new member's `ClearPartyOnboardingFlag` polling.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum ClearOutcome {
-    /// Canton reports the flag is gone — no signing round needed.
-    Cleared,
-    /// The safe time passed and the clearing transaction is proposed; for a
-    /// decentralized party it now needs threshold owner signatures, which the
-    /// coordinator's sign round provides.
-    Proposed,
-}
-
-/// New-member step: drive `ClearPartyOnboardingFlag` until the flag is gone
-/// or Canton has accepted the clearing proposal past its safe time.
-///
-/// Canton refuses to clear before its computed safe time (so no in-flight
-/// transaction from the import window can be lost) — the endpoint returns
-/// `onboarded = false` with `earliest_retry_timestamp` until then. After the
-/// safe time, a call proposes the clearing topology transaction; for a
-/// decentralized party that proposal still needs threshold owner signatures,
-/// which the workflow's next steps collect.
-pub async fn clear_onboarding_flag(
-    config: &NodeConfig,
-    storage: &SqlitePool,
-    instance_name: &str,
-    add_party_config: &AddPartyConfig,
-) -> Result<ClearOutcome> {
-    // Logical synchronizer id — see `current_ledger_offset` for why the
-    // physical id is rejected by PartyManagementService.
-    let synchronizer_id =
-        utils::extract_synchronizer_fingerprint(&utils::get_synchronizer_id(config).await?)?;
-    let self_id = config.participant_id().to_string();
-
-    // No zero fallback: ClearPartyOnboardingFlag rejects non-positive
-    // offsets, and a missing artifact means GenerateNewMemberKeys never
-    // persisted one — a real bug to surface, not paper over.
-    let offset_bytes = storage
-        .read_artifact(
-            instance_name,
-            artifact_kinds::ADD_PARTY_PRE_ACTIVATION_OFFSET,
-            Some(&self_id),
-        )
-        .await?
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "ADD_PARTY_PRE_ACTIVATION_OFFSET artifact missing for {self_id} — \
-                 did GenerateNewMemberKeys run?"
-            )
-        })?;
-    let begin_offset_exclusive: i64 = String::from_utf8(offset_bytes)?
-        .trim()
-        .parse()
-        .map_err(|e| anyhow::anyhow!("Failed to parse pre-activation offset: {e}"))?;
-
-    let mut client = PartyManagementServiceClient::new(config.admin_channel().await?);
-    let waited_start = time::Instant::now();
-
-    loop {
-        let request = tonic::Request::new(ClearPartyOnboardingFlagRequest {
-            party_id: add_party_config.decentralized_party_id.to_string(),
-            synchronizer_id: synchronizer_id.clone(),
-            begin_offset_exclusive,
-            wait_for_activation_timeout: None,
-        });
-
-        let response = client
-            .clear_party_onboarding_flag(request)
-            .await?
-            .into_inner();
-
-        if response.onboarded {
-            tracing::info!("Onboarding flag already cleared");
-            return Ok(ClearOutcome::Cleared);
-        }
-
-        let now = SystemTime::now();
-        let earliest_retry = response
-            .earliest_retry_timestamp
-            .and_then(|ts| SystemTime::try_from(ts).ok());
-
-        match earliest_retry {
-            Some(safe_time) if safe_time > now => {
-                let wait = safe_time
-                    .duration_since(now)
-                    .unwrap_or(time::Duration::from_secs(1))
-                    // Re-check at least every 10s so a moving safe time
-                    // can't park the loop on one long sleep.
-                    .min(time::Duration::from_secs(10));
-                if waited_start.elapsed().as_secs() > MAX_SAFE_TIME_WAIT_SECS {
-                    anyhow::bail!(
-                        "Onboarding-flag safe time still {wait:?} away after waiting \
-                         {MAX_SAFE_TIME_WAIT_SECS}s — synchronizer appears stuck"
-                    );
-                }
-                tracing::info!(
-                    "Safe time for clearing the onboarding flag not reached; waiting {wait:?}"
-                );
-                time::sleep(wait).await;
-            }
-            // Safe time reached (or Canton sent none): this call was made
-            // past it, so the clearing transaction is proposed. The
-            // coordinator's signing round takes it from here.
-            _ => {
-                tracing::info!(
-                    "Safe time passed; clearing transaction proposed, awaiting owner signatures"
-                );
-                return Ok(ClearOutcome::Proposed);
-            }
-        }
-    }
-}
-
 /// New-member side: author the clearing proposal and return it encoded as
 /// the `varint(len)||proto` blob the coordinator persists/ships. `None`
 /// when the flag is already gone.
@@ -325,75 +205,4 @@ pub async fn submit_clear_proposal(
         &add_party_config.new_participant_id,
     )
     .await
-}
-
-/// Poll head state until the new member's onboarding marker is gone.
-pub async fn wait_for_flag_cleared(
-    config: &NodeConfig,
-    synchronizer_id: &str,
-    party_id: &CantonId,
-    new_member: &CantonId,
-) -> Result {
-    let max_attempts = crate::consts::topology_retry_max_attempts();
-    let retry_delay = time::Duration::from_secs(crate::consts::topology_retry_delay_secs());
-    let new_member_str = new_member.to_string();
-
-    for attempt in 1..=max_attempts {
-        let p2p = fetch_p2p_mapping(config, synchronizer_id, party_id).await?;
-        if !has_onboarding_marker(&p2p, &new_member_str) {
-            tracing::info!("Onboarding flag cleared after {attempt} attempt(s)");
-            return Ok(());
-        }
-        if attempt < max_attempts {
-            tracing::debug!(
-                "Onboarding flag still set, attempt {attempt}/{max_attempts}, \
-                 retrying in {retry_delay:?}..."
-            );
-            time::sleep(retry_delay).await;
-        }
-    }
-
-    anyhow::bail!("Onboarding flag was not cleared after {max_attempts} attempts")
-}
-
-/// Whether `participant` carries the Onboarding marker in `p2p`.
-fn has_onboarding_marker(p2p: &PartyToParticipant, participant: &str) -> bool {
-    p2p.participants
-        .iter()
-        .any(|p| p.participant_uid == participant && p.onboarding.is_some())
-}
-
-#[cfg(test)]
-mod tests {
-    use canton_proto_rs::com::digitalasset::canton::protocol::v30::party_to_participant::{
-        HostingParticipant, hosting_participant,
-    };
-
-    use super::*;
-
-    fn p2p(participants: Vec<HostingParticipant>) -> PartyToParticipant {
-        PartyToParticipant {
-            party: "acme::1220abcd".to_string(),
-            threshold: 2,
-            participants,
-            party_signing_keys: None,
-        }
-    }
-
-    fn hosting(uid: &str, onboarding: bool) -> HostingParticipant {
-        HostingParticipant {
-            participant_uid: uid.to_string(),
-            permission: 0,
-            onboarding: onboarding.then_some(hosting_participant::Onboarding {}),
-        }
-    }
-
-    #[test]
-    fn detects_onboarding_marker_only_for_the_marked_participant() {
-        let mapping = p2p(vec![hosting("PAR::a", false), hosting("PAR::b", true)]);
-
-        assert!(!has_onboarding_marker(&mapping, "PAR::a"));
-        assert!(has_onboarding_marker(&mapping, "PAR::b"));
-        assert!(!has_onboarding_marker(&mapping, "PAR::missing"));
-    }
 }

--- a/crates/decman/src/workflow/add_party/steps/export_state.rs
+++ b/crates/decman/src/workflow/add_party/steps/export_state.rs
@@ -5,7 +5,8 @@ use crate::{
     error::Result,
     utils,
     workflow::{
-        add_party::{AddPartyConfig, steps::generate_keys::capture_offset_once},
+        add_party::AddPartyConfig,
+        party_replication::capture_offset_once,
         storage::{WorkflowStorage, artifact_kinds},
         topology,
     },

--- a/crates/decman/src/workflow/add_party/steps/generate_keys.rs
+++ b/crates/decman/src/workflow/add_party/steps/generate_keys.rs
@@ -1,24 +1,18 @@
-use canton_proto_rs::com::{
-    daml::ledger::api::v2::GetLedgerEndRequest,
-    digitalasset::canton::{
-        admin::participant::v30::{
-            GetHighestOffsetByTimestampRequest,
-            party_management_service_client::PartyManagementServiceClient,
-        },
-        crypto::{admin::v30::vault_service_client::VaultServiceClient, v30::SigningKeyUsage},
-    },
+use canton_proto_rs::com::digitalasset::canton::crypto::{
+    admin::v30::vault_service_client::VaultServiceClient, v30::SigningKeyUsage,
 };
 use sqlx::SqlitePool;
 
 use crate::{
     config::NodeConfig,
     error::Result,
-    utils::{self, compute_fingerprint, get_participant_id, get_synchronizer_id},
+    utils::{compute_fingerprint, get_participant_id},
     workflow::{
         add_party::AddPartyConfig,
         onboarding::steps::generate_keys::{
             encode_keys_payload, get_or_create_signing_key, propose_namespace_delegation,
         },
+        party_replication::capture_offset_once,
         storage::{WorkflowStorage, artifact_kinds},
     },
 };
@@ -105,123 +99,4 @@ pub async fn generate_keys(
 
     tracing::info!("Add-party keys persisted to workflow_artifacts");
     Ok(())
-}
-
-/// Capture this participant's ledger offset into `kind` exactly once.
-///
-/// Both add-party offsets (`ADD_PARTY_PRE_ACTIVATION_OFFSET`, scoped to the
-/// participant, and `ADD_PARTY_EXPORT_OFFSET`, unscoped) exist to name a point
-/// BEFORE the party is activated. A resumed run that re-enters its step after
-/// the activation must therefore keep the original value: re-capturing would
-/// move the offset past the activation, and `ExportPartyAcs` /
-/// `ClearPartyOnboardingFlag` would then look for it in a window that no longer
-/// contains it.
-///
-/// So the first capture wins and later calls are a no-op.
-pub(crate) async fn capture_offset_once(
-    config: &NodeConfig,
-    storage: &SqlitePool,
-    instance_name: &str,
-    kind: &str,
-    scope: Option<&str>,
-    ledger_token: Option<&str>,
-    label: &str,
-) -> Result {
-    if storage
-        .read_artifact(instance_name, kind, scope)
-        .await?
-        .is_some()
-    {
-        return Ok(());
-    }
-    let offset = current_ledger_offset(config, ledger_token).await?;
-    storage
-        .write_artifact(instance_name, kind, scope, offset.to_string().as_bytes())
-        .await?;
-    tracing::info!("Captured {label} ledger offset {offset}");
-    Ok(())
-}
-
-/// Current ledger offset on this participant — the `begin_offset_exclusive`
-/// for the activation finders behind `ExportPartyAcs` and
-/// `ClearPartyOnboardingFlag`.
-///
-/// The offset must postdate any EARLIER activation of the same (party,
-/// participant) pair: the finders take the FIRST activation event published
-/// after the offset, so on a kick-then-re-add path a too-early offset
-/// surfaces the stale flag-less activation and the export aborts with
-/// INVALID_STATE (observed in CI). Tiers:
-///
-/// 1. Ledger API `GetLedgerEnd`, with the party's ledger token when the
-///    auth registry has one: exact and always current.
-/// 2. Admin API `GetHighestOffsetByTimestamp` — strict, then `force: true`.
-///    "Now" routinely trips the clean-watermark check, and even forced
-///    lookups can fail when the latest events have no synchronizer mapping
-///    (both observed in CI).
-/// 3. Offset 1 — the smallest POSITIVE value the consumers accept. Loudly
-///    warned: correct only when the participant was never hosted on the
-///    party before (no stale activation to trip over).
-pub(crate) async fn current_ledger_offset(
-    config: &NodeConfig,
-    ledger_token: Option<&str>,
-) -> Result<i64> {
-    match ledger_end_offset(config, ledger_token).await {
-        Ok(offset) if offset > 0 => return Ok(offset),
-        Ok(offset) => {
-            tracing::warn!("Ledger end reported non-positive offset {offset}; trying admin API");
-        }
-        Err(e) => {
-            tracing::warn!("GetLedgerEnd unavailable ({e}); trying admin API");
-        }
-    }
-
-    // PartyManagementService wants the LOGICAL synchronizer id
-    // (`alias::fingerprint`) — the physical id's trailing `::<version>`
-    // fails Canton's fingerprint decoding with a reserved-delimiter error.
-    let synchronizer_id =
-        utils::extract_synchronizer_fingerprint(&get_synchronizer_id(config).await?)?;
-    let mut client = PartyManagementServiceClient::new(config.admin_channel().await?);
-
-    for force in [false, true] {
-        let now = std::time::SystemTime::now();
-        let request = tonic::Request::new(GetHighestOffsetByTimestampRequest {
-            synchronizer_id: synchronizer_id.clone(),
-            timestamp: Some(prost_types::Timestamp::from(now)),
-            force,
-        });
-
-        match client.get_highest_offset_by_timestamp(request).await {
-            Ok(response) => {
-                let offset = response.into_inner().ledger_offset;
-                if offset > 0 {
-                    return Ok(offset);
-                }
-                tracing::warn!(
-                    "GetHighestOffsetByTimestamp (force: {force}) returned non-positive \
-                     offset {offset}; retrying"
-                );
-            }
-            Err(status) => {
-                tracing::warn!("GetHighestOffsetByTimestamp (force: {force}) failed: {status}");
-            }
-        }
-    }
-
-    tracing::warn!(
-        "No offset API usable on this participant; using offset 1 as \
-         begin_offset_exclusive — UNSAFE if this participant hosted the party \
-         before (a stale activation would be found first)"
-    );
-    Ok(1)
-}
-
-/// Ledger API ledger end. Authenticated when a token is supplied; the
-/// tokenless form still works on deployments without ledger-API auth.
-async fn ledger_end_offset(config: &NodeConfig, token: Option<&str>) -> Result<i64> {
-    let mut client = utils::create_state_client(config, token.map(str::to_owned)).await?;
-    let response = client
-        .get_ledger_end(tonic::Request::new(GetLedgerEndRequest {}))
-        .await?
-        .into_inner();
-    Ok(response.offset)
 }

--- a/crates/decman/src/workflow/add_party/steps/mod.rs
+++ b/crates/decman/src/workflow/add_party/steps/mod.rs
@@ -1,14 +1,9 @@
-pub mod acs_sync;
 pub mod clear_onboarding;
 pub mod export_state;
 pub mod generate_keys;
 pub mod proposals;
 
-pub use acs_sync::{collect_party_package_ids, export_party_acs, import_party_acs};
-pub use clear_onboarding::{
-    ClearOutcome, author_clear_proposal, clear_onboarding_flag, sign_clear_proposal,
-    submit_clear_proposal,
-};
+pub use clear_onboarding::{author_clear_proposal, sign_clear_proposal, submit_clear_proposal};
 pub use export_state::export_state;
 pub use generate_keys::generate_keys;
 pub use proposals::{create_proposals, sign_proposals, submit_proposals};

--- a/crates/decman/src/workflow/mod.rs
+++ b/crates/decman/src/workflow/mod.rs
@@ -5,6 +5,7 @@ pub mod dars;
 pub mod external_party;
 pub mod kick;
 pub mod onboarding;
+pub mod party_replication;
 pub mod state;
 pub mod storage;
 pub mod topology;
@@ -849,11 +850,10 @@ pub async fn start_peer(
                     .map(str::to_string)
                     .collect();
 
-                if let Err(e) = add_party::import_party_acs(
+                if let Err(e) = party_replication::import_party_acs(
                     &node_config,
                     &db,
-                    &instance_name,
-                    &add_party_config,
+                    &add_party_config.replication_target(&instance_name),
                     items[1].clone(),
                     &required_package_ids,
                 )
@@ -884,15 +884,14 @@ pub async fn start_peer(
                     continue;
                 }
 
-                match add_party::clear_onboarding_flag(
+                match party_replication::clear_onboarding_flag(
                     &node_config,
                     &db,
-                    &instance_name,
-                    &add_party_config,
+                    &add_party_config.replication_target(&instance_name),
                 )
                 .await
                 {
-                    Ok(add_party::ClearOutcome::Proposed) => {
+                    Ok(party_replication::ClearOutcome::Proposed) => {
                         // Canton requires the ONBOARDING PARTICIPANT to issue
                         // the flag-clear transaction — author it here and ship
                         // it to the coordinator for the threshold-signing
@@ -932,7 +931,7 @@ pub async fn start_peer(
                             }
                         }
                     }
-                    Ok(add_party::ClearOutcome::Cleared) => {
+                    Ok(party_replication::ClearOutcome::Cleared) => {
                         consecutive_step_failures = 0;
                         if let Err(e) = client
                             .send_status(b"ClearOnboardingFlag: Cleared".to_vec())

--- a/crates/decman/src/workflow/party_replication/acs.rs
+++ b/crates/decman/src/workflow/party_replication/acs.rs
@@ -25,10 +25,7 @@ use crate::{
     error::Result,
     noise::MAX_CHUNKED_TOTAL_SIZE,
     utils,
-    workflow::{
-        add_party::AddPartyConfig,
-        storage::{WorkflowStorage, artifact_kinds},
-    },
+    workflow::{party_replication::ReplicationTarget, storage::WorkflowStorage},
 };
 
 /// How long Canton may wait for the party's activation topology transaction
@@ -41,20 +38,19 @@ const EXPORT_ACTIVATION_TIMEOUT_SECS: i64 = 120;
 /// Canton's default 4 MiB gRPC message cap.
 const IMPORT_CHUNK_SIZE: usize = 1024 * 1024;
 
-/// Coordinator side: export the party's ACS for replication onto the new
-/// member, via the Canton 3.4 `ExportPartyAcs` admin endpoint. Canton locates
-/// the party's activation on the new member after `begin_offset_exclusive`
-/// (the offset persisted by ExportState BEFORE the topology was submitted)
-/// and produces a snapshot consistent with that activation — this is what
-/// fixes the old implementation's export-at-current-ledger-end gap.
+/// Source side: export the party's ACS for replication onto the target
+/// participant, via the Canton `ExportPartyAcs` admin endpoint. Canton locates
+/// the party's activation on the target after `begin_offset_exclusive` (the
+/// offset captured BEFORE the topology was submitted) and produces a snapshot
+/// consistent with that activation — this is what fixes the old
+/// implementation's export-at-current-ledger-end gap.
 ///
 /// Returns the raw snapshot bytes; empty when the party has no active
 /// contracts (the import side skips on empty).
 pub async fn export_party_acs(
     config: &NodeConfig,
     storage: &SqlitePool,
-    instance_name: &str,
-    add_party_config: &AddPartyConfig,
+    target: &ReplicationTarget,
 ) -> Result<Vec<u8>> {
     // Logical synchronizer id — see `current_ledger_offset` for why the
     // physical id is rejected by PartyManagementService.
@@ -62,10 +58,13 @@ pub async fn export_party_acs(
         utils::extract_synchronizer_fingerprint(&utils::get_synchronizer_id(config).await?)?;
 
     let offset_bytes = storage
-        .read_artifact(instance_name, artifact_kinds::ADD_PARTY_EXPORT_OFFSET, None)
+        .read_artifact(&target.instance_name, target.artifacts.export_offset, None)
         .await?
         .ok_or_else(|| {
-            anyhow::anyhow!("ADD_PARTY_EXPORT_OFFSET artifact missing — did ExportState run?")
+            anyhow::anyhow!(
+                "{kind} artifact missing — the pre-topology offset was never captured",
+                kind = target.artifacts.export_offset
+            )
         })?;
     let begin_offset_exclusive: i64 = String::from_utf8(offset_bytes)?
         .trim()
@@ -73,16 +72,16 @@ pub async fn export_party_acs(
         .map_err(|e| anyhow::anyhow!("Failed to parse export offset: {e}"))?;
 
     tracing::info!(
-        "Exporting ACS of {party} for new member {member} (begin offset {begin_offset_exclusive})",
-        party = add_party_config.decentralized_party_id,
-        member = add_party_config.new_participant_id
+        "Exporting ACS of {party} for target {member} (begin offset {begin_offset_exclusive})",
+        party = target.party_id,
+        member = target.target_participant_id
     );
 
     let mut client = PartyManagementServiceClient::new(config.admin_channel().await?);
 
     // Bounded retry on INVALID_STATE: the export locates the party's MOST
     // RECENT activation on the target in this participant's published
-    // ledger-API events. When the new member was a member before (kicked,
+    // ledger-API events. When the target hosted the party before (removed,
     // now re-added), an OLD flag-less activation is already published while
     // the re-add's event may still be awaiting publication — Canton then
     // aborts with "must be activated … with the onboarding flag set"
@@ -92,9 +91,9 @@ pub async fn export_party_acs(
     let retry_delay = Duration::from_secs(topology_retry_delay_secs());
     for attempt in 1..=max_attempts {
         let request = tonic::Request::new(ExportPartyAcsRequest {
-            party_id: add_party_config.decentralized_party_id.to_string(),
+            party_id: target.party_id.to_string(),
             synchronizer_id: synchronizer_id.clone(),
-            target_participant_uid: add_party_config.new_participant_id.to_string(),
+            target_participant_uid: target.target_participant_id.to_string(),
             begin_offset_exclusive,
             wait_for_activation_timeout: Some(prost_types::Duration {
                 seconds: EXPORT_ACTIVATION_TIMEOUT_SECS,
@@ -143,7 +142,7 @@ async fn collect_export_stream(
         if snapshot.len() > MAX_CHUNKED_TOTAL_SIZE {
             return Err(tonic::Status::out_of_range(format!(
                 "Exported ACS snapshot exceeds the {MAX_CHUNKED_TOTAL_SIZE}-byte \
-                 chunked-transfer cap — the new member cannot receive it over Noise. \
+                 chunked-transfer cap — the target cannot receive it over Noise. \
                  Raise MAX_CHUNKED_TOTAL_SIZE (with a memory-bound review) to replicate \
                  a party this large."
             )));
@@ -152,7 +151,7 @@ async fn collect_export_stream(
     Ok(snapshot)
 }
 
-/// New-member side: import the ACS snapshot via the Canton `ImportPartyAcs`
+/// Target side: import the ACS snapshot via the Canton `ImportPartyAcs`
 /// admin endpoint. Canton requires the participant to be disconnected from all
 /// synchronizers for the duration of the import (refused otherwise with
 /// `IMPORT_ACS_ERROR: There are still synchronizers connected`) — the party
@@ -177,8 +176,7 @@ async fn collect_export_stream(
 pub async fn import_party_acs(
     config: &NodeConfig,
     storage: &SqlitePool,
-    instance_name: &str,
-    add_party_config: &AddPartyConfig,
+    target: &ReplicationTarget,
     snapshot: Vec<u8>,
     required_package_ids: &[String],
 ) -> Result {
@@ -190,8 +188,8 @@ pub async fn import_party_acs(
     // when the participant is already connected and healthy.
     let disconnect_window_opened = storage
         .read_artifact(
-            instance_name,
-            artifact_kinds::ADD_PARTY_ACS_IMPORT_INFLIGHT,
+            &target.instance_name,
+            target.artifacts.import_inflight,
             None,
         )
         .await?
@@ -230,9 +228,9 @@ pub async fn import_party_acs(
             .collect();
         if !missing.is_empty() {
             anyhow::bail!(
-                "new member is missing {n} package(s) required by the party's contracts — \
-                 vet the corresponding DAR(s) on this participant before onboarding; add-party \
-                 will not import the ACS without them. Missing package ids: {missing:?}",
+                "the target participant is missing {n} package(s) required by the party's \
+                 contracts — vet the corresponding DAR(s) on it before replicating; the ACS \
+                 will not be imported without them. Missing package ids: {missing:?}",
                 n = missing.len()
             );
         }
@@ -242,7 +240,7 @@ pub async fn import_party_acs(
     // pitfall) plus the party being imported.
     let synchronizer_id =
         utils::extract_synchronizer_fingerprint(&utils::get_synchronizer_id(config).await?)?;
-    let party_id = add_party_config.decentralized_party_id.to_string();
+    let party_id = target.party_id.to_string();
 
     let mut connectivity =
         SynchronizerConnectivityServiceClient::new(config.admin_channel().await?);
@@ -284,8 +282,8 @@ pub async fn import_party_acs(
     // and a verified reconnect is detected on the next attempt.
     storage
         .write_artifact(
-            instance_name,
-            artifact_kinds::ADD_PARTY_ACS_IMPORT_INFLIGHT,
+            &target.instance_name,
+            target.artifacts.import_inflight,
             None,
             b"1",
         )
@@ -425,7 +423,7 @@ fn synchronizer_healthy(
 }
 
 /// Coordinator side: the distinct package ids referenced by the party's active
-/// contracts. Shipped to the new member so its ACS-import preflight can verify
+/// contracts. Shipped to the target so its ACS-import preflight can verify
 /// it has every package the imported contracts need before disconnecting.
 pub async fn collect_party_package_ids(
     config: &NodeConfig,

--- a/crates/decman/src/workflow/party_replication/mod.rs
+++ b/crates/decman/src/workflow/party_replication/mod.rs
@@ -1,0 +1,84 @@
+//! Party replication, independent of what kind of party is being replicated.
+//!
+//! Moving a party onto a participant that does not yet hold it is the same
+//! sequence of Canton calls whoever owns the party: capture a ledger offset
+//! before the topology moves, export the ACS scoped to the target, import it on
+//! the target across a synchronizer disconnect, then clear Canton's
+//! `HostingParticipant.Onboarding` marker so the party goes live there.
+//!
+//! None of that depends on a `DecentralizedNamespaceDefinition`. It was written
+//! inside the decentralized-party add-party workflow and took an
+//! [`AddPartyConfig`](crate::workflow::add_party::AddPartyConfig), which tied it
+//! to decparties for no reason other than where it happened to live. This module
+//! is the same code addressed by a [`ReplicationTarget`] instead — a party, a
+//! participant, and the artifact keys one run's durable markers live under.
+//!
+//! What stays outside: deciding the topology and getting it authorized. That is
+//! genuinely party-type specific — a decparty needs owner-threshold signatures
+//! over a DNS, an external party needs its own key — and it lives with each
+//! workflow.
+
+pub mod acs;
+pub mod offset;
+pub mod onboarding_flag;
+
+use crate::canton_id::CantonId;
+
+pub use acs::{collect_party_package_ids, export_party_acs, import_party_acs};
+pub use offset::{capture_offset_once, current_ledger_offset};
+pub use onboarding_flag::{
+    ClearOutcome, clear_onboarding_flag, has_onboarding_marker, wait_for_flag_cleared,
+};
+
+/// The artifact keys one replication run reads and writes.
+///
+/// Passed in rather than fixed so each workflow keeps its own key namespace.
+/// The add-party run's keys are unchanged by the extraction, so no persisted
+/// run is disturbed and a workflow interrupted before it still resumes after.
+#[derive(Clone, Copy, Debug)]
+pub struct ReplicationArtifacts {
+    /// Unscoped. The source's ledger offset, captured before the topology
+    /// change so `ExportPartyAcs` can find the party's activation on the target
+    /// after it.
+    pub export_offset: &'static str,
+    /// Scoped to the target participant. Its own pre-activation offset, which
+    /// `ClearPartyOnboardingFlag` searches forward from.
+    pub pre_activation_offset: &'static str,
+    /// Unscoped, durable, never cleared. Written before the synchronizer
+    /// disconnect so a retry after a crash knows the participant was left
+    /// mid-window and recovers it before touching anything.
+    pub import_inflight: &'static str,
+}
+
+/// One replication: which party moves onto which participant, and where this
+/// run's durable markers live.
+#[derive(Clone, Debug)]
+pub struct ReplicationTarget {
+    /// The party being replicated. Any party — decentralized, external, or
+    /// local; the ACS path does not care who owns it.
+    pub party_id: CantonId,
+    /// The participant gaining the party. Carries Canton's `Onboarding` marker
+    /// until the import lands.
+    pub target_participant_id: CantonId,
+    /// The workflow run these artifacts belong to.
+    pub instance_name: String,
+    /// The artifact keys above.
+    pub artifacts: ReplicationArtifacts,
+}
+
+impl ReplicationTarget {
+    /// Build a target for `party_id` moving onto `target_participant_id`.
+    pub fn new(
+        party_id: CantonId,
+        target_participant_id: CantonId,
+        instance_name: String,
+        artifacts: ReplicationArtifacts,
+    ) -> Self {
+        Self {
+            party_id,
+            target_participant_id,
+            instance_name,
+            artifacts,
+        }
+    }
+}

--- a/crates/decman/src/workflow/party_replication/offset.rs
+++ b/crates/decman/src/workflow/party_replication/offset.rs
@@ -1,0 +1,137 @@
+//! Ledger-offset capture for a replication run.
+//!
+//! Both offsets a replication needs name a point BEFORE the party is activated
+//! on the target, which is why the capture is once-only and why finding the
+//! offset is three tiers deep rather than one call.
+
+use canton_proto_rs::com::{
+    daml::ledger::api::v2::GetLedgerEndRequest,
+    digitalasset::canton::admin::participant::v30::{
+        GetHighestOffsetByTimestampRequest,
+        party_management_service_client::PartyManagementServiceClient,
+    },
+};
+use sqlx::SqlitePool;
+
+use crate::{
+    config::NodeConfig,
+    error::Result,
+    utils::{self, get_synchronizer_id},
+    workflow::storage::WorkflowStorage,
+};
+
+/// Capture this participant's ledger offset into `kind` exactly once.
+///
+/// Both offsets a replication needs — the target's pre-activation offset,
+/// scoped to the participant, and the source's export offset, unscoped — exist
+/// to name a point BEFORE the party is activated. A resumed run that re-enters its step after
+/// the activation must therefore keep the original value: re-capturing would
+/// move the offset past the activation, and `ExportPartyAcs` /
+/// `ClearPartyOnboardingFlag` would then look for it in a window that no longer
+/// contains it.
+///
+/// So the first capture wins and later calls are a no-op.
+pub async fn capture_offset_once(
+    config: &NodeConfig,
+    storage: &SqlitePool,
+    instance_name: &str,
+    kind: &str,
+    scope: Option<&str>,
+    ledger_token: Option<&str>,
+    label: &str,
+) -> Result {
+    if storage
+        .read_artifact(instance_name, kind, scope)
+        .await?
+        .is_some()
+    {
+        return Ok(());
+    }
+    let offset = current_ledger_offset(config, ledger_token).await?;
+    storage
+        .write_artifact(instance_name, kind, scope, offset.to_string().as_bytes())
+        .await?;
+    tracing::info!("Captured {label} ledger offset {offset}");
+    Ok(())
+}
+
+/// Current ledger offset on this participant — the `begin_offset_exclusive`
+/// for the activation finders behind `ExportPartyAcs` and
+/// `ClearPartyOnboardingFlag`.
+///
+/// The offset must postdate any EARLIER activation of the same (party,
+/// participant) pair: the finders take the FIRST activation event published
+/// after the offset, so on a kick-then-re-add path a too-early offset
+/// surfaces the stale flag-less activation and the export aborts with
+/// INVALID_STATE (observed in CI). Tiers:
+///
+/// 1. Ledger API `GetLedgerEnd`, with the party's ledger token when the
+///    auth registry has one: exact and always current.
+/// 2. Admin API `GetHighestOffsetByTimestamp` — strict, then `force: true`.
+///    "Now" routinely trips the clean-watermark check, and even forced
+///    lookups can fail when the latest events have no synchronizer mapping
+///    (both observed in CI).
+/// 3. Offset 1 — the smallest POSITIVE value the consumers accept. Loudly
+///    warned: correct only when the participant was never hosted on the
+///    party before (no stale activation to trip over).
+pub async fn current_ledger_offset(config: &NodeConfig, ledger_token: Option<&str>) -> Result<i64> {
+    match ledger_end_offset(config, ledger_token).await {
+        Ok(offset) if offset > 0 => return Ok(offset),
+        Ok(offset) => {
+            tracing::warn!("Ledger end reported non-positive offset {offset}; trying admin API");
+        }
+        Err(e) => {
+            tracing::warn!("GetLedgerEnd unavailable ({e}); trying admin API");
+        }
+    }
+
+    // PartyManagementService wants the LOGICAL synchronizer id
+    // (`alias::fingerprint`) — the physical id's trailing `::<version>`
+    // fails Canton's fingerprint decoding with a reserved-delimiter error.
+    let synchronizer_id =
+        utils::extract_synchronizer_fingerprint(&get_synchronizer_id(config).await?)?;
+    let mut client = PartyManagementServiceClient::new(config.admin_channel().await?);
+
+    for force in [false, true] {
+        let now = std::time::SystemTime::now();
+        let request = tonic::Request::new(GetHighestOffsetByTimestampRequest {
+            synchronizer_id: synchronizer_id.clone(),
+            timestamp: Some(prost_types::Timestamp::from(now)),
+            force,
+        });
+
+        match client.get_highest_offset_by_timestamp(request).await {
+            Ok(response) => {
+                let offset = response.into_inner().ledger_offset;
+                if offset > 0 {
+                    return Ok(offset);
+                }
+                tracing::warn!(
+                    "GetHighestOffsetByTimestamp (force: {force}) returned non-positive \
+                     offset {offset}; retrying"
+                );
+            }
+            Err(status) => {
+                tracing::warn!("GetHighestOffsetByTimestamp (force: {force}) failed: {status}");
+            }
+        }
+    }
+
+    tracing::warn!(
+        "No offset API usable on this participant; using offset 1 as \
+         begin_offset_exclusive — UNSAFE if this participant hosted the party \
+         before (a stale activation would be found first)"
+    );
+    Ok(1)
+}
+
+/// Ledger API ledger end. Authenticated when a token is supplied; the
+/// tokenless form still works on deployments without ledger-API auth.
+async fn ledger_end_offset(config: &NodeConfig, token: Option<&str>) -> Result<i64> {
+    let mut client = utils::create_state_client(config, token.map(str::to_owned)).await?;
+    let response = client
+        .get_ledger_end(tonic::Request::new(GetLedgerEndRequest {}))
+        .await?
+        .into_inner();
+    Ok(response.offset)
+}

--- a/crates/decman/src/workflow/party_replication/onboarding_flag.rs
+++ b/crates/decman/src/workflow/party_replication/onboarding_flag.rs
@@ -1,0 +1,213 @@
+//! Canton's `HostingParticipant.Onboarding` marker: clearing it, and waiting
+//! for it to go.
+//!
+//! The marker keeps a replicated party suspended on its new host until the ACS
+//! import lands. Clearing it is the last step of any replication and is the same
+//! Canton call for every party type — only *who signs the resulting proposal*
+//! differs, and that stays with each workflow.
+
+use std::time::SystemTime;
+
+use canton_proto_rs::com::digitalasset::canton::{
+    admin::participant::v30::{
+        ClearPartyOnboardingFlagRequest,
+        party_management_service_client::PartyManagementServiceClient,
+    },
+    protocol::v30::PartyToParticipant,
+};
+use sqlx::SqlitePool;
+use tokio::time;
+
+use crate::{
+    canton_id::CantonId,
+    config::NodeConfig,
+    error::Result,
+    utils,
+    workflow::{
+        party_replication::ReplicationTarget, storage::WorkflowStorage, topology::fetch_p2p_mapping,
+    },
+};
+
+const MAX_SAFE_TIME_WAIT_SECS: u64 = 600;
+
+/// Outcome of the target participant's `ClearPartyOnboardingFlag` polling.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ClearOutcome {
+    /// Canton reports the flag is gone — no signing round needed.
+    Cleared,
+    /// The safe time passed and the clearing transaction is proposed. Who must
+    /// sign it next is party-type specific: a decentralized party needs
+    /// threshold owner signatures, which its coordinator's sign round provides.
+    Proposed,
+}
+
+/// Target-side step: drive `ClearPartyOnboardingFlag` until the flag is gone
+/// or Canton has accepted the clearing proposal past its safe time.
+///
+/// Canton refuses to clear before its computed safe time (so no in-flight
+/// transaction from the import window can be lost) — the endpoint returns
+/// `onboarded = false` with `earliest_retry_timestamp` until then. After the
+/// safe time, a call proposes the clearing topology transaction, which still
+/// needs whatever signatures the party's namespace demands — collected by the
+/// calling workflow, not here.
+pub async fn clear_onboarding_flag(
+    config: &NodeConfig,
+    storage: &SqlitePool,
+    target: &ReplicationTarget,
+) -> Result<ClearOutcome> {
+    // Logical synchronizer id — see `current_ledger_offset` for why the
+    // physical id is rejected by PartyManagementService.
+    let synchronizer_id =
+        utils::extract_synchronizer_fingerprint(&utils::get_synchronizer_id(config).await?)?;
+    let self_id = config.participant_id().to_string();
+
+    // No zero fallback: ClearPartyOnboardingFlag rejects non-positive
+    // offsets, and a missing artifact means GenerateNewMemberKeys never
+    // persisted one — a real bug to surface, not paper over.
+    let offset_bytes = storage
+        .read_artifact(
+            &target.instance_name,
+            target.artifacts.pre_activation_offset,
+            Some(&self_id),
+        )
+        .await?
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "{kind} artifact missing for {self_id} — this participant's pre-activation \
+                 offset was never captured",
+                kind = target.artifacts.pre_activation_offset
+            )
+        })?;
+    let begin_offset_exclusive: i64 = String::from_utf8(offset_bytes)?
+        .trim()
+        .parse()
+        .map_err(|e| anyhow::anyhow!("Failed to parse pre-activation offset: {e}"))?;
+
+    let mut client = PartyManagementServiceClient::new(config.admin_channel().await?);
+    let waited_start = time::Instant::now();
+
+    loop {
+        let request = tonic::Request::new(ClearPartyOnboardingFlagRequest {
+            party_id: target.party_id.to_string(),
+            synchronizer_id: synchronizer_id.clone(),
+            begin_offset_exclusive,
+            wait_for_activation_timeout: None,
+        });
+
+        let response = client
+            .clear_party_onboarding_flag(request)
+            .await?
+            .into_inner();
+
+        if response.onboarded {
+            tracing::info!("Onboarding flag already cleared");
+            return Ok(ClearOutcome::Cleared);
+        }
+
+        let now = SystemTime::now();
+        let earliest_retry = response
+            .earliest_retry_timestamp
+            .and_then(|ts| SystemTime::try_from(ts).ok());
+
+        match earliest_retry {
+            Some(safe_time) if safe_time > now => {
+                let wait = safe_time
+                    .duration_since(now)
+                    .unwrap_or(time::Duration::from_secs(1))
+                    // Re-check at least every 10s so a moving safe time
+                    // can't park the loop on one long sleep.
+                    .min(time::Duration::from_secs(10));
+                if waited_start.elapsed().as_secs() > MAX_SAFE_TIME_WAIT_SECS {
+                    anyhow::bail!(
+                        "Onboarding-flag safe time still {wait:?} away after waiting \
+                         {MAX_SAFE_TIME_WAIT_SECS}s — synchronizer appears stuck"
+                    );
+                }
+                tracing::info!(
+                    "Safe time for clearing the onboarding flag not reached; waiting {wait:?}"
+                );
+                time::sleep(wait).await;
+            }
+            // Safe time reached (or Canton sent none): this call was made
+            // past it, so the clearing transaction is proposed. The
+            // coordinator's signing round takes it from here.
+            _ => {
+                tracing::info!(
+                    "Safe time passed; clearing transaction proposed, awaiting owner signatures"
+                );
+                return Ok(ClearOutcome::Proposed);
+            }
+        }
+    }
+}
+
+/// Poll head state until the target participant's onboarding marker is gone.
+pub async fn wait_for_flag_cleared(
+    config: &NodeConfig,
+    synchronizer_id: &str,
+    party_id: &CantonId,
+    new_member: &CantonId,
+) -> Result {
+    let max_attempts = crate::consts::topology_retry_max_attempts();
+    let retry_delay = time::Duration::from_secs(crate::consts::topology_retry_delay_secs());
+    let new_member_str = new_member.to_string();
+
+    for attempt in 1..=max_attempts {
+        let p2p = fetch_p2p_mapping(config, synchronizer_id, party_id).await?;
+        if !has_onboarding_marker(&p2p, &new_member_str) {
+            tracing::info!("Onboarding flag cleared after {attempt} attempt(s)");
+            return Ok(());
+        }
+        if attempt < max_attempts {
+            tracing::debug!(
+                "Onboarding flag still set, attempt {attempt}/{max_attempts}, \
+                 retrying in {retry_delay:?}..."
+            );
+            time::sleep(retry_delay).await;
+        }
+    }
+
+    anyhow::bail!("Onboarding flag was not cleared after {max_attempts} attempts")
+}
+
+/// Whether `participant` carries the Onboarding marker in `p2p`.
+pub fn has_onboarding_marker(p2p: &PartyToParticipant, participant: &str) -> bool {
+    p2p.participants
+        .iter()
+        .any(|p| p.participant_uid == participant && p.onboarding.is_some())
+}
+
+#[cfg(test)]
+mod tests {
+    use canton_proto_rs::com::digitalasset::canton::protocol::v30::party_to_participant::{
+        HostingParticipant, hosting_participant,
+    };
+
+    use super::*;
+
+    fn p2p(participants: Vec<HostingParticipant>) -> PartyToParticipant {
+        PartyToParticipant {
+            party: "acme::1220abcd".to_string(),
+            threshold: 2,
+            participants,
+            party_signing_keys: None,
+        }
+    }
+
+    fn hosting(uid: &str, onboarding: bool) -> HostingParticipant {
+        HostingParticipant {
+            participant_uid: uid.to_string(),
+            permission: 0,
+            onboarding: onboarding.then_some(hosting_participant::Onboarding {}),
+        }
+    }
+
+    #[test]
+    fn detects_onboarding_marker_only_for_the_marked_participant() {
+        let mapping = p2p(vec![hosting("PAR::a", false), hosting("PAR::b", true)]);
+
+        assert!(!has_onboarding_marker(&mapping, "PAR::a"));
+        assert!(has_onboarding_marker(&mapping, "PAR::b"));
+        assert!(!has_onboarding_marker(&mapping, "PAR::missing"));
+    }
+}


### PR DESCRIPTION
Item 1 of the scoping study's §06, and Phase 1 of its §08 (`depends on: —`).

## The problem

Moving a party onto a participant that does not hold it yet is the same sequence of Canton calls whoever owns the party:

1. capture a ledger offset before the topology moves,
2. export the ACS scoped to the target,
3. import it across a synchronizer disconnect,
4. clear the `HostingParticipant.Onboarding` marker.

None of that needs a `DecentralizedNamespaceDefinition`. But all of it took an `AddPartyConfig`, which tied it to decentralized parties for no reason beyond where it happened to live. Any other party type wanting replication had to either fake a decparty config or copy the code.

## The change

New `crates/decman/src/workflow/party_replication/`:

| Module | Holds |
| --- | --- |
| `mod.rs` | `ReplicationTarget` + `ReplicationArtifacts` |
| `acs.rs` | export, import, the disconnect window, package preflight (moved from `add_party/steps/acs_sync.rs`) |
| `offset.rs` | `capture_offset_once`, `current_ledger_offset` (moved out of `add_party/steps/generate_keys.rs`) |
| `onboarding_flag.rs` | `clear_onboarding_flag`, `wait_for_flag_cleared`, `ClearOutcome` (moved out of `add_party/steps/clear_onboarding.rs`) |

A `ReplicationTarget` is a party, a participant, and the artifact keys one run's durable markers live under. The keys are passed in rather than fixed, so the core carries no workflow's key namespace.

## Resume safety

`ADD_PARTY_REPLICATION_ARTIFACTS` maps to the same three constants add-party has always written — `ADD_PARTY_EXPORT_OFFSET`, `ADD_PARTY_PRE_ACTIVATION_OFFSET`, `ADD_PARTY_ACS_IMPORT_INFLIGHT`. Values unchanged, so an add-party run interrupted before this commit still resumes after it. That matters more than usual here: the import-inflight marker is what makes the disconnect window crash-safe, and a renamed key would silently lose it.

## What deliberately stayed behind

Deciding the topology and getting it authorized. That is genuinely party-type specific — a decparty needs owner-threshold signatures over a DNS, an external party signs with its own key — so `export_state`, the proposal builders, and `author/sign/submit_clear_proposal` all stay in `add_party`.

## Behavior

No change. `git` reads `acs_sync.rs → acs.rs` as a rename, so that file's real diff is the `AddPartyConfig → ReplicationTarget` swap and nothing else.

The one difference is error text: the artifact-missing messages used to hardcode `"ADD_PARTY_EXPORT_OFFSET artifact missing — did ExportState run?"` and now name whichever key they looked for. Nothing asserts on those strings.

`cargo clippy --all-targets --all-features -- -D warnings` is clean. Per the usual rule I have not run `cargo test` or the IT locally — the decparty add-party e2e phases in CI are what prove "no behavior change", so that run is the real gate on this PR.
