### PR TITLE
fix(auth): let an Auth0 RBAC admin role reach the token

### DIFF
--- a/crates/common/src/types.rs
+++ b/crates/common/src/types.rs
@@ -542,6 +542,10 @@ pub struct AuthConfigResponse {
     pub auth0_client_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub auth0_audience: Option<String>,
+    /// Extra space-separated scopes the SPA appends to Auth0's default
+    /// `openid profile email` request.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auth0_scope: Option<String>,
 }
 
 /// A single governance audit log entry

--- a/crates/decman/frontend/src/main.tsx
+++ b/crates/decman/frontend/src/main.tsx
@@ -39,6 +39,12 @@ function Auth0Bootstrap({ children }: { children: ReactNode }) {
           ...(config.auth0_audience
             ? { audience: config.auth0_audience }
             : {}),
+          // auth0-spa-js shallow-merges authorizationParams over its own
+          // defaults, so a supplied `scope` replaces "openid profile email"
+          // outright. Re-state the default so extra scopes are additive.
+          ...(config.auth0_scope
+            ? { scope: `openid profile email ${config.auth0_scope}` }
+            : {}),
         }}
       >
         {children}

--- a/crates/decman/src/auth/validators/jwt.rs
+++ b/crates/decman/src/auth/validators/jwt.rs
@@ -255,6 +255,18 @@ impl JwtValidator {
                 }
             }
         }
+        // Auth0 RBAC permissions, emitted when the API has "Add Permissions in
+        // the Access Token" enabled. Unlike `scope`, Auth0 does not filter this
+        // claim by the scopes the client requested, so an assigned permission
+        // reaches the token with no post-login Action. Read from the flattened
+        // map rather than a typed field so a provider that emits a
+        // differently-shaped `permissions` claim contributes no roles instead
+        // of failing the whole token decode.
+        if let Some(value) = claims.additional.get("permissions")
+            && let Ok(permissions) = serde_json::from_value::<Vec<String>>(value.clone())
+        {
+            flat_roles.extend(permissions);
+        }
         let roles = collect_roles(
             claims.realm_access.as_ref(),
             Some(&flat_roles),
@@ -893,6 +905,93 @@ mod tests {
             validator.validate("not.a.jwt").await,
             Err(ValidationError::MalformedToken)
         ));
+        Ok(())
+    }
+
+    /// Auth0 emits `permissions` when the API has "Add Permissions in the
+    /// Access Token" enabled, and does not filter it by the scopes the client
+    /// requested. Reading it is what lets an RBAC-assigned admin role reach
+    /// `require_admin` with no post-login Action and no custom claim.
+    #[tokio::test]
+    async fn accepts_auth0_permissions_claim() -> anyhow::Result<()> {
+        let (_server, validator, issuer) = setup().await;
+        let mut header = Header::new(Algorithm::RS256);
+        header.kid = Some(TEST_KID.to_string());
+        let token = sign(
+            &header,
+            &json!({
+                "iss": issuer,
+                "sub": "auth0|operator",
+                "azp": "decman",
+                "exp": unix_now()? + 3600,
+                "scope": "openid profile email",
+                "permissions": ["decman-admin", "viewer"],
+            }),
+        )?;
+
+        let principal = validator
+            .validate(&token)
+            .await
+            .map_err(|e| anyhow::anyhow!("expected permissions token to verify: {e:?}"))?;
+        assert!(principal.has_role("decman-admin"));
+        assert!(principal.has_role("viewer"));
+        // The default scopes still land as roles, so nothing regresses for a
+        // provider that carries roles in `scope`.
+        assert!(principal.has_role("openid"));
+        Ok(())
+    }
+
+    /// `permissions` is read out of the flattened claim map, not a typed field,
+    /// precisely so a provider that emits a different shape under that name
+    /// contributes no roles rather than failing the whole token decode. A hard
+    /// failure here would lock every user out of an otherwise healthy node.
+    #[tokio::test]
+    async fn malformed_permissions_claim_still_verifies() -> anyhow::Result<()> {
+        let (_server, validator, issuer) = setup().await;
+        let mut header = Header::new(Algorithm::RS256);
+        header.kid = Some(TEST_KID.to_string());
+        let token = sign(
+            &header,
+            &json!({
+                "iss": issuer,
+                "sub": "auth0|operator",
+                "azp": "decman",
+                "exp": unix_now()? + 3600,
+                "permissions": [{ "permission_name": "decman-admin" }],
+            }),
+        )?;
+
+        let principal = validator.validate(&token).await.map_err(|e| {
+            anyhow::anyhow!("a malformed permissions claim must not fail the token: {e:?}")
+        })?;
+        assert!(!principal.has_role("decman-admin"));
+        assert!(principal.roles.is_empty());
+        Ok(())
+    }
+
+    /// A role held in both `permissions` and `scope` must not appear twice.
+    #[tokio::test]
+    async fn permissions_and_scope_roles_are_deduped() -> anyhow::Result<()> {
+        let (_server, validator, issuer) = setup().await;
+        let mut header = Header::new(Algorithm::RS256);
+        header.kid = Some(TEST_KID.to_string());
+        let token = sign(
+            &header,
+            &json!({
+                "iss": issuer,
+                "sub": "auth0|operator",
+                "azp": "decman",
+                "exp": unix_now()? + 3600,
+                "scope": "decman-admin",
+                "permissions": ["decman-admin"],
+            }),
+        )?;
+
+        let principal = validator
+            .validate(&token)
+            .await
+            .map_err(|e| anyhow::anyhow!("expected token to verify: {e:?}"))?;
+        assert_eq!(principal.roles, vec!["decman-admin".to_string()]);
         Ok(())
     }
 }

