### PR TITLE
fix(decman): bounded the per-party read fan-out

### DIFF
--- a/crates/decman/src/server/handlers/parties.rs
+++ b/crates/decman/src/server/handlers/parties.rs
@@ -41,7 +41,7 @@ use crate::{
         AppState,
         health::classify_health_reply,
         package_inventory::fetch_vetted_packages,
-        queries::{get_contracts, get_party_metadata, sort_contracts},
+        queries::{fetch_package_versions, get_contracts, get_party_metadata, sort_contracts},
         types::{
             ConnectionStatus, ContractInfo, DecentralizedPartiesResponse, DecentralizedParty,
             ErrorResponse, PackageInfo, ParticipantInfo, ParticipantStatus,
@@ -51,6 +51,18 @@ use crate::{
     },
     utils,
 };
+
+/// How many parties [`fetch_decentralized_parties`] reads at once.
+///
+/// The read used to await one future per hosted party together, so peak memory
+/// scaled with the number of parties: each in-flight future holds an ACS read's
+/// results and its gRPC buffers. A node hosting 213 parties ran 213 of those
+/// concurrently and was OOMKilled at a 2Gi limit (#415). Bounding the
+/// concurrency makes the peak track this number instead.
+///
+/// Small on purpose: the work is dominated by waiting on the participant, and
+/// the node shares a 500m CPU limit with everything else it serves.
+const PARTY_READ_CONCURRENCY: usize = 8;
 
 /// Query parameters for decentralized parties endpoint
 #[derive(Debug, Deserialize, utoipa::IntoParams)]
@@ -158,9 +170,13 @@ pub async fn get_decentralized_parties(
                 .write()
                 .await
                 .insert(prefix.clone());
+            // Serialise first, then hand the parties themselves to the task.
+            // Cloning them instead meant a second full copy of every party and
+            // its contracts alive at once, on top of the response body (#415).
+            let body = HttpResponse::Ok().json(&response);
             if spawned {
                 let data = data.clone();
-                let parties = response.parties.clone();
+                let parties = response.parties;
                 tokio::spawn(async move {
                     if let Err(e) = store_parties_to_db(&data.db, &prefix, &parties).await {
                         tracing::warn!("Failed to cache parties: {e}");
@@ -170,7 +186,7 @@ pub async fn get_decentralized_parties(
                     data.refreshing_prefixes.write().await.remove(&prefix);
                 });
             }
-            HttpResponse::Ok().json(response)
+            body
         }
         Err(e) => {
             tracing::error!("Failed to fetch decentralized parties: {e}");
@@ -892,12 +908,27 @@ pub async fn fetch_decentralized_parties(
     // Check if we're in test mode (mock auth)
     let test_mode = matches!(auth, Some(WorkflowAuth::Mock(_)));
 
-    // Fetch contracts and metadata in parallel for all parties
-    let futures: Vec<_> = my_parties
-        .into_iter()
-        .map(|(item, my_owner_key, p2p)| {
+    // Hoisted out of the per-party futures: both are the same for every party,
+    // and `list_packages` is a whole-participant Admin API read. Building them
+    // per party meant one full package inventory in flight per hosted party.
+    let packages = default_package_config();
+    let package_versions = match fetch_package_versions(config).await {
+        Ok(map) => map,
+        Err(e) => {
+            tracing::warn!("Failed to load package versions from Admin API: {e}");
+            HashMap::new()
+        }
+    };
+
+    // Fetch contracts and metadata for all parties, at most
+    // `PARTY_READ_CONCURRENCY` at a time.
+    let parties = utils::bounded_ordered(
+        PARTY_READ_CONCURRENCY,
+        my_parties.into_iter().map(|(item, my_owner_key, p2p)| {
             let config = config.clone();
             let auth = auth.clone();
+            let packages = &packages;
+            let package_versions = &package_versions;
             let party_id_str = p2p.party.clone();
             async move {
                 let party_id = CantonId::parse(&p2p.party)?;
@@ -917,12 +948,11 @@ pub async fn fetch_decentralized_parties(
                     None => None,
                 };
 
-                let packages = default_package_config();
                 let token_clone = token.clone();
                 let (contracts, local_metadata) = if token.is_some() || test_mode {
                     tokio::join!(
                         async {
-                            get_contracts(&config, &party_id, token, &packages)
+                            get_contracts(&config, &party_id, token, packages, package_versions)
                                 .await
                                 .unwrap_or_else(|e| {
                                     tracing::warn!(
@@ -971,11 +1001,9 @@ pub async fn fetch_decentralized_parties(
                     local_metadata,
                 })
             }
-        })
-        .collect();
-
-    let results = futures::future::join_all(futures).await;
-    let parties: Vec<_> = results.into_iter().filter_map(|r| r.ok()).collect();
+        }),
+    )
+    .await;
 
     Ok(DecentralizedPartiesResponse {
         parties,

--- a/crates/decman/src/server/handlers/parties.rs
+++ b/crates/decman/src/server/handlers/parties.rs
@@ -912,12 +912,20 @@ pub async fn fetch_decentralized_parties(
     // and `list_packages` is a whole-participant Admin API read. Building them
     // per party meant one full package inventory in flight per hosted party.
     let packages = default_package_config();
-    let package_versions = match fetch_package_versions(config).await {
-        Ok(map) => map,
-        Err(e) => {
-            tracing::warn!("Failed to load package versions from Admin API: {e}");
-            HashMap::new()
+    // Only when some party can use it. With no auth and no test mode every
+    // per-party read below is skipped, so fetching a whole-participant
+    // inventory would be pure waste — and it was never fetched on that path
+    // before, when `get_contracts` fetched it for itself.
+    let package_versions = if auth.is_some() || test_mode {
+        match fetch_package_versions(config).await {
+            Ok(map) => map,
+            Err(e) => {
+                tracing::warn!("Failed to load package versions from Admin API: {e}");
+                HashMap::new()
+            }
         }
+    } else {
+        HashMap::new()
     };
 
     // Fetch contracts and metadata for all parties, at most

--- a/crates/decman/src/server/queries.rs
+++ b/crates/decman/src/server/queries.rs
@@ -232,21 +232,9 @@ pub async fn get_contracts(
     party_id: &CantonId,
     token: Option<String>,
     packages: &PackageConfig,
+    package_versions: &HashMap<String, String>,
 ) -> Result<Vec<ContractInfo>> {
     let mut contracts = Vec::new();
-
-    // Build a {package_id → version} map once per request from the
-    // participant Admin API. The Ledger API itself only returns
-    // `package_name` on each created event — version metadata lives on the
-    // Admin PackageService. Failure to load is non-fatal: contracts simply
-    // ship with an empty version string.
-    let package_versions = match fetch_package_versions(config).await {
-        Ok(map) => map,
-        Err(e) => {
-            tracing::warn!("Failed to load package versions from Admin API: {e}");
-            HashMap::new()
-        }
-    };
 
     {
         // One query per template, so a package missing from this participant
@@ -258,7 +246,7 @@ pub async fn get_contracts(
                 party_id,
                 token.clone(),
                 t,
-                &package_versions,
+                package_versions,
                 &mut contracts,
             )
             .await
@@ -346,9 +334,14 @@ pub(crate) fn compare_versions(a: &str, b: &str) -> std::cmp::Ordering {
     }
 }
 
-/// Load `(package_id → version)` from the participant's Admin PackageService.
-/// One call per request — small map (~hundreds of rows), no caching needed.
-async fn fetch_package_versions(config: &NodeConfig) -> Result<HashMap<String, String>> {
+/// A `{package_id → version}` map from the participant's Admin PackageService.
+///
+/// The Ledger API returns only `package_name` on a created event; version
+/// metadata lives on the Admin `PackageService`. This is a whole-participant
+/// read, identical for every party, so a caller reading many parties must fetch
+/// it **once** and pass it to each [`get_contracts`] call — one inventory in
+/// flight per party is what OOMKilled a node (#415).
+pub(crate) async fn fetch_package_versions(config: &NodeConfig) -> Result<HashMap<String, String>> {
     let mut client = PackageServiceClient::new(config.admin_channel().await?);
     let response = client
         .list_packages(tonic::Request::new(ListPackagesRequest {

--- a/crates/decman/src/utils.rs
+++ b/crates/decman/src/utils.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use bytes::{Buf, BufMut, BytesMut};
+use futures::StreamExt;
 use prost::Message;
 use tokio::{fs, sync::OnceCell};
 
@@ -606,8 +607,118 @@ pub fn version_at_least(v: &str, min: &str) -> bool {
     v >= min
 }
 
+/// Await `tasks` with at most `limit` of them in flight, in input order,
+/// keeping the values that succeeded.
+///
+/// The bound is the point. Awaiting a whole batch together — `join_all` over
+/// one future per item — makes peak memory scale with the batch, because every
+/// future's buffers and results are alive at once. Reading one party per future
+/// that way OOMKilled a node hosting 213 of them (#415). Here the peak tracks
+/// `limit`.
+///
+/// Order is preserved (`buffered`, not `buffer_unordered`) so a caller's result
+/// list does not reshuffle between calls. A failed future is dropped, so the
+/// caller decides nothing per item; log the cause inside the future if it
+/// matters. `limit` of 0 is treated as 1, so a caller can never deadlock on a
+/// misconfigured bound.
+pub async fn bounded_ordered<T, F>(limit: usize, tasks: impl Iterator<Item = F>) -> Vec<T>
+where
+    F: std::future::Future<Output = anyhow::Result<T>>,
+{
+    futures::stream::iter(tasks)
+        .buffered(limit.max(1))
+        .filter_map(|r| async move { r.ok() })
+        .collect()
+        .await
+}
+
 #[cfg(test)]
 mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use super::bounded_ordered;
+
+    /// A future that records how many of its peers run at the same time.
+    async fn tracked(
+        n: usize,
+        live: Arc<AtomicUsize>,
+        peak: Arc<AtomicUsize>,
+    ) -> anyhow::Result<usize> {
+        let now = live.fetch_add(1, Ordering::SeqCst) + 1;
+        peak.fetch_max(now, Ordering::SeqCst);
+        // Yield enough times that every future the bound allows has started
+        // before the first one finishes; without this the executor could run
+        // them one after another and the test would pass for the wrong reason.
+        for _ in 0..8 {
+            tokio::task::yield_now().await;
+        }
+        live.fetch_sub(1, Ordering::SeqCst);
+        Ok(n)
+    }
+
+    #[tokio::test]
+    async fn bounded_ordered_never_exceeds_the_limit() {
+        let live = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let got = bounded_ordered(4, (0..40).map(|n| tracked(n, live.clone(), peak.clone()))).await;
+
+        assert_eq!(got.len(), 40);
+        assert!(
+            peak.load(Ordering::SeqCst) <= 4,
+            "ran {} at once against a limit of 4",
+            peak.load(Ordering::SeqCst)
+        );
+        // And it really did overlap — a bound that serialised everything would
+        // also satisfy the assertion above while losing all the concurrency.
+        assert!(
+            peak.load(Ordering::SeqCst) > 1,
+            "never ran two at once, so the bound serialised the batch"
+        );
+    }
+
+    #[tokio::test]
+    async fn bounded_ordered_keeps_input_order() {
+        // Reverse the completion order: the first future waits the longest, so
+        // an unordered bound would return it last.
+        let got = bounded_ordered(
+            8,
+            (0..8usize).map(|n| async move {
+                for _ in 0..(8 - n) {
+                    tokio::task::yield_now().await;
+                }
+                Ok(n)
+            }),
+        )
+        .await;
+        assert_eq!(got, (0..8).collect::<Vec<usize>>());
+    }
+
+    #[tokio::test]
+    async fn bounded_ordered_drops_the_failures_and_keeps_the_rest() {
+        let got = bounded_ordered(
+            3,
+            (0..6usize).map(|n| async move {
+                if n % 2 == 0 {
+                    Ok(n)
+                } else {
+                    Err(anyhow::anyhow!("no"))
+                }
+            }),
+        )
+        .await;
+        assert_eq!(got, vec![0, 2, 4]);
+    }
+
+    #[tokio::test]
+    async fn bounded_ordered_treats_a_zero_limit_as_one() {
+        // `buffered(0)` never polls anything, which would hang the caller.
+        let got = bounded_ordered(0, (0..3usize).map(|n| async move { Ok(n) })).await;
+        assert_eq!(got, vec![0, 1, 2]);
+    }
+
     #[test]
     fn version_at_least_compares_numerically() {
         assert!(version_at_least("0.1.9", "0.1.9"));


### PR DESCRIPTION
Closes #415.

`fetch_decentralized_parties` awaited one future per hosted party with `join_all`, so every ACS read's results and gRPC buffers were alive at once and peak memory scaled with the party count, not the result. A node hosting 213 parties was OOMKilled at its 2Gi limit, and because the parties endpoint refreshes whenever its cache is over 60s old, any client polling faster than that re-ran the fan-out indefinitely.

### What changed

**The package inventory, which was the biggest multiplier.** `get_contracts` called `fetch_package_versions` itself, so the fan-out put one whole-participant `ListPackages` (`limit: 0`, every package) in flight *per party*. It now takes the map as an argument and the caller fetches it once — which is what `get_contracts`' own comment already claimed ("once per request"). `default_package_config()` came out of the futures for the same reason. `get_contracts` has exactly one caller, so this needed no wrapper.

**The fan-out itself.** `join_all` became `utils::bounded_ordered(8, ..)`, so at most 8 reads are in flight and the peak tracks that number instead of the party count. It uses `buffered`, deliberately not `buffer_unordered`, so the result order is byte-for-byte what it was — the list feeds both the UI and the DB cache and should not reshuffle between calls. Failed reads are dropped exactly as the old `filter_map(|r| r.ok())` did.

**One deep clone.** The cold-cache branch of `get_decentralized_parties` cloned every party and its contracts to hand to the caching task, on top of the response body. It now serialises the response by reference and moves the parties into the task.

`PARTY_READ_CONCURRENCY` is 8 as a plain const rather than a config knob. Say the word if you want it tunable without a rebuild, like `reward_max_creates` is.

### What I deliberately did not touch

The three other `join_all` sites — `parties.rs:1159`, `parties.rs:1361` and `mod.rs:2234` — all fan out over **peers**, not parties. That is the mesh size, 7 on devnet, so they are bounded by construction and not part of this bug.

### Tests

`bounded_ordered` exists as a helper mainly so the behaviour is testable; the old inline pipeline was not. Four unit tests in `utils.rs`:

- `bounded_ordered_never_exceeds_the_limit` — 40 futures against a limit of 4, each recording how many peers are live via an `AtomicUsize`, asserting the observed peak is `<= 4` **and** `> 1`, so a bound that quietly serialised the batch fails too
- `bounded_ordered_keeps_input_order` — completion order reversed against input order, asserting the output is still `0..8`
- `bounded_ordered_drops_the_failures_and_keeps_the_rest`
- `bounded_ordered_treats_a_zero_limit_as_one` — `buffered(0)` polls nothing and would hang the caller

Written but not run locally: `cargo fmt --all -- --check` and `cargo clippy --all-targets --all-features --no-deps -- -D warnings` are both clean. CI runs them.

The gRPC read paths stay covered by the localnet and devnet integration tests, as before.

### Verifying on devnet

Node 1 currently carries a 4Gi live patch (`kubectl set resources`) that the manifest does not have, put back after it OOMed on the #413 fix. Once this ships, the check is that node 1 holds at 2Gi through repeated parties-list polls — that is the exact case that killed it.
