### PR TITLE
fix(auth): let the startup IdP check see an Auth0-only node

### DIFF
--- a/crates/decman/src/config.rs
+++ b/crates/decman/src/config.rs
@@ -501,6 +501,10 @@ impl Default for CantonConfig {
 }
 
 impl NodeConfig {
+    pub fn has_top_level_idp(&self) -> bool {
+        self.keycloak.is_some() || self.auth0.is_some()
+    }
+
     /// Create a NodeConfig with the given root directory
     pub fn with_root_dir<P: AsRef<Path>>(mut self, root_dir: P) -> Self {
         self.root_dir = root_dir.as_ref().to_path_buf();
@@ -880,6 +884,41 @@ mod tests {
             assert!(defaults.url.is_empty());
             assert!(defaults.realm.is_empty());
         }
+    }
+
+    fn auth0_config() -> Auth0Config {
+        Auth0Config {
+            domain: "tenant.eu.auth0.com".to_string(),
+            client_id: "spa-client-id".to_string(),
+            audience: Some("https://decman-api.example".to_string()),
+        }
+    }
+
+    #[test]
+    fn has_top_level_idp_is_false_when_neither_provider_is_set() {
+        assert!(!NodeConfig::default().has_top_level_idp());
+    }
+
+    #[test]
+    fn has_top_level_idp_accepts_a_keycloak_only_node() {
+        let config = NodeConfig {
+            keycloak: Some(KeycloakConfig::default()),
+            auth0: None,
+            ..NodeConfig::default()
+        };
+
+        assert!(config.has_top_level_idp());
+    }
+
+    #[test]
+    fn has_top_level_idp_accepts_an_auth0_only_node() {
+        let config = NodeConfig {
+            keycloak: None,
+            auth0: Some(auth0_config()),
+            ..NodeConfig::default()
+        };
+
+        assert!(config.has_top_level_idp());
     }
 
     #[test]

--- a/crates/decman/src/server/mod.rs
+++ b/crates/decman/src/server/mod.rs
@@ -941,18 +941,19 @@ pub async fn start_server(
             admin_role.clone().unwrap_or_default(),
         )))
     } else {
-        let no_top_level_config = config.keycloak.is_none();
+        let no_top_level_config = !config.has_top_level_idp();
         let no_party_creds = party_credentials.read().await.is_empty();
         if no_top_level_config && no_party_creds {
             tracing::warn!(
-                "No top-level Keycloak config (--keycloak-url/realm/client-id) and no \
-                 party credentials yet. Inbound auth will reject every request except \
-                 the first-run PUT /party-config bootstrap. Configure the IdP and \
-                 provision a party to make the node usable."
+                "No top-level IdP config (--keycloak-url/realm/client-id or \
+                 DECPM_AUTH0_DOMAIN/CLIENT_ID) and no party credentials yet. Inbound \
+                 auth will reject every request except the first-run PUT /party-config \
+                 bootstrap. Configure the IdP and provision a party to make the node \
+                 usable."
             );
         } else if no_top_level_config {
             tracing::info!(
-                "No top-level Keycloak config; trusting only issuers from \
+                "No top-level IdP config; trusting only issuers from \
                  party_credentials ({} configured).",
                 party_credentials.read().await.len()
             );


### PR DESCRIPTION
## Summary

The startup check tested `config.keycloak` alone, so a node configured with Auth0 and no party credentials yet logged a warning saying inbound auth would reject everything. It doesn't: `config.auth0` is handed to `JwtValidator::new` a few lines below and validates normally.

Adds `NodeConfig::has_top_level_idp()` so both carriers are consulted in one place, and rewords the two messages to say IdP rather than Keycloak.

## Related issues

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build / CI / chore

## Checklist

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` is clean
- [x] `cargo test` passes
- [x] Added/updated tests where appropriate
- [ ] Updated documentation where appropriate
- [x] Commits follow the `<type>(<scope>): <subject>` convention

## Notes for reviewers
