### PR TITLE
chore(decman): bump version to 1.6.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1800,7 +1800,7 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "decman"
-version = "1.6.2"
+version = "1.6.3"
 dependencies = [
  "actix-cors",
  "actix-web",

--- a/crates/decman/Cargo.toml
+++ b/crates/decman/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "decman"
-version = "1.6.2"
+version = "1.6.3"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
## What this does

This bumps the version to **1.6.3**. Two lines change, nothing else.

After this merges, tagging `v1.6.3` makes the release workflow build the image and push it to the public registry. The workflow refuses a tag that does not match this version, which is why the bump comes first.

## Why we need a release now

The newest public image is **v1.6.2**. It has a display bug: the governance page fetches proposals from the ledger and then drops them before the screen, because the old code reads a field (`create_arguments`) that interface queries do not return. The fix is `6795cc9` ("read proposal details from the interface view"), which sits on `main` but in no published release.

The practical effect today: three `KeyGenerationAction` proposals are live on testnet, and no partner can see them to confirm. Partners pull from the public registry, so they cannot upgrade past the bug until this ships.

We proved the fix end to end on our own testnet node: on v1.6.1 the page was empty, on a `main` build (`78af4d7`, the image devnet runs) all three proposals appear.

## Safe for mixed versions

`MIN_PEER_VERSION` is a separate constant (`0.1.9`) and does not move with this bump. A v1.6.3 node keeps working with v1.6.1 peers, so partners can upgrade one at a time.

## After the merge

1. Tag the merge commit `v1.6.3` (signed, matching the existing tags).
2. The release workflow publishes `public.ecr.aws/dlc-link/decentralization-manager:v1.6.3`.
3. We tell partners to upgrade — the message is ready and waiting on this tag.

---

## For AI tools

- Convention followed: same two-file shape as `1b8a806` ("bump version to 1.6.1") — `crates/decman/Cargo.toml` + the `decman` block in `Cargo.lock`.
- `release.yml` gates on tag == crate version (`verify-tag` job) before the expensive build; it pushes `public.ecr.aws/dlc-link/decentralization-manager:$VERSION_TAG`.
- v1.6.3 ships everything on `main` since v1.6.2 (54 commits), including `6795cc9` (interface-view card fix), `785e58b` (vetted packages read from the synchronizer store) and `bfc672c` (add-party signature loss on coordinator restart).
- Context: testnet DecMan-1 was manually set to the private-ECR `78af4d7` image on 2026-09-01 to verify the fix; it should be re-pinned to `v1.6.3` once published. Related incident: stale Keycloak URL in the `cbtc-network` party-config, fixed the same day via `PUT /party-config`.
