### PR TITLE
chore(decman): bump version to 1.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1800,7 +1800,7 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "decman"
-version = "1.6.2"
+version = "1.7.0"
 dependencies = [
  "actix-cors",
  "actix-web",

--- a/crates/decman/Cargo.toml
+++ b/crates/decman/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "decman"
-version = "1.6.2"
+version = "1.7.0"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
## Summary

Bumps `decman` from 1.6.2 to 1.7.0 to prepare the `v1.7.0` release tag.

Two reasons the number has to land in the crate manifest first:

- `release.yml` refuses to build unless the release tag equals `crates/decman/Cargo.toml`'s version, so the tag cannot be cut before this merges.
- That same version is the `MIN_PEER_VERSION` peers gate on, so it is the peer-compatibility semver, not just a label.

Minor rather than patch because main has picked up feature work since 1.6.2 (UI modernization, nonroot image, audit-trail modes). Note that `v1.6.3` was tagged off `release-1.6`, so main itself never carried 1.6.3.

Diff is the manifest line plus the matching `Cargo.lock` entry, same shape as the 1.6.3 bump.

## Related issues

None.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Build / CI / chore

## Checklist

- [x] `cargo fmt -- --check` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` is clean
- [ ] `cargo test` passes
- [ ] Added/updated tests where appropriate
- [ ] Updated documentation where appropriate
- [x] Commits follow the `<type>(<scope>): <subject>` convention

Clippy and tests not run locally, leaving those to CI. No code changed, so there is nothing to add tests for.

## Notes for reviewers

`docs/DEPLOYMENT_GUIDE.md` still says `v1.6.2` in two places. One is a historical note about the root-only image and should stay. The other is the "use the latest tagged release" example. The 1.6.3 bump left both alone, so I did too. Say the word and I will refresh the example in a follow-up once the tag exists.
