### PR TITLE
Count the pass that cannot read its enablement set

### DIFF
--- a/crates/decman/src/auth/mod.rs
+++ b/crates/decman/src/auth/mod.rs
@@ -76,6 +76,26 @@ pub struct TokenManager {
     http: reqwest::Client,
 }
 
+/// How long a token call may take before it fails.
+///
+/// `reqwest::Client::new()` applies no timeout, so an IdP that accepts the
+/// connection and never answers blocks the caller forever. The reward
+/// automation calls this from the task that also carries its heartbeat, so one
+/// hung token call stops the beat and stalls every decparty on the node. 15s
+/// matches the decman-cli client (`crates/decman-cli/src/api.rs`).
+const TOKEN_REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// An HTTP client for token calls, with [`TOKEN_REQUEST_TIMEOUT`] applied.
+///
+/// `build()` fails only if the TLS backend cannot initialise, which a
+/// timeout-only builder on a working platform does not do.
+fn token_http_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(TOKEN_REQUEST_TIMEOUT)
+        .build()
+        .expect("a timeout-only client builder cannot fail")
+}
+
 impl TokenManager {
     /// Create a TokenManager from a Keycloak config and perform initial auth.
     ///
@@ -88,7 +108,7 @@ impl TokenManager {
         member_party_id: CantonId,
     ) -> Result<Self> {
         let source = TokenSource::Keycloak(config);
-        let http = reqwest::Client::new();
+        let http = token_http_client();
         let state = Self::authenticate(&source, &http).await?;
         Ok(Self {
             source,
@@ -110,7 +130,7 @@ impl TokenManager {
         member_party_id: CantonId,
     ) -> Result<Self> {
         let source = TokenSource::Auth0(config);
-        let http = reqwest::Client::new();
+        let http = token_http_client();
         let state = Self::authenticate(&source, &http).await?;
         Ok(Self {
             source,

--- a/crates/decman/src/server/reward_automation.rs
+++ b/crates/decman/src/server/reward_automation.rs
@@ -618,6 +618,16 @@ static AUTH_UNREGISTERED: LazyLock<IntCounterVec> = LazyLock::new(|| {
     .expect("metric name is a unique literal")
 });
 
+// Carries no decparty label: one enablement read serves every decparty this
+// node holds credentials for, and a pass that fails reads none of them.
+static ENABLEMENT_UNREADABLE: LazyLock<IntCounter> = LazyLock::new(|| {
+    prometheus::register_int_counter!(
+        "decman_reward_enablement_unreadable_total",
+        "Passes that could not read the delegated decparties, so no auth fault was attributable to any of them."
+    )
+    .expect("metric name is a unique literal")
+});
+
 static OLDEST_EXPIRES_IN: LazyLock<GaugeVec> = LazyLock::new(|| {
     prometheus::register_gauge_vec!(
         "decman_reward_oldest_unassigned_expires_in_seconds",
@@ -638,6 +648,7 @@ pub(crate) fn register_metrics() {
     LazyLock::force(&EXPIRY_READS);
     LazyLock::force(&CREDENTIALS_UNAVAILABLE);
     LazyLock::force(&AUTH_UNREGISTERED);
+    LazyLock::force(&ENABLEMENT_UNREADABLE);
     LazyLock::force(&OLDEST_EXPIRES_IN);
 }
 
@@ -1160,8 +1171,25 @@ fn counts_as_auth_fault(
     ) && enabled.is_some_and(|set| set.contains(decparty))
 }
 
+/// Whether a pass that could not read the enablement set is a fault (pure).
+///
+/// [`counts_as_auth_fault`] attributes an auth fault only to a decparty in the
+/// set, so a pass holding no set attributes nothing. A node whose every
+/// credential fails therefore counts no auth fault at all, and it keeps beating
+/// because the loop still ticks. Both reward rules stay silent while nothing
+/// assigns. This counter is that pass's only signal.
+///
+/// A node serving no decparty has nothing to read, so `None` there is not a
+/// fault — counting it would alert on every idle node.
+fn counts_as_unreadable_enablement(read: Option<&HashSet<CantonId>>, served: usize) -> bool {
+    read.is_none() && served > 0
+}
+
 /// The decparties this node is a named assigner for, or `None` when no token
 /// could be obtained to ask with.
+///
+/// A `None` moves `decman_reward_enablement_unreadable_total` at the call site,
+/// so the blind pass reports itself — see [`counts_as_unreadable_enablement`].
 ///
 /// Tries each served decparty in turn: the read needs any one working token, not
 /// that decparty's own. A node whose every credential fails cannot ask, and
@@ -1254,7 +1282,16 @@ pub(crate) async fn run_reward_automation_loop(data: actix_web::web::Data<AppSta
 
         prune_unserved(&mut oldest, &parties);
 
-        if let Some(set) = read_enablement(&data, &parties).await {
+        let read = read_enablement(&data, &parties).await;
+        if counts_as_unreadable_enablement(read.as_ref(), parties.len()) {
+            ENABLEMENT_UNREADABLE.inc();
+            tracing::warn!(
+                served = parties.len(),
+                "no credential could read the delegated decparties; until one can, this node \
+                 attributes no auth fault to any of them"
+            );
+        }
+        if let Some(set) = read {
             enabled = Some(set);
         }
 
@@ -2324,6 +2361,18 @@ mod tests {
     }
 
     #[test]
+    fn the_unreadable_enablement_counter_is_exposed_before_any_pass_runs() {
+        // Unlabelled, so `gather()` exports it from boot. Its alert reads an
+        // increase, which needs a zero to increase from.
+        register_metrics();
+        assert!(
+            gathered_family_names()
+                .iter()
+                .any(|n| n == "decman_reward_enablement_unreadable_total")
+        );
+    }
+
+    #[test]
     fn a_labelled_family_appears_once_a_decparty_is_known() {
         // `gather()` omits a labelled family with no series, so these appear only
         // once a decparty is known.
@@ -2554,7 +2603,8 @@ mod tests {
     fn an_unread_enablement_set_counts_nothing() {
         // `None` is "we could not ask", not "nothing is enabled". Counting on it
         // would alert for every decparty on a node whose first read has not
-        // landed yet.
+        // landed yet. The pass itself is counted instead — see
+        // `counts_as_unreadable_enablement`.
         let decparty = CantonId::parse(GOV).expect("GOV is a valid canton id");
         assert!(!counts_as_auth_fault(
             &SweepOutcome::AuthUnregistered,
@@ -2566,6 +2616,28 @@ mod tests {
             &decparty,
             None
         ));
+    }
+
+    #[test]
+    fn an_unreadable_enablement_set_counts_on_a_serving_node() {
+        // The blind pass attributes no auth fault to any decparty, so without
+        // this counter a node whose every credential fails reports nothing at
+        // all while it keeps beating.
+        assert!(counts_as_unreadable_enablement(None, 17));
+    }
+
+    #[test]
+    fn an_unreadable_enablement_set_counts_nothing_on_an_idle_node() {
+        // A node serving no decparty has nothing to read, and a stall alert
+        // already states that such a node still beats.
+        assert!(!counts_as_unreadable_enablement(None, 0));
+    }
+
+    #[test]
+    fn a_read_enablement_set_counts_nothing() {
+        let decparty = CantonId::parse(GOV).expect("GOV is a valid canton id");
+        let enabled: HashSet<CantonId> = std::iter::once(decparty).collect();
+        assert!(!counts_as_unreadable_enablement(Some(&enabled), 17));
     }
 
     #[test]


### PR DESCRIPTION
## What this PR does

**Old behavior**

Both reward auth counters are gated on the enablement set — the decparties whose `CouponReassignmentDelegation` names this node as an assigner. `read_enablement` returns `None` when no credential on the node yields a working token, and `counts_as_auth_fault` counts nothing against a `None`.

So a node whose **every** credential fails counted no auth fault for any decparty. The reward loop still ticked, so the heartbeat kept beating and the stall rule stayed quiet too. Both reward rules reported nothing while the node assigned nothing.

A restart is when this bites. `enabled` is kept across passes only once a read has succeeded, so a long-running process that read the set once survives a later credentials outage and still counts. A fresh start with every credential broken never populates the set at all.

Separately, `TokenManager` built its HTTP client with `reqwest::Client::new()`, which applies **no timeout**, in the same task that carries the heartbeat. An IdP that accepts the connection and never answers blocked the sweep and stopped the beat indefinitely.

**New behavior**

`decman_reward_enablement_unreadable_total` counts each pass that could not read the set, so the blind pass reports itself. Token calls fail after 15 seconds instead of hanging.

**Verification**

- `cargo test -p decman --lib`: **536 passed, 0 failed**, on current `main` (`55b35b6`).
- `cargo clippy -p decman --all-targets`: no warnings. `cargo fmt --check`: clean.
- Four new tests: the counter fires on a serving node, stays silent on an idle node, stays silent when the read succeeded, and the family is exported before any pass runs.
- The existing `an_unread_enablement_set_counts_nothing` still passes unchanged. It is still correct — the per-decparty counters must not fire on an unread set — and its comment now names where that silence is disposed of.

**Not covered:**
- No integration test drives a node whose every credential fails. The unit tests cover the pure predicate, not the loop that calls it.
- The metric is deployed nowhere yet, so this is unproven against a real fault.
- The companion alert rule is not in this PR and has no home yet (see Caveats), so nothing alerts on the new counter even once it ships.

**The change that enables it**

- New unlabelled `IntCounter` `decman_reward_enablement_unreadable_total`, added to `register_metrics` so it exports zero from boot — its alert reads an increase, which needs a zero to increase from.
- New pure predicate `counts_as_unreadable_enablement(read, served)`. The `served > 0` guard is load-bearing: a node serving no decparty has nothing to read, and counting there would alert on every idle node. The stall rule's own description already states that such a node still beats.
- The loop increments the counter and logs one WARN when the read fails.
- `token_http_client()` replaces both `reqwest::Client::new()` calls with a 15s timeout, matching the decman-cli client.

**Caveats**

- **Draft, because the companion alert rule has nowhere to land yet.** The six `decman-reward-*` rules are absent from dlc-infra `main`; they exist only on unmerged branches and in ClickHouse. The rule for this counter is written and committed locally but cannot be PR'd until that family lands.
- The counter is unlabelled, so it says the node is blind but not which decparty lost value. That is deliberate: one enablement read serves every decparty, and a failed read reads none of them.
- On devnet today the counter would read 0. Three of node 1's seventeen credentials work, so the read succeeds.
- 15 seconds is a judgement call, taken from the decman-cli precedent rather than measured against Keycloak.

## Details

**This is not the gap that was accepted**

`cip104-auth-broken-rule-enablement-gate` records a knowingly accepted gap: *enabled but unconfigured*, where a delegation names this node for a decparty with no `party_credentials` row. That was decided on 2026-08-26 as not-implement and not-file. **This PR addresses a different one** — `enabled: None`, where the set cannot be read at all. Please do not conflate them when reviewing.

**Where the numbers come from**

Measured on devnet node 1 on 2026-08-27. The node initialised **17** decparties and **14 failed** Keycloak M2M auth: tokenmgmt, demo-1, UAT, custody1, Ui-walkthrough, UAT2, UAT0, UAT5, UAT8, just-2, UAT02, TokenMgmt, custody2, bernhard-test. Only `cbtc-network`, `test-kms-2` and `mpch-test` worked. `read_enablement` returns on the first success, so the node's entire ability to report a fault rested on those three.

**Why `.expect` rather than a new error variant**

`token_http_client()` uses `.expect("a timeout-only client builder cannot fail")`. `AuthError` is public, so adding a variant breaks exhaustive matches downstream. `build()` fails only if the TLS backend cannot initialise, which a timeout-only builder on a working platform does not do. The crate already uses this idiom for `register_int_counter!`.

**Notes**

Cherry-picked onto `main` rather than rebased. The original commit sat on `feature/decman-reward-metrics`, which `main` took as the squash merge #325, so a rebase tried to replay the metrics commits and conflicted.

---
Companion: [dlc-infra #196](https://github.com/DLC-link/dlc-infra/pull/196) (rolls devnet to `78af4d7` with the scrape wiring) · related: [dlc-infra #197](https://github.com/DLC-link/dlc-infra/issues/197) (alert notification cadence)