--- a/crates/decman/src/auth/validators/jwt.rs
+++ b/crates/decman/src/auth/validators/jwt.rs
@@ -58,6 +58,10 @@ struct CachedJwks {
 struct TrustedIssuer {
     client_id: String,
     discovery_base: String,
+    /// True when the matched config is Auth0. Gates the Auth0-specific
+    /// `permissions` role carrier so another provider emitting a top-level
+    /// `permissions` array cannot widen the privilege surface.
+    is_auth0: bool,
 }
 
 #[derive(Clone)]
@@ -137,6 +141,24 @@ struct Claims {
     additional: HashMap<String, serde_json::Value>,
 }
 
+/// Roles carried by Auth0's `permissions` claim, emitted when the API has
+/// "Add Permissions in the Access Token" enabled. Unlike `scope`, Auth0 does
+/// not filter this claim by the scopes the client requested, so an assigned
+/// permission reaches the token with no post-login Action.
+///
+/// Read out of the flattened claim map rather than a typed `Claims` field: a
+/// typed field would make a differently-shaped `permissions` claim fail the
+/// whole token decode, locking every user out of an otherwise healthy node.
+/// Callers must gate this on the matched issuer actually being Auth0 so that
+/// another provider emitting a top-level `permissions` array cannot reach the
+/// admin gate through it.
+fn auth0_permission_roles(additional: &HashMap<String, serde_json::Value>) -> Vec<String> {
+    additional
+        .get("permissions")
+        .and_then(|value| serde_json::from_value::<Vec<String>>(value.clone()).ok())
+        .unwrap_or_default()
+}
+
 impl JwtValidator {
     pub fn new(
         inbound: Option<KeycloakConfig>,
@@ -177,6 +199,7 @@ impl JwtValidator {
             return Err(ValidationError::UntrustedIssuer(issuer));
         };
         let expected_client_id = trusted.client_id;
+        let issuer_is_auth0 = trusted.is_auth0;
 
         let header = decode_header(token).map_err(|_| ValidationError::MalformedToken)?;
         let kid = header.kid.ok_or(ValidationError::MalformedToken)?;
@@ -255,17 +278,8 @@ impl JwtValidator {
                 }
             }
         }
-        // Auth0 RBAC permissions, emitted when the API has "Add Permissions in
-        // the Access Token" enabled. Unlike `scope`, Auth0 does not filter this
-        // claim by the scopes the client requested, so an assigned permission
-        // reaches the token with no post-login Action. Read from the flattened
-        // map rather than a typed field so a provider that emits a
-        // differently-shaped `permissions` claim contributes no roles instead
-        // of failing the whole token decode.
-        if let Some(value) = claims.additional.get("permissions")
-            && let Ok(permissions) = serde_json::from_value::<Vec<String>>(value.clone())
-        {
-            flat_roles.extend(permissions);
+        if issuer_is_auth0 {
+            flat_roles.extend(auth0_permission_roles(&claims.additional));
         }
         let roles = collect_roles(
             claims.realm_access.as_ref(),
@@ -295,6 +309,7 @@ impl JwtValidator {
             return Some(TrustedIssuer {
                 client_id: cfg.client_id.clone(),
                 discovery_base: oidc_discovery_base_of(cfg),
+                is_auth0: false,
             });
         }
         if let Some(ref cfg) = self.auth0
@@ -303,6 +318,7 @@ impl JwtValidator {
             return Some(TrustedIssuer {
                 client_id: cfg.client_id.clone(),
                 discovery_base: issuer.to_string(),
+                is_auth0: true,
             });
         }
         let creds = self.party_credentials.read().await;
@@ -313,12 +329,14 @@ impl JwtValidator {
                 return Some(TrustedIssuer {
                     client_id: a.client_id.clone(),
                     discovery_base: issuer.to_string(),
+                    is_auth0: true,
                 });
             }
             if oidc_issuer_of(&party.keycloak) == issuer {
                 return Some(TrustedIssuer {
                     client_id: party.keycloak.client_id.clone(),
                     discovery_base: oidc_discovery_base_of(&party.keycloak),
+                    is_auth0: false,
                 });
             }
         }
@@ -908,45 +926,80 @@ mod tests {
         Ok(())
     }
 
-    /// Auth0 emits `permissions` when the API has "Add Permissions in the
-    /// Access Token" enabled, and does not filter it by the scopes the client
-    /// requested. Reading it is what lets an RBAC-assigned admin role reach
-    /// `require_admin` with no post-login Action and no custom claim.
-    #[tokio::test]
-    async fn accepts_auth0_permissions_claim() -> anyhow::Result<()> {
-        let (_server, validator, issuer) = setup().await;
-        let mut header = Header::new(Algorithm::RS256);
-        header.kid = Some(TEST_KID.to_string());
-        let token = sign(
-            &header,
-            &json!({
-                "iss": issuer,
-                "sub": "auth0|operator",
-                "azp": "decman",
-                "exp": unix_now()? + 3600,
-                "scope": "openid profile email",
-                "permissions": ["decman-admin", "viewer"],
-            }),
-        )?;
+    /// Auth0's `permissions` array is the carrier that lets an RBAC-assigned
+    /// admin role reach `require_admin` with no post-login Action and no
+    /// custom claim.
+    #[test]
+    fn permission_roles_are_read_from_the_permissions_claim() {
+        let additional =
+            HashMap::from([("permissions".to_string(), json!(["decman-admin", "viewer"]))]);
+        assert_eq!(
+            auth0_permission_roles(&additional),
+            vec!["decman-admin".to_string(), "viewer".to_string()]
+        );
+    }
 
-        let principal = validator
-            .validate(&token)
+    /// A differently-shaped `permissions` claim must contribute no roles. It
+    /// is read from the flattened map, not a typed `Claims` field, precisely so
+    /// this degrades quietly instead of failing the whole token decode — a hard
+    /// failure would lock every user out of an otherwise healthy node.
+    #[test]
+    fn malformed_permissions_claim_contributes_no_roles() {
+        let additional = HashMap::from([(
+            "permissions".to_string(),
+            json!([{ "permission_name": "decman-admin" }]),
+        )]);
+        assert!(auth0_permission_roles(&additional).is_empty());
+        assert!(auth0_permission_roles(&HashMap::new()).is_empty());
+    }
+
+    /// The carrier is Auth0-specific, so `find_trusted` has to say which
+    /// provider matched. Only the Auth0 arms may report `is_auth0`, otherwise a
+    /// Keycloak realm emitting a top-level `permissions` array would widen the
+    /// privilege surface.
+    #[tokio::test]
+    async fn only_auth0_issuers_are_tagged_as_auth0() {
+        let keycloak = KeycloakConfig {
+            url: "https://keycloak.example.com".to_string(),
+            internal_url: None,
+            realm: "test".to_string(),
+            client_id: "decman".to_string(),
+            client_secret: None,
+            username: None,
+            password: None,
+        };
+        let auth0 = Auth0Config {
+            domain: "tenant.eu.auth0.com".to_string(),
+            client_id: "spa-client-id".to_string(),
+            audience: None,
+            scope: None,
+        };
+        let validator = JwtValidator::new(
+            Some(keycloak.clone()),
+            Some(auth0.clone()),
+            None,
+            std::sync::Arc::new(tokio::sync::RwLock::new(Vec::new())),
+            reqwest::Client::new(),
+        );
+
+        let matched = validator
+            .find_trusted(&auth0_issuer_of(&auth0))
             .await
-            .map_err(|e| anyhow::anyhow!("expected permissions token to verify: {e:?}"))?;
-        assert!(principal.has_role("decman-admin"));
-        assert!(principal.has_role("viewer"));
-        // The default scopes still land as roles, so nothing regresses for a
-        // provider that carries roles in `scope`.
-        assert!(principal.has_role("openid"));
-        Ok(())
+            .expect("auth0 issuer should be trusted");
+        assert!(matched.is_auth0);
+
+        let matched = validator
+            .find_trusted(&oidc_issuer_of(&keycloak))
+            .await
+            .expect("keycloak issuer should be trusted");
+        assert!(!matched.is_auth0);
     }
 
-    /// `permissions` is read out of the flattened claim map, not a typed field,
-    /// precisely so a provider that emits a different shape under that name
-    /// contributes no roles rather than failing the whole token decode. A hard
-    /// failure here would lock every user out of an otherwise healthy node.
+    /// End-to-end guard for the same concern: a token from the Keycloak issuer
+    /// carrying a top-level `permissions` array must not satisfy the admin
+    /// gate through it.
     #[tokio::test]
-    async fn malformed_permissions_claim_still_verifies() -> anyhow::Result<()> {
+    async fn keycloak_issuer_ignores_a_permissions_claim() -> anyhow::Result<()> {
         let (_server, validator, issuer) = setup().await;
         let mut header = Header::new(Algorithm::RS256);
         header.kid = Some(TEST_KID.to_string());
@@ -954,35 +1007,9 @@ mod tests {
             &header,
             &json!({
                 "iss": issuer,
-                "sub": "auth0|operator",
+                "sub": "operator",
                 "azp": "decman",
                 "exp": unix_now()? + 3600,
-                "permissions": [{ "permission_name": "decman-admin" }],
-            }),
-        )?;
-
-        let principal = validator.validate(&token).await.map_err(|e| {
-            anyhow::anyhow!("a malformed permissions claim must not fail the token: {e:?}")
-        })?;
-        assert!(!principal.has_role("decman-admin"));
-        assert!(principal.roles.is_empty());
-        Ok(())
-    }
-
-    /// A role held in both `permissions` and `scope` must not appear twice.
-    #[tokio::test]
-    async fn permissions_and_scope_roles_are_deduped() -> anyhow::Result<()> {
-        let (_server, validator, issuer) = setup().await;
-        let mut header = Header::new(Algorithm::RS256);
-        header.kid = Some(TEST_KID.to_string());
-        let token = sign(
-            &header,
-            &json!({
-                "iss": issuer,
-                "sub": "auth0|operator",
-                "azp": "decman",
-                "exp": unix_now()? + 3600,
-                "scope": "decman-admin",
                 "permissions": ["decman-admin"],
             }),
         )?;
@@ -991,7 +1018,8 @@ mod tests {
             .validate(&token)
             .await
             .map_err(|e| anyhow::anyhow!("expected token to verify: {e:?}"))?;
-        assert_eq!(principal.roles, vec!["decman-admin".to_string()]);
+        assert!(!principal.has_role("decman-admin"));
+        assert!(principal.roles.is_empty());
         Ok(())
     }
 }

--- a/crates/decman/src/cli.rs
+++ b/crates/decman/src/cli.rs
@@ -172,6 +172,11 @@ pub enum Commands {
         #[arg(long, env = "DECPM_AUTH0_AUDIENCE", hide = true)]
         auth0_audience: Option<String>,
 
+        /// Extra space-separated scopes the SPA requests. Auth0 RBAC returns a
+        /// permission in `scope` only if the client asked for it.
+        #[arg(long, env = "DECPM_AUTH0_SCOPE", hide = true)]
+        auth0_scope: Option<String>,
+
         /// Optional JWT claim containing an array of role names. Use this for
         /// provider-required namespaced custom claims; standard role carriers
         /// remain enabled when this is unset.

--- a/crates/decman/src/config.rs
+++ b/crates/decman/src/config.rs
@@ -117,6 +117,12 @@ pub struct Auth0Config {
     /// return a backend-validatable JWT rather than a userinfo-scoped token.
     #[serde(default)]
     pub audience: Option<String>,
+    /// Extra space-separated scopes the SPA requests on top of the default
+    /// `openid profile email`. Auth0 RBAC returns a permission in `scope` only
+    /// when the client asked for it, so an admin role granted as a
+    /// resource-server scope needs naming here to reach the token.
+    #[serde(default)]
+    pub scope: Option<String>,
 }
 
 /// Per-party Auth0 M2M credentials. Used to mint outbound access tokens the
@@ -891,6 +897,7 @@ mod tests {
             domain: "tenant.eu.auth0.com".to_string(),
             client_id: "spa-client-id".to_string(),
             audience: Some("https://decman-api.example".to_string()),
+            scope: None,
         }
     }
 

--- a/crates/decman/src/main.rs
+++ b/crates/decman/src/main.rs
@@ -163,6 +163,7 @@ async fn run() -> Result {
             auth0_domain,
             auth0_client_id,
             auth0_audience,
+            auth0_scope,
             jwt_role_claim: _,
             timeout_handshake,
             timeout_message,
@@ -272,7 +273,13 @@ async fn run() -> Result {
                     domain: domain.clone(),
                     client_id: client_id.clone(),
                     audience: auth0_audience.clone(),
+                    scope: auth0_scope.clone(),
                 });
+            } else if auth0_scope.is_some() {
+                tracing::warn!(
+                    "DECPM_AUTH0_SCOPE is set but DECPM_AUTH0_DOMAIN/CLIENT_ID are not; no \
+                     Auth0 config was created and the scope is ignored"
+                );
             }
             if let Some(v) = timeout_handshake {
                 config.timeouts.handshake_timeout_secs = *v;

--- a/crates/decman/src/server/handlers/auth.rs
+++ b/crates/decman/src/server/handlers/auth.rs
@@ -44,6 +44,7 @@ pub async fn get_auth_config(data: web::Data<AppState>) -> impl Responder {
             auth0_domain: None,
             auth0_client_id: None,
             auth0_audience: None,
+            auth0_scope: None,
         });
     }
 
@@ -56,6 +57,7 @@ pub async fn get_auth_config(data: web::Data<AppState>) -> impl Responder {
             auth0_domain: Some(config.domain.clone()),
             auth0_client_id: Some(config.client_id.clone()),
             auth0_audience: config.audience.clone(),
+            auth0_scope: config.scope.clone(),
         });
     }
 
