### PR TITLE
feat(audit): add all-activity and local-log modes to the trail

### DIFF
--- a/crates/decman/frontend/src/components/GovernanceAuditTrail.tsx
+++ b/crates/decman/frontend/src/components/GovernanceAuditTrail.tsx
@@ -12,6 +12,8 @@ import {
   Chip,
   IconButton,
   Collapse,
+  ToggleButton,
+  ToggleButtonGroup,
   Tooltip,
   useTheme,
 } from "@mui/material";
@@ -25,7 +27,12 @@ import { authenticatedFetch } from "../api";
 import { zebraRow } from "../styles";
 import { CopyableText } from "./CopyableText";
 import { CursorPagination } from "./Pagination";
-import type { ChainAuditEntry, ChainAuditResponse } from "../types";
+import type {
+  AuditLogEntry,
+  AuditLogResponse,
+  ChainAuditEntry,
+  ChainAuditResponse,
+} from "../types";
 
 interface GovernanceAuditTrailProps {
   partyId: string;
@@ -45,8 +52,91 @@ interface GovernanceAuditTrailProps {
 
 export const CHAIN_LIMIT = PAGE_SIZE;
 
+/**
+ * Which trail the panel shows.
+ *
+ * `governance` and `all` are the two scopes of the on-ledger read; `local` is
+ * this node's own record of what it attempted, which exists even for actions
+ * that never reached the ledger.
+ */
+export type AuditMode = "governance" | "all" | "local";
+
+const MODE_LABELS: { value: AuditMode; label: string; hint: string }[] = [
+  {
+    value: "governance",
+    label: "Governance",
+    hint: "Proposals, confirmations and executions from the governance packages",
+  },
+  {
+    value: "all",
+    label: "All activity",
+    hint: "Every ledger event this party witnesses, its own application templates included",
+  },
+  {
+    value: "local",
+    label: "Local log",
+    hint: "What this node attempted for the party, successes and failures alike",
+  },
+];
+
+const EMPTY_MESSAGE: Record<AuditMode, string> = {
+  governance:
+    "No on-chain governance events found for this party. A party with no governance contracts deployed never produces any — switch to All activity to see its ledger events.",
+  all: "No on-chain events found for this party.",
+  local: "This node has not run a governance action for this party.",
+};
+
+/** One table row, whichever trail it came from. */
+interface AuditRow {
+  key: string;
+  timestamp: number;
+  eventType: string;
+  action: string;
+  /** Fourth column: governance type on-ledger, outcome in the local log. */
+  meta: string;
+  metaTone?: "success" | "error";
+  /** Fifth column: the contract on-ledger, the acting member locally. */
+  ident: string;
+  details: unknown;
+  /** Label/value pairs shown when the row is expanded. */
+  facts: [string, string][];
+  error?: string;
+}
+
 const formatTimestamp = (epochSeconds: number): string =>
   new Date(epochSeconds * 1000).toLocaleString();
+
+const chainRow = (entry: ChainAuditEntry): AuditRow => ({
+  key: `${entry.offset}-${entry.contract_id}-${entry.event_type}`,
+  timestamp: entry.timestamp,
+  eventType: entry.event_type,
+  action: entry.action_summary,
+  meta: entry.governance_type,
+  ident: entry.contract_id,
+  details: entry.details,
+  facts: [
+    ["Template", entry.template_id],
+    ["Package", entry.package_id],
+    ["Acting parties", entry.acting_parties.join(", ")],
+    ["Update ID", entry.update_id],
+    ...(entry.choice
+      ? ([["Choice", entry.choice]] as [string, string][])
+      : []),
+  ],
+});
+
+const localRow = (entry: AuditLogEntry): AuditRow => ({
+  key: `local-${entry.id}`,
+  timestamp: entry.timestamp,
+  eventType: entry.event_type,
+  action: entry.action_summary,
+  meta: entry.status,
+  metaTone: entry.status === "success" ? "success" : "error",
+  ident: entry.member_party_id,
+  details: entry.details,
+  facts: [["Governance type", entry.governance_type]],
+  error: entry.error_message,
+});
 
 const eventTypeColor = (
   eventType: string,
@@ -130,24 +220,32 @@ export const GovernanceAuditTrail = ({
   onLoadingChange,
 }: GovernanceAuditTrailProps) => {
   const jsonTreeTheme = useJsonTreeTheme();
+  const [mode, setMode] = useState<AuditMode>("governance");
+  const modeRef = useRef<AuditMode>("governance");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [entries, setEntries] = useState<ChainAuditEntry[]>([]);
-  const sortedEntries = useMemo(
-    () => [...entries].sort((a, b) => b.timestamp - a.timestamp),
-    [entries],
+  const [rows, setRows] = useState<AuditRow[]>([]);
+  const sortedRows = useMemo(
+    () => [...rows].sort((a, b) => b.timestamp - a.timestamp),
+    [rows],
   );
   const [expandedRow, setExpandedRow] = useState<string | null>(null);
-  const [cacheLoaded, setCacheLoaded] = useState(false);
-  // One cursor per visited page. Index 0 is `undefined` (newest page); each
-  // Next pushes the `next_before_offset` the server handed back, so Previous
-  // is a pop rather than a re-query from the top.
+  const [loadedMode, setLoadedMode] = useState<AuditMode | null>(null);
+  // One cursor per visited page of an on-ledger trail. Index 0 is `undefined`
+  // (newest page); each Next pushes the `next_before_offset` the server handed
+  // back, so Previous is a pop rather than a re-query from the top. The local
+  // log pages by offset instead and ignores this.
   const [cursors, setCursors] = useState<(number | undefined)[]>([undefined]);
   const [page, setPage] = useState(0);
   const [nextCursor, setNextCursor] = useState<number | null>(null);
+  // The local log has no cursor: a full page is what says another one follows.
+  const [localHasNext, setLocalHasNext] = useState(false);
   const [canScrollUp, setCanScrollUp] = useState(false);
   const [canScrollDown, setCanScrollDown] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
+
+  const isLocal = mode === "local";
+  const hasNext = isLocal ? localHasNext : nextCursor !== null;
 
   const updateScrollShadows = useCallback(() => {
     const el = scrollRef.current;
@@ -169,15 +267,21 @@ export const GovernanceAuditTrail = ({
         observer.disconnect();
       };
     }
-  }, [entries, updateScrollShadows]);
+  }, [rows, updateScrollShadows]);
 
   const fetchAudit = useCallback(
-    async (refresh: boolean, before?: number): Promise<boolean> => {
+    async (
+      target: AuditMode,
+      refresh: boolean,
+      // On-ledger cursor, or the page index for the local log.
+      before?: number,
+      pageIndex = 0,
+    ): Promise<boolean> => {
       setLoading(true);
       setError(null);
       // A refresh pulls in events newer than anything we've paged past, which
       // invalidates every cursor below — start the stack over at the top.
-      if (refresh && before === undefined) {
+      if (refresh && before === undefined && pageIndex === 0) {
         setCursors([undefined]);
         setPage(0);
       }
@@ -186,6 +290,24 @@ export const GovernanceAuditTrail = ({
           party_id: partyId,
           limit: String(CHAIN_LIMIT),
         });
+
+        if (target === "local") {
+          params.set("offset", String(pageIndex * CHAIN_LIMIT));
+          const res = await authenticatedFetch(
+            `${API_BASE}/governance/audit?${params}`,
+          );
+          if (res.ok) {
+            const response: AuditLogResponse = await res.json();
+            setRows(response.entries.map(localRow));
+            setLocalHasNext(response.entries.length >= CHAIN_LIMIT);
+            return true;
+          }
+          const errData = await res.json().catch(() => ({}));
+          setError(errData.error || "Failed to fetch audit trail");
+          return false;
+        }
+
+        params.set("scope", target);
         if (refresh) params.set("refresh", "true");
         if (before !== undefined) params.set("before_offset", String(before));
 
@@ -194,7 +316,7 @@ export const GovernanceAuditTrail = ({
         );
         if (res.ok) {
           const response: ChainAuditResponse = await res.json();
-          setEntries(response.entries);
+          setRows(response.entries.map(chainRow));
           setNextCursor(response.next_before_offset ?? null);
           return true;
         }
@@ -213,19 +335,30 @@ export const GovernanceAuditTrail = ({
     [partyId],
   );
 
-  // Load from cache on mount
+  // Load on mount, and again whenever the operator switches trail. Switching
+  // starts from the newest page: the cursors of the trail left behind mean
+  // nothing in the one being entered.
   useEffect(() => {
-    if (!cacheLoaded) {
-      setCacheLoaded(true);
-      fetchAudit(false);
+    if (loadedMode !== mode) {
+      setLoadedMode(mode);
+      setRows([]);
+      setExpandedRow(null);
+      setCursors([undefined]);
+      setPage(0);
+      setNextCursor(null);
+      setLocalHasNext(false);
+      fetchAudit(mode, false);
     }
-  }, [cacheLoaded, fetchAudit]);
+  }, [loadedMode, mode, fetchAudit]);
 
   // Re-fetch (force fresh) whenever the parent bumps the nonce after a
-  // sibling governance mutation.
+  // sibling governance mutation. The trail is read from `modeRef` — which the
+  // toggle writes alongside `setMode` — so the nonce stays the only trigger;
+  // depending on `mode` here would re-run this on a switch, on top of the
+  // fetch the switch effect above already does.
   useEffect(() => {
     if (refreshNonce === undefined || refreshNonce === 0) return;
-    fetchAudit(true);
+    fetchAudit(modeRef.current, true);
   }, [refreshNonce, fetchAudit]);
 
   // A new page is read from its top, same as the client-paged views — see
@@ -238,34 +371,77 @@ export const GovernanceAuditTrail = ({
   // leave the indicator and the cursor stack describing a page whose rows
   // never arrived, and the next Prev would then walk from the wrong cursor.
   const goToNextPage = useCallback(async () => {
+    if (isLocal) {
+      if (!localHasNext) return;
+      if (await fetchAudit(mode, false, undefined, page + 1)) {
+        setPage(page + 1);
+        scrollToFirstRow();
+      }
+      return;
+    }
     if (nextCursor === null) return;
     const cursor = nextCursor;
-    if (await fetchAudit(false, cursor)) {
+    if (await fetchAudit(mode, false, cursor)) {
       setCursors((prev) => [...prev.slice(0, page + 1), cursor]);
       setPage(page + 1);
       scrollToFirstRow();
     }
-  }, [nextCursor, page, fetchAudit, scrollToFirstRow]);
+  }, [
+    isLocal,
+    localHasNext,
+    mode,
+    nextCursor,
+    page,
+    fetchAudit,
+    scrollToFirstRow,
+  ]);
 
   const goToPrevPage = useCallback(async () => {
     if (page === 0) return;
-    if (await fetchAudit(false, cursors[page - 1])) {
+    const landed = isLocal
+      ? await fetchAudit(mode, false, undefined, page - 1)
+      : await fetchAudit(mode, false, cursors[page - 1]);
+    if (landed) {
       setPage(page - 1);
       scrollToFirstRow();
     }
-  }, [page, cursors, fetchAudit, scrollToFirstRow]);
+  }, [isLocal, mode, page, cursors, fetchAudit, scrollToFirstRow]);
 
   useEffect(() => {
-    onCountChange?.(entries.length, nextCursor !== null);
-  }, [entries.length, nextCursor, onCountChange]);
+    onCountChange?.(rows.length, hasNext);
+  }, [rows.length, hasNext, onCountChange]);
 
   useEffect(() => {
     onLoadingChange?.(loading);
   }, [loading, onLoadingChange]);
 
+  const modeToggle = (
+    <ToggleButtonGroup
+      size="small"
+      exclusive
+      value={mode}
+      onChange={(_e, next: AuditMode | null) => {
+        if (next) {
+          modeRef.current = next;
+          setMode(next);
+        }
+      }}
+      sx={{ mb: 1.5 }}
+    >
+      {MODE_LABELS.map(({ value, label, hint }) => (
+        <Tooltip key={value} title={hint}>
+          <ToggleButton value={value} sx={{ textTransform: "none", px: 1.5 }}>
+            {label}
+          </ToggleButton>
+        </Tooltip>
+      ))}
+    </ToggleButtonGroup>
+  );
+
   if (error) {
     return (
       <Box sx={{ mt: 2, mb: 2 }}>
+        {modeToggle}
         <Alert
           severity="error"
           sx={{ mb: 2 }}
@@ -275,7 +451,7 @@ export const GovernanceAuditTrail = ({
         </Alert>
         <Button
           startIcon={<RefreshIcon />}
-          onClick={() => fetchAudit(true)}
+          onClick={() => fetchAudit(mode, true)}
           size="small"
           variant="outlined"
         >
@@ -287,9 +463,10 @@ export const GovernanceAuditTrail = ({
 
   return (
     <Box>
-      {entries.length === 0 ? (
+      {modeToggle}
+      {rows.length === 0 ? (
         <Typography variant="body2" color="text.secondary" sx={{ py: 2 }}>
-          No on-chain governance events found for this party.
+          {EMPTY_MESSAGE[mode]}
         </Typography>
       ) : (
         <Box sx={{ position: "relative" }}>
@@ -327,25 +504,26 @@ export const GovernanceAuditTrail = ({
                 <TableCell sx={{ py: 1, whiteSpace: "nowrap" }}>Time</TableCell>
                 <TableCell sx={{ py: 1, whiteSpace: "nowrap" }}>Event</TableCell>
                 <TableCell sx={{ py: 1, whiteSpace: "nowrap" }}>Action</TableCell>
-                <TableCell sx={{ py: 1, whiteSpace: "nowrap" }}>Type</TableCell>
                 <TableCell sx={{ py: 1, whiteSpace: "nowrap" }}>
-                  Contract
+                  {isLocal ? "Status" : "Type"}
+                </TableCell>
+                <TableCell sx={{ py: 1, whiteSpace: "nowrap" }}>
+                  {isLocal ? "Member party" : "Contract"}
                 </TableCell>
               </TableRow>
             </TableHead>
             <TableBody>
-              {sortedEntries.map((entry, idx) => {
-                const rowKey = `${entry.offset}-${entry.contract_id}`;
-                const isExpanded = expandedRow === rowKey;
+              {sortedRows.map((row, idx) => {
+                const isExpanded = expandedRow === row.key;
                 return (
-                  <Fragment key={rowKey}>
+                  <Fragment key={row.key}>
                     <TableRow sx={zebraRow(idx)}>
                       <TableCell sx={{ py: 0.5 }}>
                         <Tooltip title={isExpanded ? "Hide details" : "Show details"}>
                           <IconButton
                             size="small"
                             onClick={() =>
-                              setExpandedRow(isExpanded ? null : rowKey)
+                              setExpandedRow(isExpanded ? null : row.key)
                             }
                           >
                             {isExpanded ? (
@@ -359,19 +537,19 @@ export const GovernanceAuditTrail = ({
                       <TableCell
                         sx={{ py: 1, fontSize: "0.8rem", whiteSpace: "nowrap" }}
                       >
-                        {entry.timestamp > 0
-                          ? formatTimestamp(entry.timestamp)
+                        {row.timestamp > 0
+                          ? formatTimestamp(row.timestamp)
                           : "—"}
                       </TableCell>
                       <TableCell sx={{ py: 1, whiteSpace: "nowrap" }}>
                         <Chip
-                          label={entry.event_type}
+                          label={row.eventType}
                           size="small"
-                          color={eventTypeColor(entry.event_type)}
+                          color={eventTypeColor(row.eventType)}
                         />
                       </TableCell>
                       <TableCell sx={{ py: 1, maxWidth: 320 }}>
-                        <Tooltip title={entry.action_summary}>
+                        <Tooltip title={row.action}>
                           <Typography
                             variant="body2"
                             sx={{
@@ -382,18 +560,27 @@ export const GovernanceAuditTrail = ({
                               textOverflow: "ellipsis",
                             }}
                           >
-                            {entry.action_summary}
+                            {row.action}
                           </Typography>
                         </Tooltip>
                       </TableCell>
                       <TableCell
                         sx={{ py: 1, fontSize: "0.8rem", whiteSpace: "nowrap" }}
                       >
-                        {entry.governance_type}
+                        {row.metaTone ? (
+                          <Chip
+                            label={row.meta}
+                            size="small"
+                            color={row.metaTone}
+                            variant="outlined"
+                          />
+                        ) : (
+                          row.meta
+                        )}
                       </TableCell>
                       <TableCell sx={{ py: 1, whiteSpace: "nowrap" }}>
                         <CopyableText
-                          text={entry.contract_id}
+                          text={row.ident}
                           truncate={{ start: 8, end: 8 }}
                           variant="caption"
                         />
@@ -406,44 +593,26 @@ export const GovernanceAuditTrail = ({
                       >
                         <Collapse in={isExpanded} timeout="auto" unmountOnExit>
                           <Box sx={{ p: 2, overflow: "hidden" }}>
-                            <Typography
-                              variant="caption"
-                              color="text.secondary"
-                              component="div"
-                            >
-                              Template: {entry.template_id}
-                            </Typography>
-                            <Typography
-                              variant="caption"
-                              color="text.secondary"
-                              component="div"
-                            >
-                              Package: {entry.package_id}
-                            </Typography>
-                            <Typography
-                              variant="caption"
-                              color="text.secondary"
-                              component="div"
-                            >
-                              Acting parties: {entry.acting_parties.join(", ")}
-                            </Typography>
-                            <Typography
-                              variant="caption"
-                              color="text.secondary"
-                              component="div"
-                            >
-                              Update ID: {entry.update_id}
-                            </Typography>
-                            {entry.choice && (
+                            {row.facts.map(([label, value]) => (
                               <Typography
+                                key={label}
                                 variant="caption"
                                 color="text.secondary"
                                 component="div"
                               >
-                                Choice: {entry.choice}
+                                {label}: {value}
+                              </Typography>
+                            ))}
+                            {row.error && (
+                              <Typography
+                                variant="caption"
+                                color="error"
+                                component="div"
+                              >
+                                Error: {row.error}
                               </Typography>
                             )}
-                            {entry.details != null && Object.keys(entry.details).length > 0 && <Box
+                            {row.details != null && Object.keys(row.details).length > 0 && <Box
                               sx={{
                                 mt: 1,
                                 p: 1.5,
@@ -457,10 +626,10 @@ export const GovernanceAuditTrail = ({
                               }}
                             >
                               <Box sx={{ position: "absolute", top: 4, right: 4, zIndex: 1 }}>
-                                <CopyButton data={entry.details} label="Copy JSON" />
+                                <CopyButton data={row.details} label="Copy JSON" />
                               </Box>
                               <JSONTree
-                                data={entry.details}
+                                data={row.details}
                                 theme={jsonTreeTheme}
                                 invertTheme={false}
                                 hideRoot
@@ -507,7 +676,7 @@ export const GovernanceAuditTrail = ({
       )}
       <CursorPagination
         page={page}
-        hasNext={nextCursor !== null}
+        hasNext={hasNext}
         disabled={loading}
         onPrev={goToPrevPage}
         onNext={goToNextPage}

--- a/crates/decman/frontend/src/components/GovernanceAuditTrail.tsx
+++ b/crates/decman/frontend/src/components/GovernanceAuditTrail.tsx
@@ -298,6 +298,15 @@ export const GovernanceAuditTrail = ({
           );
           if (res.ok) {
             const response: AuditLogResponse = await res.json();
+            // The local log pages by offset and reports no total, so a page
+            // that comes back exactly full cannot say whether another follows.
+            // An empty page past the first is that answer arriving late: it is
+            // the end of the log, so stay on the page we are on rather than
+            // replacing the table with the empty state.
+            if (response.entries.length === 0 && pageIndex > 0) {
+              setLocalHasNext(false);
+              return false;
+            }
             setRows(response.entries.map(localRow));
             setLocalHasNext(response.entries.length >= CHAIN_LIMIT);
             return true;

--- a/crates/decman/src/server/chain_audit.rs
+++ b/crates/decman/src/server/chain_audit.rs
@@ -567,17 +567,23 @@ where
 
     let mut entries: Vec<ChainAuditEntry> = Vec::new();
     let mut page_token = None;
-    // Whether Canton still had pages left when we stopped. Distinguishes
+    // Whether Canton still had updates left when we stopped. Distinguishes
     // "stopped because the page was full" from "stopped because the range ran
-    // out", which is what decides if an older page exists.
-    let mut pages_remain = false;
+    // out", which is what decides if an older page exists. Every exit from the
+    // walk below sets it, so it starts unassigned rather than at a default the
+    // compiler can see is never read.
+    let pages_remain;
 
     loop {
-        let page = fetch_page(page_token)
+        let TransactionPage {
+            transactions,
+            next_page_token,
+            truncated,
+        } = fetch_page(page_token)
             .await
             .context("Failed to read ledger updates")?;
 
-        for tx in page.transactions {
+        for tx in transactions {
             entries.extend(
                 transaction_entries(tx, template_index, scope)
                     .into_iter()
@@ -585,14 +591,20 @@ where
             );
         }
 
+        // A truncated page counts the same as a continuation token: the
+        // pre-3.5.1 fallback has none to give, and reading its short page as
+        // "the range is done" would hide every older entry behind it.
         if entries.len() >= limit {
-            pages_remain = page.next_page_token.is_some();
+            pages_remain = next_page_token.is_some() || truncated;
             break;
         }
 
-        match page.next_page_token {
+        match next_page_token {
             Some(next) => page_token = Some(next),
-            None => break,
+            None => {
+                pages_remain = truncated;
+                break;
+            }
         }
     }
 
@@ -1127,6 +1139,7 @@ mod tests {
         TransactionPage {
             transactions: vec![tx_at(offsets)],
             next_page_token: more.then(|| b"next".to_vec()),
+            ..Default::default()
         }
     }
 
@@ -1244,6 +1257,7 @@ mod tests {
             TransactionPage {
                 transactions: vec![noise],
                 next_page_token: Some(b"next".to_vec()),
+                ..Default::default()
             },
             scripted_page(&[30], false),
         ];
@@ -1275,6 +1289,23 @@ mod tests {
         assert_eq!(plan(AuditScope::All, 0).page_size(), 1);
     }
 
+    /// The pre-3.5.1 fallback has no continuation token, so a page it cut to
+    /// its bound is the only signal that older updates exist. Reading it as an
+    /// exhausted range would strand every entry behind it.
+    #[tokio::test]
+    async fn walk_reports_more_when_the_page_was_truncated() {
+        let pages = vec![TransactionPage {
+            transactions: vec![tx_at(&[30, 20])],
+            next_page_token: None,
+            truncated: true,
+        }];
+
+        let page = walk(pages, 5).await;
+
+        assert_eq!(offsets_of(&page.entries), vec![30, 20]);
+        assert!(page.has_more);
+    }
+
     /// One transaction exercising a choice the governance classifier has no
     /// name for — an application party's own template.
     fn app_exercise_at(offset: i64) -> Transaction {
@@ -1303,7 +1334,7 @@ mod tests {
     async fn governance_scope_drops_application_events() {
         let pages = vec![TransactionPage {
             transactions: vec![app_exercise_at(40)],
-            next_page_token: None,
+            ..Default::default()
         }];
 
         let page = walk_scoped(pages, AuditScope::Governance, 5).await;
@@ -1317,7 +1348,7 @@ mod tests {
     async fn all_scope_keeps_application_events() {
         let pages = vec![TransactionPage {
             transactions: vec![app_exercise_at(40)],
-            next_page_token: None,
+            ..Default::default()
         }];
 
         let page = walk_scoped(pages, AuditScope::All, 5).await;

--- a/crates/decman/src/server/chain_audit.rs
+++ b/crates/decman/src/server/chain_audit.rs
@@ -16,9 +16,9 @@ use crate::{
 
 use super::{
     event_filters::{interface_filter, party_event_format, template_filter, wildcard_filter},
-    ledger_paging::{TransactionPage, fetch_transactions_page},
+    ledger_paging::{FETCH_CHUNK, TransactionPage, fetch_transactions_page},
     package_inventory::{fetch_package_names, matching_names, package_name_prefix},
-    types::ChainAuditEntry,
+    types::{AuditScope, ChainAuditEntry},
 };
 
 struct ChainTemplate {
@@ -278,13 +278,19 @@ fn optional_value_to_json(v: &Option<Value>) -> JsonValue {
     }
 }
 
-/// Query Canton's ledger for on-chain governance events for a party.
+/// Query Canton's ledger for on-chain events for a party.
 ///
 /// Streams `GetUpdates` from the pruned offset to the current ledger end,
-/// filtered to governance templates Canton-side when possible (falling back
-/// to a wildcard query otherwise). Returns only governance actions —
-/// proposals, confirmations, executions and their outcomes — sorted
-/// newest-first.
+/// sorted newest-first.
+///
+/// Under [`AuditScope::Governance`] the read is filtered to governance
+/// templates Canton-side when possible (falling back to a wildcard query
+/// otherwise) and narrowed to governance actions — proposals, confirmations,
+/// executions and their outcomes.
+///
+/// Under [`AuditScope::All`] neither filter applies: the party's whole
+/// witnessed history comes back, so an app party that never deploys
+/// governance contracts still has a trail.
 ///
 /// # Errors
 ///
@@ -294,6 +300,7 @@ pub async fn get_chain_audit(
     party_id: &CantonId,
     token: Option<String>,
     packages: &PackageConfig,
+    scope: AuditScope,
     limit: usize,
     before_offset: Option<i64>,
 ) -> Result<AuditPage> {
@@ -331,13 +338,20 @@ pub async fn get_chain_audit(
     if end_offset <= begin_offset {
         return Ok(AuditPage::default());
     }
-    let range = OffsetRange {
-        begin_exclusive: begin_offset,
-        end_inclusive: end_offset,
+    let plan = ReadPlan {
+        range: OffsetRange {
+            begin_exclusive: begin_offset,
+            end_inclusive: end_offset,
+        },
+        scope,
+        limit,
     };
 
     let filters = chain_filters(packages);
-    if filters.templates.is_empty() && filters.interfaces.is_empty() {
+    if scope == AuditScope::Governance
+        && filters.templates.is_empty()
+        && filters.interfaces.is_empty()
+    {
         tracing::warn!("No governance templates configured; returning empty chain audit");
         return Ok(AuditPage::default());
     }
@@ -366,25 +380,32 @@ pub async fn get_chain_audit(
     // inventory. Fall back to the wildcard (every event for the party,
     // classified client-side) if the inventory is unavailable or the
     // filtered query is rejected.
-    let canton_filters = match fetch_package_names(config).await {
-        Ok(names) => {
-            let cumulative = build_canton_filters(&filters, &names);
-            if cumulative.is_empty() {
+    let canton_filters = match scope {
+        // `all` narrows nothing, so the package inventory is not worth a round
+        // trip: the wildcard read is what it wants either way.
+        AuditScope::All => None,
+        AuditScope::Governance => match fetch_package_names(config).await {
+            Ok(names) => {
+                let cumulative = build_canton_filters(&filters, &names);
+                if cumulative.is_empty() {
+                    tracing::warn!(
+                        "No governance packages found on participant; falling back to wildcard"
+                    );
+                    None
+                } else {
+                    Some(cumulative)
+                }
+            }
+            Err(e) => {
                 tracing::warn!(
-                    "No governance packages found on participant; falling back to wildcard"
+                    "Failed to list participant packages: {e:#}; falling back to wildcard"
                 );
                 None
-            } else {
-                Some(cumulative)
             }
-        }
-        Err(e) => {
-            tracing::warn!("Failed to list participant packages: {e:#}; falling back to wildcard");
-            None
-        }
+        },
     };
 
-    // `collect_entries` already keeps governance entries only, sorted newest
+    // `collect_entries` already applies the scope's narrowing, sorted newest
     // first and trimmed to whole offset groups around `limit`.
     let page = match canton_filters {
         Some(cumulative) => {
@@ -392,10 +413,9 @@ pub async fn get_chain_audit(
                 config,
                 token.clone(),
                 party_id,
-                range,
+                plan,
                 cumulative,
                 &template_index,
-                limit,
             )
             .await;
             match filtered {
@@ -408,10 +428,9 @@ pub async fn get_chain_audit(
                         config,
                         token,
                         party_id,
-                        range,
+                        plan,
                         wildcard_filters(),
                         &template_index,
-                        limit,
                     )
                     .await?
                 }
@@ -422,10 +441,9 @@ pub async fn get_chain_audit(
                 config,
                 token,
                 party_id,
-                range,
+                plan,
                 wildcard_filters(),
                 &template_index,
-                limit,
             )
             .await?
         }
@@ -445,6 +463,31 @@ pub async fn get_chain_audit(
 struct OffsetRange {
     begin_exclusive: i64,
     end_inclusive: i64,
+}
+
+/// What one chain-audit read asks for, aside from which filters it carries.
+#[derive(Clone, Copy)]
+struct ReadPlan {
+    range: OffsetRange,
+    scope: AuditScope,
+    /// Entries to collect before the walk may stop.
+    limit: usize,
+}
+
+impl ReadPlan {
+    /// How many transactions to pull from Canton per round trip.
+    ///
+    /// The governance scope discards nearly everything it reads, so it wants
+    /// the full chunk — a small page there would turn one long range scan into
+    /// hundreds of round trips. `all` discards nothing, so a page the size of
+    /// what the caller asked for is enough, and asking for a thousand
+    /// transaction payloads to render twenty-five rows is not.
+    fn page_size(self) -> i32 {
+        match self.scope {
+            AuditScope::Governance => FETCH_CHUNK,
+            AuditScope::All => i32::try_from(self.limit).unwrap_or(FETCH_CHUNK).max(1),
+        }
+    }
 }
 
 /// One page of the audit trail, newest-first.
@@ -471,10 +514,9 @@ async fn collect_entries(
     config: &NodeConfig,
     token: Option<String>,
     party_id: &str,
-    range: OffsetRange,
+    plan: ReadPlan,
     cumulative: Vec<CumulativeFilter>,
     template_index: &HashMap<(String, String), &'static str>,
-    limit: usize,
 ) -> Result<AuditPage> {
     let update_format = UpdateFormat {
         include_transactions: Some(TransactionFormat {
@@ -490,14 +532,16 @@ async fn collect_entries(
             fetch_transactions_page(
                 config,
                 token.clone(),
-                range.begin_exclusive,
-                range.end_inclusive,
+                plan.range.begin_exclusive,
+                plan.range.end_inclusive,
                 update_format.clone(),
+                plan.page_size(),
                 page_token,
             )
         },
         template_index,
-        limit,
+        plan.scope,
+        plan.limit,
     )
     .await
 }
@@ -510,6 +554,7 @@ async fn collect_entries(
 async fn collect_from_pages<F, Fut>(
     mut fetch_page: F,
     template_index: &HashMap<(String, String), &'static str>,
+    scope: AuditScope,
     limit: usize,
 ) -> Result<AuditPage>
 where
@@ -534,9 +579,9 @@ where
 
         for tx in page.transactions {
             entries.extend(
-                transaction_entries(tx, template_index)
+                transaction_entries(tx, template_index, scope)
                     .into_iter()
-                    .filter(is_governance_entry),
+                    .filter(|entry| scope == AuditScope::All || is_governance_entry(entry)),
             );
         }
 
@@ -591,9 +636,15 @@ fn trim_to_offset_groups(entries: &mut Vec<ChainAuditEntry>, limit: usize) -> bo
 }
 
 /// Convert one transaction's Created/Exercised events into audit entries.
+///
+/// Under [`AuditScope::All`] an event the governance index does not recognise
+/// keeps its plain ledger kind — `create` or `exercise` — rather than being
+/// forced through the governance naming heuristics, which would label an
+/// unrelated application create a `propose`.
 fn transaction_entries(
     tx: Transaction,
     template_index: &HashMap<(String, String), &'static str>,
+    scope: AuditScope,
 ) -> Vec<ChainAuditEntry> {
     let mut entries: Vec<ChainAuditEntry> = Vec::new();
     let tx_ts = tx.effective_at.as_ref().map(|t| t.seconds).unwrap_or(0);
@@ -634,7 +685,12 @@ fn transaction_entries(
                 let is_child_of_exercise = exercise_ranges
                     .iter()
                     .any(|(start, end)| c.node_id > *start && c.node_id <= *end);
-                let (event_type, action_summary) = classify_created(tid, is_child_of_exercise);
+                let (event_type, action_summary) = match scope {
+                    AuditScope::All if gov_type == "unknown" => {
+                        ("create".to_string(), tid.entity_name.clone())
+                    }
+                    _ => classify_created(tid, is_child_of_exercise),
+                };
 
                 entries.push(ChainAuditEntry {
                     offset: c.offset,
@@ -666,7 +722,10 @@ fn transaction_entries(
                     })
                     .unwrap_or("unknown");
 
-                let event_type = classify_choice(&x.choice);
+                let event_type = match scope {
+                    AuditScope::All if gov_type == "unknown" => "exercise".to_string(),
+                    _ => classify_choice(&x.choice),
+                };
                 let choice = x.choice.clone();
                 entries.push(ChainAuditEntry {
                     offset: x.offset,
@@ -740,7 +799,8 @@ mod tests {
     use std::collections::VecDeque;
 
     use canton_proto_rs::com::daml::ledger::api::v2::{
-        CreatedEvent, Enum, Event as EventEnvelope, Optional, RecordField, TextMap, Variant,
+        CreatedEvent, Enum, Event as EventEnvelope, ExercisedEvent, Optional, RecordField, TextMap,
+        Variant,
     };
 
     use super::*;
@@ -1073,6 +1133,15 @@ mod tests {
     /// Run the walk over `pages`. Asking for a page beyond the script is an
     /// error, so a test that over-reads fails rather than quietly passing.
     async fn walk(pages: Vec<TransactionPage>, limit: usize) -> AuditPage {
+        walk_scoped(pages, AuditScope::Governance, limit).await
+    }
+
+    /// [`walk`] with the scope under test.
+    async fn walk_scoped(
+        pages: Vec<TransactionPage>,
+        scope: AuditScope,
+        limit: usize,
+    ) -> AuditPage {
         let mut remaining = VecDeque::from(pages);
         let template_index = HashMap::new();
 
@@ -1082,6 +1151,7 @@ mod tests {
                 async move { page.context("asked for a page beyond the script") }
             },
             &template_index,
+            scope,
             limit,
         )
         .await
@@ -1182,5 +1252,91 @@ mod tests {
 
         assert_eq!(offsets_of(&page.entries), vec![30]);
         assert!(!page.has_more);
+    }
+
+    /// The page size follows the scope: the filtered read wants the big chunk
+    /// so a long range costs few round trips, the unfiltered one only what the
+    /// caller asked for.
+    #[test]
+    fn page_size_follows_the_scope() {
+        let plan = |scope, limit| ReadPlan {
+            range: OffsetRange {
+                begin_exclusive: 0,
+                end_inclusive: 100,
+            },
+            scope,
+            limit,
+        };
+
+        assert_eq!(plan(AuditScope::Governance, 25).page_size(), FETCH_CHUNK);
+        assert_eq!(plan(AuditScope::All, 25).page_size(), 25);
+        // A zero-row page never reaches Canton, but the size stays valid — a
+        // `max_page_size` of 0 is rejected outright.
+        assert_eq!(plan(AuditScope::All, 0).page_size(), 1);
+    }
+
+    /// One transaction exercising a choice the governance classifier has no
+    /// name for — an application party's own template.
+    fn app_exercise_at(offset: i64) -> Transaction {
+        Transaction {
+            events: vec![EventEnvelope {
+                event: Some(Event::Exercised(ExercisedEvent {
+                    offset,
+                    contract_id: format!("c-{offset}"),
+                    choice: "PriceFeed_Push".to_string(),
+                    template_id: Some(Identifier {
+                        package_id: "#alpend-oracle-chainlink".to_string(),
+                        module_name: "Alpend.Oracle".to_string(),
+                        entity_name: "PriceFeed".to_string(),
+                    }),
+                    ..Default::default()
+                })),
+            }],
+            ..Default::default()
+        }
+    }
+
+    /// The governance scope has no name for an application choice, so it drops
+    /// it — which is why a party whose whole history is application traffic
+    /// reads as empty.
+    #[tokio::test]
+    async fn governance_scope_drops_application_events() {
+        let pages = vec![TransactionPage {
+            transactions: vec![app_exercise_at(40)],
+            next_page_token: None,
+        }];
+
+        let page = walk_scoped(pages, AuditScope::Governance, 5).await;
+
+        assert!(page.entries.is_empty());
+    }
+
+    /// The same read under `all` keeps it, labelled by its plain ledger kind
+    /// rather than squeezed into a governance event name.
+    #[tokio::test]
+    async fn all_scope_keeps_application_events() {
+        let pages = vec![TransactionPage {
+            transactions: vec![app_exercise_at(40)],
+            next_page_token: None,
+        }];
+
+        let page = walk_scoped(pages, AuditScope::All, 5).await;
+
+        assert_eq!(offsets_of(&page.entries), vec![40]);
+        assert_eq!(page.entries[0].event_type, "exercise");
+        assert_eq!(page.entries[0].choice.as_deref(), Some("PriceFeed_Push"));
+        assert_eq!(page.entries[0].template_id, "Alpend.Oracle:PriceFeed");
+    }
+
+    /// A create the governance index does not recognise is a `create` under
+    /// `all`, not the `propose` the governance heuristics would call it.
+    #[tokio::test]
+    async fn all_scope_does_not_call_an_unknown_create_a_proposal() {
+        let governance =
+            walk_scoped(vec![scripted_page(&[30], false)], AuditScope::Governance, 5).await;
+        assert_eq!(governance.entries[0].event_type, "propose");
+
+        let all = walk_scoped(vec![scripted_page(&[30], false)], AuditScope::All, 5).await;
+        assert_eq!(all.entries[0].event_type, "create");
     }
 }

--- a/crates/decman/src/server/handlers/governance.rs
+++ b/crates/decman/src/server/handlers/governance.rs
@@ -40,11 +40,12 @@ use crate::{
         },
         types::{
             ActiveCouponReassignmentDelegation, AuditLogEntry, AuditLogQuery, AuditLogResponse,
-            CancelConfirmationRequest, CancelProposalRequest, ChainAuditEntry, ChainAuditQuery,
-            ChainAuditResponse, ConfirmActionRequest, CouponReassignmentDelegationSummary,
-            ErrorResponse, ExecuteActionRequest, ExpireConfirmationRequest, GovernanceResponse,
-            GovernanceStateResponse, GovernanceType, KnownMember, KnownMembersResponse,
-            MessageResponse, ProposalType, ProposeActionRequest, chain_audit_entry_from_row,
+            AuditScope, CancelConfirmationRequest, CancelProposalRequest, ChainAuditEntry,
+            ChainAuditQuery, ChainAuditResponse, ConfirmActionRequest,
+            CouponReassignmentDelegationSummary, ErrorResponse, ExecuteActionRequest,
+            ExpireConfirmationRequest, GovernanceResponse, GovernanceStateResponse, GovernanceType,
+            KnownMember, KnownMembersResponse, MessageResponse, ProposalType, ProposeActionRequest,
+            chain_audit_entry_from_row,
         },
     },
     utils,
@@ -383,8 +384,13 @@ fn cached_chain_audit_page(
     Some(chain_audit_response(entries, has_more))
 }
 
-/// Get on-chain governance audit entries.
-/// Returns cached data by default. Pass `refresh=true` to fetch from Canton and update cache.
+/// Get on-chain audit entries for a party.
+///
+/// Defaults to the governance scope, served from cache; pass `refresh=true` to
+/// fetch from Canton and update the cache. `scope=all` returns every ledger
+/// event the party witnesses and is always read live — the cache holds
+/// governance-scoped pages, and mixing the two under one party key would let
+/// an `all` read answer a governance request.
 #[utoipa::path(
     tag = "Governance",
     params(ChainAuditQuery),
@@ -408,7 +414,9 @@ pub async fn get_governance_chain_audit(
         return HttpResponse::Ok().json(chain_audit_response(Vec::new(), false));
     }
 
-    if !query.refresh {
+    let cacheable = query.scope == AuditScope::Governance;
+
+    if !query.refresh && cacheable {
         match data
             .db
             .get_chain_audit_cache(party_id, limit as i64, query.before_offset)
@@ -435,19 +443,22 @@ pub async fn get_governance_chain_audit(
         party_id,
         token,
         &pkgs,
+        query.scope,
         limit,
         query.before_offset,
     )
     .await
     {
         Ok(page) => {
-            // Save to cache in background
-            let pool = data.db.clone();
-            let pid = party_id.clone();
-            let cached = page.entries.clone();
-            tokio::spawn(async move {
-                chain_audit::save_chain_audit_cache(&pool, &pid, &cached).await;
-            });
+            if cacheable {
+                // Save to cache in background
+                let pool = data.db.clone();
+                let pid = party_id.clone();
+                let cached = page.entries.clone();
+                tokio::spawn(async move {
+                    chain_audit::save_chain_audit_cache(&pool, &pid, &cached).await;
+                });
+            }
 
             HttpResponse::Ok().json(chain_audit_response(page.entries, page.has_more))
         }

--- a/crates/decman/src/server/handlers/governance.rs
+++ b/crates/decman/src/server/handlers/governance.rs
@@ -395,7 +395,7 @@ fn cached_chain_audit_page(
     tag = "Governance",
     params(ChainAuditQuery),
     responses(
-        (status = 200, description = "On-chain governance audit entries", body = ChainAuditResponse),
+        (status = 200, description = "On-chain audit entries for the requested scope", body = ChainAuditResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     )
 )]

--- a/crates/decman/src/server/ledger_paging.rs
+++ b/crates/decman/src/server/ledger_paging.rs
@@ -234,6 +234,11 @@ pub(crate) struct TransactionPage {
 /// a time, so a caller that only wants the most recent N can stop early instead
 /// of draining the whole ledger.
 ///
+/// `max_page_size` is the caller's, not [`FETCH_CHUNK`]: a narrow filter wants
+/// a big page so a long range is walked in few round trips, while an unfiltered
+/// read wants a small one — nearly every transaction it sees is a keeper, so a
+/// full chunk would pull a thousand payloads to use the first handful.
+///
 /// On a pre-3.5.1 participant there is no way to ask for "newest first" — the
 /// fallback drains the range in ascending order and reverses, which is exactly
 /// the behaviour this replaces.
@@ -243,6 +248,7 @@ pub(crate) async fn fetch_transactions_page(
     begin_exclusive: i64,
     end_inclusive: i64,
     update_format: UpdateFormat,
+    max_page_size: i32,
     page_token: Option<Vec<u8>>,
 ) -> Result<TransactionPage> {
     let mut client = utils::create_update_client(config, token.clone()).await?;
@@ -250,7 +256,7 @@ pub(crate) async fn fetch_transactions_page(
     let request = GetUpdatesPageRequest {
         begin_offset_exclusive: Some(begin_exclusive),
         end_offset_inclusive: Some(end_inclusive),
-        max_page_size: Some(FETCH_CHUNK),
+        max_page_size: Some(max_page_size),
         update_format: Some(update_format.clone()),
         descending_order: true,
         page_token,

--- a/crates/decman/src/server/ledger_paging.rs
+++ b/crates/decman/src/server/ledger_paging.rs
@@ -13,6 +13,8 @@
 //! result set anyway; sizing that at 25 would turn one stream into hundreds of
 //! round trips.
 
+use std::collections::VecDeque;
+
 use crate::{config::NodeConfig, error::Result, utils};
 use canton_proto_rs::com::daml::ledger::api::v2::{
     CreatedEvent, EventFormat, GetActiveContractsPageRequest, GetActiveContractsRequest,
@@ -225,9 +227,17 @@ where
 /// (`GetUpdateResponse` vs `GetUpdatesResponse` — the latter also carries
 /// offset checkpoints), so both paths are narrowed to transactions here and
 /// callers see one shape.
+#[derive(Default)]
 pub(crate) struct TransactionPage {
     pub transactions: Vec<Transaction>,
     pub next_page_token: Option<Vec<u8>>,
+    /// The range held updates older than this page that it does not carry.
+    ///
+    /// Only the pre-3.5.1 fallback sets it: that path has no continuation
+    /// token, so without this a caller could not tell a page that exhausted
+    /// the range from one that was cut short. The paged RPC says the same
+    /// thing with `next_page_token`.
+    pub truncated: bool,
 }
 
 /// Read updates in `(begin_exclusive, end_inclusive]` newest-first, one page at
@@ -276,6 +286,7 @@ pub(crate) async fn fetch_transactions_page(
             Ok(TransactionPage {
                 transactions,
                 next_page_token: page.next_page_token.filter(|t| !t.is_empty()),
+                truncated: false,
             })
         }
         Err(status) if is_unimplemented(&status) => {
@@ -283,39 +294,55 @@ pub(crate) async fn fetch_transactions_page(
                 "GetUpdatesPage unavailable (participant older than Canton 3.5.1); falling back \
                  to the streaming update read"
             );
-            let transactions =
-                stream_transactions(config, token, begin_exclusive, end_inclusive, update_format)
-                    .await?;
-            Ok(descending_page(transactions))
+            stream_transactions(
+                config,
+                token,
+                begin_exclusive,
+                end_inclusive,
+                update_format,
+                max_page_size,
+            )
+            .await
         }
         Err(status) => Err(status.into()),
     }
 }
 
-/// Present an ascending stream of transactions as one descending page.
+/// Present an ascending run of transactions as one descending page.
 ///
 /// The pre-3.5.1 `GetUpdates` has no "newest first" option, so the reversal
 /// here is what makes the fallback meet the same contract as the paged RPC.
-/// There is no continuation token to hand back: the stream drained the whole
-/// range in one go.
-fn descending_page(mut transactions: Vec<Transaction>) -> TransactionPage {
+/// There is no continuation token to hand back — the stream covers the whole
+/// range in one go — so `truncated` is what tells the caller that older
+/// updates were passed over.
+fn descending_page(transactions: VecDeque<Transaction>, truncated: bool) -> TransactionPage {
+    let mut transactions: Vec<Transaction> = transactions.into();
     transactions.reverse();
 
     TransactionPage {
         transactions,
         next_page_token: None,
+        truncated,
     }
 }
 
 /// Pre-3.5.1 path for [`fetch_transactions_page`]: drain the range as one
-/// stream.
+/// stream, keeping only the newest `max_page_size` transactions.
+///
+/// An ascending stream cannot be stopped early when the caller wants the
+/// newest rows — the last message is the one it is after — so the range is
+/// read out either way. What the bound changes is memory: only a page is held
+/// at a time, instead of every transaction in the range at once. An
+/// unfiltered read (`scope=all`) over a busy party's history would otherwise
+/// materialise the lot to use the first handful.
 async fn stream_transactions(
     config: &NodeConfig,
     token: Option<String>,
     begin_exclusive: i64,
     end_inclusive: i64,
     update_format: UpdateFormat,
-) -> Result<Vec<Transaction>> {
+    max_page_size: i32,
+) -> Result<TransactionPage> {
     let mut client = utils::create_update_client(config, token).await?;
 
     let request = GetUpdatesRequest {
@@ -330,14 +357,21 @@ async fn stream_transactions(
         .await?
         .into_inner();
 
-    let mut transactions = Vec::new();
+    let keep = usize::try_from(max_page_size).unwrap_or(1).max(1);
+    let mut transactions: VecDeque<Transaction> = VecDeque::with_capacity(keep);
+    let mut truncated = false;
+
     while let Some(response) = stream.message().await? {
         if let Some(get_updates_response::Update::Transaction(tx)) = response.update {
-            transactions.push(tx);
+            if transactions.len() == keep {
+                transactions.pop_front();
+                truncated = true;
+            }
+            transactions.push_back(tx);
         }
     }
 
-    Ok(transactions)
+    Ok(descending_page(transactions, truncated))
 }
 
 #[cfg(test)]
@@ -360,21 +394,25 @@ mod tests {
     /// the fallback has to hand back the reverse of what it read.
     #[test]
     fn fallback_page_is_newest_first() {
-        let page = descending_page(vec![tx_at(10), tx_at(20), tx_at(30)]);
+        let page = descending_page(VecDeque::from(vec![tx_at(10), tx_at(20), tx_at(30)]), false);
 
         assert_eq!(offsets_of(&page), vec![30, 20, 10]);
+        assert!(!page.truncated);
     }
 
-    /// The stream drained the whole range, so there is nothing to continue
+    /// The stream covers the whole range, so there is nothing to continue
     /// from — a token here would send the caller round the same range again.
+    /// A page cut to its bound says so through `truncated` instead.
     #[test]
     fn fallback_page_has_no_continuation() {
-        let page = descending_page(vec![tx_at(10)]);
+        let page = descending_page(VecDeque::from(vec![tx_at(10)]), true);
         assert!(page.next_page_token.is_none());
+        assert!(page.truncated);
 
-        let empty = descending_page(Vec::new());
+        let empty = descending_page(VecDeque::new(), false);
         assert!(empty.transactions.is_empty());
         assert!(empty.next_page_token.is_none());
+        assert!(!empty.truncated);
     }
 
     /// Only `Unimplemented` means "this participant predates the paged RPCs".

--- a/crates/decman/src/server/types.rs
+++ b/crates/decman/src/server/types.rs
@@ -1461,6 +1461,22 @@ fn default_audit_limit() -> i64 {
 // Chain Audit Trail Types
 // ============================================================================
 
+/// Which ledger events a chain-audit read returns.
+///
+/// `Governance` filters Canton-side to the governance packages and keeps only
+/// proposals, confirmations, executions and their outcomes. `All` drops both
+/// filters and returns every event the party witnesses, so a party whose
+/// activity lives in its own application packages — an app or oracle party
+/// that never deploys governance contracts — is not reported as having done
+/// nothing.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, utoipa::ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum AuditScope {
+    #[default]
+    Governance,
+    All,
+}
+
 /// Query parameters for the on-chain governance audit endpoint
 #[derive(Debug, Deserialize, utoipa::IntoParams)]
 pub struct ChainAuditQuery {
@@ -1477,6 +1493,9 @@ pub struct ChainAuditQuery {
     /// When true, fetches fresh data from Canton and updates cache
     #[serde(default)]
     pub refresh: bool,
+    /// Which events to return: `governance` (default) or `all`.
+    #[serde(default)]
+    pub scope: AuditScope,
 }
 
 fn default_chain_audit_limit() -> usize {


### PR DESCRIPTION
## Why

A customer reported that `alpend-poolOperator::12209eb8…` on mainnet showed **No on-chain governance events found for this party** while their team was making transactions through the CLI.

It was not a CLI/UI mismatch. What I found on `dec-party-manager-1` (ieu-mainnet):

- `Chain audit for alpend-poolOperator…: 0 entries (ledger_end=146698007, has_more=false)`, filters resolved, no wildcard fallback — the read walked the whole retained range and matched nothing. The same node returns 27 entries for `cbtc-network::1220…`, so the machinery works.
- The party's `PartyToParticipant` entry (serial 1, 2026-08-24) carries `partySigningKeys` with threshold 2. It is an **external party**; its transactions arrive by interactive submission and never touch `GovernanceRules`. It has no `GovernanceRules` contract at all.
- Lighthouse lists **2,500+ transactions since 2026-08-28** for it, every one acted by `alpend-oracle-pusher::1220f66f5b…` — their Chainlink price pusher, running against the `alpend-lending` / `alpend-oracle-chainlink` DARs uploaded through DecMan on 2026-08-26.

The trail asks Canton only for the governance packages and then keeps only `propose|confirm|execute|expire|cancel|execute_result`. An oracle push matches neither test, so a party like this can never have a trail under that scope — and the panel said "no events found" rather than "nothing here is governance".

## What changed

`/governance/chain-audit` takes `scope=governance|all` (default `governance`, so every existing caller — the CLI included — is unaffected).

`all` drops the Canton-side template filter and the governance narrowing. An event the governance index does not recognise keeps its plain ledger kind, `create` or `exercise`, rather than being forced through the governance naming heuristics — those would label an unrelated application create a `propose`. Recognised governance templates keep their governance labels in both scopes.

`all` is always read live: the cache holds governance-scoped pages under the same party key, so letting an `all` read write there would let it answer a governance request. The Canton page size now follows the scope as well — a filtered scan still wants the 1000-transaction chunk so a long range costs few round trips, while an unfiltered read keeps nearly everything it sees and only needs the caller's page.

The panel gets one toggle, **Governance / All activity / Local log**. The third reads `/governance/audit`, this node's own record of what it attempted — which had no web UI at all until now, only the CLI showed it, so a propose that failed before reaching the ledger was invisible from the browser. Its columns swap to Status and Member party, and a failed row shows its error.

The governance empty state now says the party may have no governance contracts deployed, and points at the other tab.

## Tests

Five new unit tests in `chain_audit`: the governance scope drops an application exercise, `all` keeps it with `exercise` / choice / template intact, `all` does not call an unknown create a proposal, and the page size follows the scope. Existing walk tests pass the governance scope explicitly, so their behaviour is pinned unchanged.

`cargo clippy --all-targets --all-features` clean, `cargo fmt --check` clean, frontend `tsc -b` clean. The component drops one pre-existing eslint error.

## Not in scope

The CLI keeps its governance-only on-chain popup — it already shows the local log in its party view.