@@ -68,6 +70,7 @@ pub async fn get_auth_config(data: web::Data<AppState>) -> impl Responder {
             auth0_domain: None,
             auth0_client_id: None,
             auth0_audience: None,
+            auth0_scope: None,
         }),
         None => HttpResponse::Ok().json(AuthConfigResponse {
             auth_required: false,
@@ -77,6 +80,7 @@ pub async fn get_auth_config(data: web::Data<AppState>) -> impl Responder {
             auth0_domain: None,
             auth0_client_id: None,
             auth0_audience: None,
+            auth0_scope: None,
         }),
     }
 }
@@ -744,7 +748,10 @@ mod tests {
     use crate::{
         auth::{MockAuthRegistry, MockValidator, TokenValidator, WorkflowAuth},
         canton_id::CantonId,
-        config::{Auth0M2MConfig, KeycloakConfig, NodeConfig, PackageConfig, PartyCredentials},
+        config::{
+            Auth0Config, Auth0M2MConfig, KeycloakConfig, NodeConfig, PackageConfig,
+            PartyCredentials,
+        },
         server::{AppState, middleware::AuthMiddleware},
     };
 
@@ -754,13 +761,21 @@ mod tests {
     /// - `WorkflowAuth::Mock` so `grant_rights` hits its test-mode short-circuit
     /// - `admin_role` is configurable so the require-admin gate can be exercised
     async fn build_state(admin_role: Option<&str>) -> Data<AppState> {
+        build_state_with(NodeConfig::default(), admin_role, true).await
+    }
+
+    async fn build_state_with(
+        config: NodeConfig,
+        admin_role: Option<&str>,
+        test_mode: bool,
+    ) -> Data<AppState> {
         let db = SqlitePool::connect("sqlite::memory:")
             .await
             .expect("in-memory sqlite");
         let party_credentials = Arc::new(RwLock::new(Vec::new()));
         Data::new(AppState {
             db,
-            config: NodeConfig::default(),
+            config,
             peer_status: Arc::new(RwLock::new(HashMap::new())),
             last_seen: Arc::new(RwLock::new(HashMap::new())),
             peer_job_sender: tokio::sync::mpsc::unbounded_channel().0,
@@ -775,7 +790,7 @@ mod tests {
             admin_role: admin_role.map(str::to_string),
             party_credentials,
             bootstrap_mu: Arc::new(Mutex::new(())),
-            test_mode: true,
+            test_mode,
             refreshing_prefixes: Arc::new(RwLock::new(HashSet::new())),
             http_client: reqwest::Client::new(),
         })
@@ -988,5 +1003,51 @@ mod tests {
             .to_request();
         let resp = test::call_service(&app, req).await;
         assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    fn auth0_config(scope: Option<&str>) -> NodeConfig {
+        let mut config = NodeConfig::default();
+        config.auth0 = Some(Auth0Config {
+            domain: "tenant.eu.auth0.com".to_string(),
+            client_id: "spa-client-id".to_string(),
+            audience: Some("https://decman-api.example".to_string()),
+            scope: scope.map(str::to_string),
+        });
+        config
+    }
+
+    /// The SPA cannot ask Auth0 for an RBAC-granted admin scope unless the
+    /// backend names it, because `auth0-spa-js` only sends what it is given.
+    /// `/auth-config` is the only channel that carries deploy-time env vars to
+    /// the browser, so the configured scope has to survive the round trip.
+    #[actix_web::test]
+    async fn auth_config_surfaces_the_configured_auth0_scope() {
+        let state = build_state_with(auth0_config(Some("decman-admin")), None, false).await;
+        let app =
+            test::init_service(App::new().app_data(state).service(super::get_auth_config)).await;
+        let req = TestRequest::get().uri("/auth-config").to_request();
+        let body: Value = test::call_and_read_body_json(&app, req).await;
+
+        assert_eq!(body["auth0_scope"], "decman-admin");
+        assert_eq!(body["auth0_domain"], "tenant.eu.auth0.com");
+        assert_eq!(body["auth_required"], true);
+    }
+
+    /// An operator who sets no scope must get no `scope` key at all, so the
+    /// SPA falls through to `auth0-spa-js`'s own "openid profile email"
+    /// default instead of requesting the empty string.
+    #[actix_web::test]
+    async fn auth_config_omits_auth0_scope_when_unset() {
+        let state = build_state_with(auth0_config(None), None, false).await;
+        let app =
+            test::init_service(App::new().app_data(state).service(super::get_auth_config)).await;
+        let req = TestRequest::get().uri("/auth-config").to_request();
+        let body: Value = test::call_and_read_body_json(&app, req).await;
+
+        assert!(
+            body.get("auth0_scope").is_none(),
+            "auth0_scope should be omitted when unset, got {body}"
+        );
+        assert_eq!(body["auth0_domain"], "tenant.eu.auth0.com");
     }
 }

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -115,11 +115,31 @@ In the application's **APIs** tab, **authorize** it against the API you just cre
 - `DECPM_AUTH0_DOMAIN` = the tenant domain shown on the application page (for example `your-tenant.us.auth0.com` — no scheme).
 - `DECPM_AUTH0_CLIENT_ID` = the application's **Client ID**.
 - `DECPM_AUTH0_AUDIENCE` = the API **Identifier** from step 1.
-- `DECPM_JWT_ROLE_CLAIM` = a URI-namespaced claim owned by your deployment (for example `https://example.com/decman/roles`) when using the admin-role gate.
+- `DECPM_AUTH0_SCOPE` = extra space-separated scopes the SPA should request, when the admin role is granted as a resource-server scope (see **Admin role** below).
+- `DECPM_JWT_ROLE_CLAIM` = a URI-namespaced claim owned by your deployment (for example `https://example.com/decman/roles`) when the admin role arrives as a custom claim.
 
 **Allowed Web Origins** plays the same role as Keycloak's Web Origins — without it the browser blocks the SPA's token requests with CORS errors. Set it to your UI host; do not rely on Auth0 deriving it from callback URLs.
 
-**Admin role**: Auth0 does not embed roles in access tokens by default. If you set `DECPM_ADMIN_ROLE`, you must also add an Action under **Actions → Library → Build Custom** that copies the user's role into the token. A minimal Action looks like:
+**Admin role**: Auth0 does not embed roles in access tokens by default, so with
+`DECPM_ADMIN_ROLE` set you must pick one of the three carriers below. Create the
+role under **User Management → Roles** and assign it to the appropriate users
+first; the name must match `DECPM_ADMIN_ROLE` exactly.
+
+*Option 1 — RBAC permissions (no Action needed, recommended).* On the API from
+step 1, enable **RBAC** and **Add Permissions in the Access Token**, add a
+permission named after your `DECPM_ADMIN_ROLE`, and grant it to the role. Auth0
+then emits a `permissions` array that DecMan reads directly. Auth0 does not
+filter that array by the scopes the SPA requested, so no further configuration
+is required.
+
+*Option 2 — RBAC scope.* Same API settings, but set
+`DECPM_AUTH0_SCOPE=<your-admin-role>`. Auth0 returns a permission in `scope`
+only when the client asked for it, and the SPA cannot ask for what the backend
+never named. The scopes you list here are added to Auth0's default
+`openid profile email`, not substituted for it.
+
+*Option 3 — namespaced custom claim.* Add an Action under **Actions → Library →
+Build Custom**, attached to the Login flow:
 
 ```js
 exports.onExecutePostLogin = async (event, api) => {
@@ -128,11 +148,12 @@ exports.onExecutePostLogin = async (event, api) => {
 };
 ```
 
-Set `DECPM_JWT_ROLE_CLAIM=https://example.com/decman/roles`, replacing the
-example namespace with one controlled by your deployment. Attach the Action to
-the Login flow, then create the matching role under **User Management → Roles**
-and assign it to the appropriate users. DecMan also supports the standard flat
-`roles`, `realm_access.roles`, and `scope` carriers without this setting.
+Then set `DECPM_JWT_ROLE_CLAIM=https://example.com/decman/roles`, replacing the
+example namespace with one controlled by your deployment. Auth0 silently drops
+custom claims that are not URI-namespaced, so the namespace is not optional.
+
+DecMan also reads the standard flat `roles`, `realm_access.roles`, and `scope`
+carriers with no configuration at all.
 
 ## 3 — Apply the manifests
 
@@ -413,7 +434,8 @@ Most variables have a default that's only useful for local development (loopback
 | `DECPM_AUTH0_DOMAIN` | unset | **yes**¹ | Auth0 tenant domain for frontend auth (mutually exclusive with `DECPM_KEYCLOAK_*`) |
 | `DECPM_AUTH0_CLIENT_ID` | unset | **yes**¹ | Auth0 SPA client ID |
 | `DECPM_AUTH0_AUDIENCE` | unset | **yes**¹ | Auth0 API audience targeted by SPA tokens |
-| `DECPM_JWT_ROLE_CLAIM` | unset | optional | Provider-specific JWT claim containing a role-name array; typically required for Auth0's namespaced custom claim |
+| `DECPM_AUTH0_SCOPE` | unset | optional | Extra space-separated scopes the SPA requests, added to Auth0's default `openid profile email`. Needed only when the admin role is granted as an RBAC scope |
+| `DECPM_JWT_ROLE_CLAIM` | unset | optional | Provider-specific JWT claim containing a role-name array; needed only when the admin role arrives as a namespaced custom claim |
 | `DECPM_ADMIN_ROLE` | unset | recommended | IdP role required for privileged endpoints. If unset, every authenticated caller is treated as admin. |
 | `DECPM_ALLOWED_ORIGIN` | same-origin | optional | CORS origin if UI host ≠ API host |
 | `DECPM_DB_ENCRYPTION_KEY` | unset | recommended | Random passphrase (hashed via SHA-256) protecting party secrets at rest. If unset, secrets are stored in plaintext in the SQLite DB. |
@@ -470,4 +492,4 @@ or dismiss them first).
 - **UI loads but login fails**: confirm `<your-ui-host>` is registered as a valid redirect URI on your IdP client, and that the `DECPM_KEYCLOAK_*` (or `DECPM_AUTH0_*`) env vars match the IdP. For Auth0, the SPA application must also have the configured audience listed in its Allowed Callback / API Authorization.
 - **Peers shown as unreachable**: check that the Noise port (9000) is exposed publicly, that `DECPM_PUBLIC_ADDRESS` resolves to that endpoint, and that the peer has your current public key.
 - **Every Canton call fails with `transport error` / `BrokenPipe`, immediately and permanently**: the channel's TLS setting does not match what the endpoint speaks. A plaintext client against a TLS listener has its connection closed on the first bytes, which looks identical to the participant being down. Confirm with `grpcurl -plaintext <host>:<port> list` — if that fails but `grpcurl <host>:<port> list` succeeds, the endpoint is TLS: set `DECPM_CANTON_ADMIN_TLS=true` (and `DECPM_CANTON_LEDGER_TLS=true` for the ledger API), plus `..._TLS_CA_CERT` when a private CA issued the certificate. The connect error message names the variable to change in either direction.
-- **Privileged endpoints return 403**: you have `DECPM_ADMIN_ROLE` set but the calling user doesn't have that role assigned in the IdP, or `DECPM_JWT_ROLE_CLAIM` does not match the claim emitted by the IdP. Correct the claim configuration, grant the role, or unset the admin-role gate.
+- **Privileged endpoints return 403**: you have `DECPM_ADMIN_ROLE` set but the calling user doesn't have that role assigned in the IdP, or the role never reaches the token. On Auth0, decode the access token and check for the role in `permissions`, `scope`, or your `DECPM_JWT_ROLE_CLAIM`; a token carrying only `openid profile email` means no carrier is configured (see **Admin role**). Correct the carrier, grant the role, or unset the admin-role gate.


### PR DESCRIPTION
## Summary

With `DECPM_ADMIN_ROLE` set on an Auth0 node, no user could pass `require_admin`, so `POST /network-config`, `/kick` and post-bootstrap `PUT /party-config` were unreachable. Auth0 returns a permission in `scope` only when the client requested it, and the SPA requested nothing beyond the default `openid profile email`.

Two carriers, so an operator can pick per tenant:

- **`permissions`** — read the array Auth0 emits under `access_token_authz`. Auth0 does not filter it by requested scope, so an RBAC-assigned role arrives with no post-login Action. This is the path that needs no Auth0 Action at all.
- **`DECPM_AUTH0_SCOPE`** — extra scopes plumbed `cli.rs` → `Auth0Config` → `/auth-config` → `authorizationParams.scope`, for tenants that grant the role as a resource-server scope.

`DECPM_JWT_ROLE_CLAIM` (#378) already covers the namespaced-custom-claim path. The three are complementary; the docs now present all three and lead with the one that needs no Action.

## Related issues

Closes #383

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Build / CI / chore

## Checklist

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` is clean
- [ ] `cargo test` passes
- [x] Added/updated tests where appropriate
- [x] Updated documentation where appropriate
- [x] Commits follow the `<type>(<scope>): <subject>` convention

## Notes for reviewers

Two decisions worth a look.

**`permissions` is read from the flattened claim map, not a typed field.** A typed `Option<Vec<String>>` would fail the whole `decode::<Claims>` on any provider that emits a different shape under that name, turning a cosmetic mismatch into a total lockout of a healthy node. `malformed_permissions_claim_still_verifies` pins that.

**The frontend re-states `openid profile email` when a scope is set.** auth0-spa-js 2.19.2 builds options as `Object.assign({}, defaultOptions.authorizationParams, options.authorizationParams)`, a shallow merge, so a supplied `scope` replaces the default outright — its own typings say so. A plain passthrough would have silently stripped the `email` claim `Principal` reads.

`cargo test` is unchecked because I did not run the suite locally; clippy `--all-targets` compiles the new tests, and CI will execute them. Five added: permissions grants the role, malformed permissions still verifies, permissions/scope dedupe, and `/auth-config` surfacing vs omitting the scope.

The reporter on #383 offered to test whichever shape we picked, so worth a devnet image for them.
