### PR TITLE
fix(peer): validate coordinator payloads against the accepted invitation

### DIFF
--- a/crates/common/src/api.rs
+++ b/crates/common/src/api.rs
@@ -492,6 +492,13 @@ pub struct DeclineInvitationPayload {
 #[cfg_attr(feature = "typegen", derive(ts_rs::TS), ts(optional_fields))]
 pub struct DarsInvitePayload {
     pub dar_filenames: Vec<String>,
+    /// SHA-256 of each DAR's content, hex encoded and index-aligned with
+    /// `dar_filenames`. A peer pins the accepted content with these, so a
+    /// coordinator cannot get a different DAR vetted under an accepted name.
+    /// Empty from a coordinator that predates the field; the peer then falls
+    /// back to checking filenames only.
+    #[serde(default)]
+    pub dar_hashes: Vec<String>,
     /// The member set (selected peers) this distribution targets, so the peer
     /// card can render the same participant list the coordinator shows.
     #[serde(default)]

--- a/crates/common/src/types.rs
+++ b/crates/common/src/types.rs
@@ -496,6 +496,10 @@ pub struct PendingInvitation {
     /// Dars-only: filenames the coordinator is distributing.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub dar_filenames: Vec<String>,
+    /// Dars-only: SHA-256 of each DAR, index-aligned with `dar_filenames`.
+    /// Recorded at accept time so the peer can pin the content it agreed to.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub dar_hashes: Vec<String>,
     /// Kick-only: the participant being removed from the party.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub kicked_participant: Option<CantonId>,

--- a/crates/decman-cli/src/ui.rs
+++ b/crates/decman-cli/src/ui.rs
@@ -2817,6 +2817,7 @@ mod tests {
                 prefix: Some("treasury-rc5".to_owned()),
                 participants: Vec::new(),
                 dar_filenames: Vec::new(),
+                dar_hashes: Vec::new(),
                 kicked_participant: None,
                 new_threshold: None,
                 previous_threshold: None,

--- a/crates/decman-cli/src/ui.rs
+++ b/crates/decman-cli/src/ui.rs
@@ -2580,7 +2580,17 @@ fn invitation_detail_lines(invitation: &PendingInvitation) -> Vec<Line<'static>>
         lines.push(detail_kv("Packages", invitation.package_names.join(", ")));
     }
     if !invitation.dar_filenames.is_empty() {
-        lines.push(detail_kv("DARs", invitation.dar_filenames.join(", ")));
+        // Show the pinned content hash beside each filename. The peer refuses
+        // any DAR whose bytes do not hash to this value, so it is the operator
+        // accepting the content — not just the name — and it can be compared
+        // against a published release hash before accepting.
+        lines.push(detail_kv("DARs", String::new()));
+        for (index, filename) in invitation.dar_filenames.iter().enumerate() {
+            lines.push(detail_item(match invitation.dar_hashes.get(index) {
+                Some(hash) => format!("{filename}  sha256:{hash}"),
+                None => format!("{filename}  (no hash pinned)"),
+            }));
+        }
     }
     lines
 }

--- a/crates/decman/frontend/src/components/NotificationsView.tsx
+++ b/crates/decman/frontend/src/components/NotificationsView.tsx
@@ -473,15 +473,29 @@ const InvitationCard = ({
               >
                 DARs ({invitation.dar_filenames.length})
               </Typography>
-              <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5 }}>
-                {invitation.dar_filenames.map((filename) => (
-                  <Chip
-                    key={filename}
-                    size="small"
-                    variant="outlined"
-                    label={filename}
-                  />
-                ))}
+              {/* The peer refuses any DAR whose bytes do not hash to the
+                  value pinned here, so this is the operator accepting the
+                  content rather than just the name. Shown in full so it can be
+                  compared against a published release hash before accepting. */}
+              <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
+                {invitation.dar_filenames.map((filename, index) => {
+                  const hash = invitation.dar_hashes?.[index];
+                  return (
+                    <Box
+                      key={filename}
+                      sx={{ display: "flex", alignItems: "baseline", gap: 1 }}
+                    >
+                      <Chip size="small" variant="outlined" label={filename} />
+                      <Typography
+                        variant="caption"
+                        color={hash ? "text.secondary" : "warning.main"}
+                        sx={{ fontFamily: "monospace", wordBreak: "break-all" }}
+                      >
+                        {hash ? `sha256:${hash}` : "no hash pinned"}
+                      </Typography>
+                    </Box>
+                  );
+                })}
               </Box>
             </Box>
           )}

--- a/crates/decman/migrations/000016_dar_invitation_hashes.down.sql
+++ b/crates/decman/migrations/000016_dar_invitation_hashes.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE pending_invitations DROP COLUMN dar_hashes;

--- a/crates/decman/migrations/000016_dar_invitation_hashes.up.sql
+++ b/crates/decman/migrations/000016_dar_invitation_hashes.up.sql
@@ -1,0 +1,3 @@
+-- Dars invitations carry the SHA-256 of each DAR so a peer can refuse a file
+-- whose content differs from the one its operator accepted.
+ALTER TABLE pending_invitations ADD COLUMN dar_hashes TEXT;

--- a/crates/decman/src/canton_hash/encoding.rs
+++ b/crates/decman/src/canton_hash/encoding.rs
@@ -1,0 +1,480 @@
+//! Deterministic encoding primitives shared by every hashing scheme version.
+//!
+//! Protobuf serialization is not canonical, so Canton defines its own byte
+//! encoding over the decoded message tree and hashes that. This module is a
+//! port of the primitives in Canton's `HashBuilder` / `LfValueHashBuilder`
+//! (`community/base/.../protocol/hash/`), cross-checked against the reference
+//! Python implementation Canton ships for external signers
+//! (`examples/08-interactive-submission/daml_transaction_hashing_common.py`).
+
+use canton_proto_rs::com::daml::ledger::api::v2::{Identifier, Value, value};
+use sha2::{Digest, Sha256};
+
+use crate::error::Result;
+
+/// `HashPurpose.PreparedSubmission` (48) as a 4-byte big-endian integer. Every
+/// hash in the scheme is domain-separated with this prefix.
+pub(super) const HASH_PURPOSE: [u8; 4] = [0x00, 0x00, 0x00, 0x30];
+
+/// Nesting limit for [`Encoder::value`]. The payload is supplied by a
+/// potentially hostile coordinator, so a deeply nested `Value` must not be
+/// able to blow the stack — it is refused instead. Real Daml arguments are
+/// nowhere near this deep.
+const MAX_VALUE_DEPTH: usize = 100;
+
+/// SHA-256 of `data`, the only hash algorithm the scheme uses.
+pub(super) fn sha256(data: &[u8]) -> [u8; 32] {
+    Sha256::digest(data).into()
+}
+
+/// Accumulates the deterministic encoding of a message tree.
+#[derive(Default)]
+pub(super) struct Encoder {
+    buf: Vec<u8>,
+}
+
+impl Encoder {
+    pub(super) fn new() -> Self {
+        Self::default()
+    }
+
+    /// An encoder pre-loaded with the hash purpose — the starting point for
+    /// every hash the scheme produces (as opposed to a nested encoding whose
+    /// bytes are folded into an enclosing one).
+    pub(super) fn with_purpose() -> Self {
+        let mut encoder = Self::new();
+        encoder.raw(&HASH_PURPOSE);
+        encoder
+    }
+
+    pub(super) fn into_bytes(self) -> Vec<u8> {
+        self.buf
+    }
+
+    pub(super) fn digest(&self) -> [u8; 32] {
+        sha256(&self.buf)
+    }
+
+    fn raw(&mut self, bytes: &[u8]) {
+        self.buf.extend_from_slice(bytes);
+    }
+
+    /// Append a fixed-size hash. No length prefix: hashes have a fixed width.
+    pub(super) fn add_hash(&mut self, hash: &[u8]) {
+        self.raw(hash);
+    }
+
+    pub(super) fn byte(&mut self, byte: u8) {
+        self.buf.push(byte);
+    }
+
+    pub(super) fn bool(&mut self, value: bool) {
+        self.byte(u8::from(value));
+    }
+
+    pub(super) fn int32(&mut self, value: i32) {
+        self.raw(&value.to_be_bytes());
+    }
+
+    pub(super) fn int64(&mut self, value: i64) {
+        self.raw(&value.to_be_bytes());
+    }
+
+    /// Canton encodes lengths as Java `int`s. A payload claiming more than
+    /// `i32::MAX` elements cannot be encoded the way Canton would, so refuse
+    /// rather than truncate into a different (attacker-chosen) encoding.
+    fn length(&mut self, length: usize) -> Result {
+        let length = i32::try_from(length)
+            .map_err(|_| anyhow::anyhow!("length {length} exceeds the int32 the encoding uses"))?;
+        self.int32(length);
+        Ok(())
+    }
+
+    pub(super) fn bytes(&mut self, bytes: &[u8]) -> Result {
+        self.length(bytes.len())?;
+        self.raw(bytes);
+        Ok(())
+    }
+
+    pub(super) fn string(&mut self, value: &str) -> Result {
+        self.bytes(value.as_bytes())
+    }
+
+    /// Canton hashes contract ids as their raw bytes; the protobuf carries the
+    /// hex rendering of those bytes.
+    pub(super) fn hex_string(&mut self, value: &str) -> Result {
+        let raw = hex::decode(value)
+            .map_err(|e| anyhow::anyhow!("expected a hex-encoded value, got {value:?}: {e}"))?;
+        self.bytes(&raw)
+    }
+
+    /// A `Set[String]` on the Canton side: sorted and deduplicated before
+    /// hashing, so the encoding does not depend on the order the coordinator
+    /// happened to serialize the repeated field in.
+    pub(super) fn string_set(&mut self, values: &[String]) -> Result {
+        let mut sorted: Vec<&str> = values.iter().map(String::as_str).collect();
+        sorted.sort_unstable();
+        sorted.dedup();
+        self.length(sorted.len())?;
+        for value in sorted {
+            self.string(value)?;
+        }
+        Ok(())
+    }
+
+    /// A repeated field whose order is part of the encoding (list elements,
+    /// node children, query results).
+    pub(super) fn repeated<T>(
+        &mut self,
+        values: &[T],
+        mut encode: impl FnMut(&mut Self, &T) -> Result,
+    ) -> Result {
+        self.length(values.len())?;
+        for value in values {
+            encode(self, value)?;
+        }
+        Ok(())
+    }
+
+    pub(super) fn optional<T>(
+        &mut self,
+        value: Option<&T>,
+        encode: impl FnOnce(&mut Self, &T) -> Result,
+    ) -> Result {
+        match value {
+            Some(value) => {
+                self.byte(0x01);
+                encode(self, value)
+            }
+            None => {
+                self.byte(0x00);
+                Ok(())
+            }
+        }
+    }
+
+    pub(super) fn identifier(&mut self, identifier: &Identifier) -> Result {
+        self.string(&identifier.package_id)?;
+        self.dotted_name(&identifier.module_name)?;
+        self.dotted_name(&identifier.entity_name)
+    }
+
+    /// Canton hashes a dotted name as the list of its segments, so the
+    /// segment boundaries are part of the hash.
+    fn dotted_name(&mut self, name: &str) -> Result {
+        let segments: Vec<&str> = name.split('.').collect();
+        self.length(segments.len())?;
+        for segment in segments {
+            self.string(segment)?;
+        }
+        Ok(())
+    }
+
+    /// Encode a Daml-LF value. Each variant carries a distinct type tag so a
+    /// value of one type can never hash to the same bytes as a value of
+    /// another.
+    pub(super) fn value(&mut self, value: &Value) -> Result {
+        self.value_at_depth(value, 0)
+    }
+
+    fn value_at_depth(&mut self, value: &Value, depth: usize) -> Result {
+        if depth > MAX_VALUE_DEPTH {
+            anyhow::bail!("value nesting exceeds the {MAX_VALUE_DEPTH} level limit");
+        }
+        let sum = value
+            .sum
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("value has no variant set"))?;
+        match sum {
+            value::Sum::Unit(()) => self.byte(0x00),
+            value::Sum::Bool(v) => {
+                self.byte(0x01);
+                self.bool(*v);
+            }
+            value::Sum::Int64(v) => {
+                self.byte(0x02);
+                self.int64(*v);
+            }
+            value::Sum::Numeric(v) => {
+                self.byte(0x03);
+                self.string(v)?;
+            }
+            value::Sum::Timestamp(v) => {
+                self.byte(0x04);
+                self.int64(*v);
+            }
+            value::Sum::Date(v) => {
+                self.byte(0x05);
+                self.int32(*v);
+            }
+            value::Sum::Party(v) => {
+                self.byte(0x06);
+                self.string(v)?;
+            }
+            value::Sum::Text(v) => {
+                self.byte(0x07);
+                self.string(v)?;
+            }
+            value::Sum::ContractId(v) => {
+                self.byte(0x08);
+                self.hex_string(v)?;
+            }
+            value::Sum::Optional(v) => {
+                self.byte(0x09);
+                match v.value.as_deref() {
+                    Some(inner) => {
+                        self.byte(0x01);
+                        self.value_at_depth(inner, depth + 1)?;
+                    }
+                    None => self.byte(0x00),
+                }
+            }
+            value::Sum::List(v) => {
+                self.byte(0x0a);
+                self.length(v.elements.len())?;
+                for element in &v.elements {
+                    self.value_at_depth(element, depth + 1)?;
+                }
+            }
+            value::Sum::TextMap(v) => {
+                self.byte(0x0b);
+                self.length(v.entries.len())?;
+                for entry in &v.entries {
+                    self.string(&entry.key)?;
+                    self.value_at_depth(
+                        required(entry.value.as_ref(), "text map entry value")?,
+                        depth + 1,
+                    )?;
+                }
+            }
+            value::Sum::Record(v) => {
+                self.byte(0x0c);
+                self.optional(v.record_id.as_ref(), Self::identifier)?;
+                self.length(v.fields.len())?;
+                for field in &v.fields {
+                    // The label is always encoded as a set optional: Canton
+                    // enriches the prepared transaction, so every record field
+                    // carries its label by the time it reaches a signer.
+                    self.byte(0x01);
+                    self.string(&field.label)?;
+                    self.value_at_depth(
+                        required(field.value.as_ref(), "record field value")?,
+                        depth + 1,
+                    )?;
+                }
+            }
+            value::Sum::Variant(v) => {
+                self.byte(0x0d);
+                self.optional(v.variant_id.as_ref(), Self::identifier)?;
+                self.string(&v.constructor)?;
+                self.value_at_depth(required(v.value.as_deref(), "variant value")?, depth + 1)?;
+            }
+            value::Sum::Enum(v) => {
+                self.byte(0x0e);
+                self.optional(v.enum_id.as_ref(), Self::identifier)?;
+                self.string(&v.constructor)?;
+            }
+            value::Sum::GenMap(v) => {
+                self.byte(0x0f);
+                self.length(v.entries.len())?;
+                for entry in &v.entries {
+                    self.value_at_depth(
+                        required(entry.key.as_ref(), "gen map entry key")?,
+                        depth + 1,
+                    )?;
+                    self.value_at_depth(
+                        required(entry.value.as_ref(), "gen map entry value")?,
+                        depth + 1,
+                    )?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Unwrap a protobuf field the encoding treats as required.
+pub(super) fn required<T>(value: Option<T>, what: &str) -> Result<T> {
+    value.ok_or_else(|| anyhow::anyhow!("prepared transaction is missing its {what}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use canton_proto_rs::com::daml::ledger::api::v2::{
+        List, Optional, Record, RecordField, TextMap, text_map,
+    };
+
+    use super::*;
+
+    fn text(value: &str) -> Value {
+        Value {
+            sum: Some(value::Sum::Text(value.to_string())),
+        }
+    }
+
+    fn encode(value: &Value) -> Result<Vec<u8>> {
+        let mut encoder = Encoder::new();
+        encoder.value(value)?;
+        Ok(encoder.into_bytes())
+    }
+
+    /// Canton's own trace for a text value: type tag, then the length-prefixed
+    /// UTF-8 bytes (see `v2/NodeHashTest.scala`, "Arg" section).
+    #[test]
+    fn encodes_text_like_canton() -> Result {
+        assert_eq!(encode(&text("hello"))?, b"\x07\x00\x00\x00\x05hello");
+        Ok(())
+    }
+
+    #[test]
+    fn encodes_identifier_as_package_and_dotted_names() -> Result {
+        let mut encoder = Encoder::new();
+        encoder.identifier(&Identifier {
+            package_id: "package".to_string(),
+            module_name: "module".to_string(),
+            entity_name: "name".to_string(),
+        })?;
+        let expected = [
+            b"\x00\x00\x00\x07package".as_slice(),
+            b"\x00\x00\x00\x01\x00\x00\x00\x06module",
+            b"\x00\x00\x00\x01\x00\x00\x00\x04name",
+        ]
+        .concat();
+        assert_eq!(encoder.into_bytes(), expected);
+        Ok(())
+    }
+
+    #[test]
+    fn splits_dotted_module_names_into_segments() -> Result {
+        let mut encoder = Encoder::new();
+        encoder.identifier(&Identifier {
+            package_id: "p".to_string(),
+            module_name: "a.b".to_string(),
+            entity_name: "c".to_string(),
+        })?;
+        let expected = [
+            b"\x00\x00\x00\x01p".as_slice(),
+            b"\x00\x00\x00\x02\x00\x00\x00\x01a\x00\x00\x00\x01b",
+            b"\x00\x00\x00\x01\x00\x00\x00\x01c",
+        ]
+        .concat();
+        assert_eq!(encoder.into_bytes(), expected);
+        Ok(())
+    }
+
+    /// Party sets are hashed sorted and deduplicated, so a coordinator cannot
+    /// change the encoding by reordering the repeated field.
+    #[test]
+    fn string_set_is_order_and_duplicate_independent() -> Result {
+        let mut ordered = Encoder::new();
+        ordered.string_set(&["alice".to_string(), "bob".to_string()])?;
+        let mut shuffled = Encoder::new();
+        shuffled.string_set(&["bob".to_string(), "alice".to_string(), "bob".to_string()])?;
+        assert_eq!(ordered.into_bytes(), shuffled.into_bytes());
+        Ok(())
+    }
+
+    /// A list's order IS part of the encoding — the sorting above must not
+    /// leak into ordered collections.
+    #[test]
+    fn list_order_changes_the_encoding() -> Result {
+        let forwards = List {
+            elements: vec![text("a"), text("b")],
+        };
+        let backwards = List {
+            elements: vec![text("b"), text("a")],
+        };
+        let encode_list = |list: List| {
+            encode(&Value {
+                sum: Some(value::Sum::List(list)),
+            })
+        };
+        assert_ne!(encode_list(forwards)?, encode_list(backwards)?);
+        Ok(())
+    }
+
+    /// The type tags exist to stop a value of one type colliding with another
+    /// (Canton's example: `Some(42)` vs a plain integer).
+    #[test]
+    fn distinct_types_do_not_collide() -> Result {
+        let some_text = Value {
+            sum: Some(value::Sum::Optional(Box::new(Optional {
+                value: Some(Box::new(text("hello"))),
+            }))),
+        };
+        assert_ne!(encode(&some_text)?, encode(&text("hello"))?);
+        Ok(())
+    }
+
+    #[test]
+    fn none_and_some_differ() -> Result {
+        let none = Value {
+            sum: Some(value::Sum::Optional(Box::new(Optional { value: None }))),
+        };
+        let some_unit = Value {
+            sum: Some(value::Sum::Optional(Box::new(Optional {
+                value: Some(Box::new(Value {
+                    sum: Some(value::Sum::Unit(())),
+                })),
+            }))),
+        };
+        assert_ne!(encode(&none)?, encode(&some_unit)?);
+        Ok(())
+    }
+
+    #[test]
+    fn record_field_label_is_part_of_the_encoding() -> Result {
+        let record = |label: &str| Value {
+            sum: Some(value::Sum::Record(Record {
+                record_id: None,
+                fields: vec![RecordField {
+                    label: label.to_string(),
+                    value: Some(text("hello")),
+                }],
+            })),
+        };
+        assert_ne!(encode(&record("amount"))?, encode(&record("recipient"))?);
+        Ok(())
+    }
+
+    #[test]
+    fn text_map_keys_are_part_of_the_encoding() -> Result {
+        let map = |key: &str| Value {
+            sum: Some(value::Sum::TextMap(TextMap {
+                entries: vec![text_map::Entry {
+                    key: key.to_string(),
+                    value: Some(text("v")),
+                }],
+            })),
+        };
+        assert_ne!(encode(&map("a"))?, encode(&map("b"))?);
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_a_value_with_no_variant() {
+        assert!(encode(&Value { sum: None }).is_err());
+    }
+
+    #[test]
+    fn rejects_a_non_hex_contract_id() {
+        let value = Value {
+            sum: Some(value::Sum::ContractId("not-hex".to_string())),
+        };
+        assert!(encode(&value).is_err());
+    }
+
+    /// A hostile payload must not be able to blow the stack.
+    #[test]
+    fn rejects_deeply_nested_values() {
+        let mut value = text("bottom");
+        for _ in 0..(MAX_VALUE_DEPTH + 5) {
+            value = Value {
+                sum: Some(value::Sum::Optional(Box::new(Optional {
+                    value: Some(Box::new(value)),
+                }))),
+            };
+        }
+        assert!(encode(&value).is_err());
+    }
+}

--- a/crates/decman/src/canton_hash/metadata.rs
+++ b/crates/decman/src/canton_hash/metadata.rs
@@ -1,0 +1,96 @@
+//! Metadata encoding for the interactive-submission hashing scheme.
+//!
+//! Port of Canton's `v2` / `v3` `TransactionMetadataHasher`. Everything in the
+//! metadata is signed: the fields that describe the ledger change, and the
+//! Canton-protocol fields (mediator group, synchronizer, time bounds) that
+//! decide where and when the change may be committed.
+
+use canton_proto_rs::com::daml::ledger::api::v2::interactive::{
+    Metadata, metadata::InputContract, metadata::input_contract::Contract,
+};
+
+use crate::{
+    canton_hash::{
+        HashingScheme,
+        encoding::{Encoder, required},
+        nodes::NodeHasher,
+    },
+    error::Result,
+};
+
+/// V2 prefixes the metadata with the version of the protobuf used to encode
+/// it; V3 dropped the prefix.
+const METADATA_ENCODING_V1: u8 = 0x01;
+
+pub(super) fn hash_metadata(scheme: HashingScheme, metadata: &Metadata) -> Result<[u8; 32]> {
+    let mut encoder = Encoder::with_purpose();
+    if scheme == HashingScheme::V2 {
+        encoder.byte(METADATA_ENCODING_V1);
+    }
+
+    let submitter = required(metadata.submitter_info.as_ref(), "submitter info")?;
+    encoder.string_set(&submitter.act_as)?;
+    encoder.string(&submitter.command_id)?;
+    encoder.string(&metadata.transaction_uuid)?;
+    let mediator_group = i32::try_from(metadata.mediator_group).map_err(|_| {
+        anyhow::anyhow!(
+            "mediator group {group} exceeds the int32 the encoding uses",
+            group = metadata.mediator_group
+        )
+    })?;
+    encoder.int32(mediator_group);
+    encoder.string(&metadata.synchronizer_id)?;
+    encode_optional_timestamp(&mut encoder, metadata.min_ledger_effective_time)?;
+    encode_optional_timestamp(&mut encoder, metadata.max_ledger_effective_time)?;
+    encoder.int64(timestamp(metadata.preparation_time, "preparation time")?);
+
+    // Canton keeps the input contracts in a map keyed by contract id, so the
+    // hash is over that key order regardless of how they arrived on the wire.
+    let mut contracts: Vec<(&str, &InputContract)> =
+        Vec::with_capacity(metadata.input_contracts.len());
+    for contract in &metadata.input_contracts {
+        contracts.push((contract_id(contract)?, contract));
+    }
+    contracts.sort_by_key(|(id, _)| *id);
+
+    encoder.repeated(&contracts, |encoder, (_, contract)| {
+        encoder.int64(timestamp(
+            contract.created_at,
+            "input contract creation time",
+        )?);
+        let Contract::V1(create) = required(contract.contract.as_ref(), "input contract")?;
+        let hash = NodeHasher::hash_detached_create(scheme, create)?;
+        encoder.add_hash(&hash);
+        Ok(())
+    })?;
+
+    if scheme == HashingScheme::V3 {
+        encode_optional_timestamp(&mut encoder, metadata.max_record_time)?;
+    }
+
+    Ok(encoder.digest())
+}
+
+fn contract_id(contract: &InputContract) -> Result<&str> {
+    let Contract::V1(create) = required(contract.contract.as_ref(), "input contract")?;
+    Ok(&create.contract_id)
+}
+
+/// Canton stores timestamps as microseconds in a Java `long`; the protobuf
+/// widens them to `uint64`. A value that does not fit the signed range could
+/// not have come from Canton.
+fn timestamp(micros: u64, what: &str) -> Result<i64> {
+    i64::try_from(micros)
+        .map_err(|_| anyhow::anyhow!("{what} {micros} exceeds the int64 the encoding uses"))
+}
+
+fn encode_optional_timestamp(encoder: &mut Encoder, micros: Option<u64>) -> Result {
+    match micros {
+        Some(micros) => {
+            encoder.byte(0x01);
+            encoder.int64(timestamp(micros, "timestamp")?);
+        }
+        None => encoder.byte(0x00),
+    }
+    Ok(())
+}

--- a/crates/decman/src/canton_hash/mod.rs
+++ b/crates/decman/src/canton_hash/mod.rs
@@ -1,0 +1,663 @@
+//! Canton's interactive-submission transaction hash, recomputed locally.
+//!
+//! A `PrepareSubmissionResponse` carries both the transaction and the hash to
+//! sign, and the Ledger API is explicit that the hash is "provided for
+//! convenience" — a client MUST recompute it from the transaction when the
+//! preparing participant is not trusted. In DecMan the preparing participant
+//! is the *coordinator*, which is exactly the party a peer is defending
+//! against: signing the supplied hash blind lets a compromised coordinator
+//! show one transaction and collect signatures over another.
+//!
+//! This module implements the hashing scheme so a peer can bind its signature
+//! to the transaction it can actually inspect. It is a port of Canton's
+//! `com.digitalasset.canton.protocol.hash` package (v3.5.8), cross-checked
+//! against the reference Python implementation Canton ships with the
+//! interactive-submission example, and pinned by the golden vectors from
+//! Canton's own `NodeHashTest` / `MetadataHashTest` suites in the tests below.
+//!
+//! Unsupported input fails closed: an unknown scheme version, or a field a
+//! scheme does not cover, produces an error rather than a hash that omits it.
+
+mod encoding;
+mod metadata;
+mod nodes;
+
+use canton_proto_rs::com::daml::ledger::api::v2::interactive::{
+    HashingSchemeVersion, PrepareSubmissionResponse, PreparedTransaction,
+};
+
+use crate::{
+    canton_hash::encoding::{Encoder, required},
+    error::Result,
+};
+
+/// The hashing scheme versions this implementation covers.
+///
+/// Protocol version 34 supports V2; 35 supports V2 and V3. V4 is
+/// development-protocol only and adds exercise external-call results to the
+/// hash, so it is deliberately absent: a peer that cannot reproduce a hash
+/// must refuse to sign it, not approximate it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HashingScheme {
+    V2,
+    V3,
+}
+
+impl std::fmt::Display for HashingScheme {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::V2 => f.write_str("V2"),
+            Self::V3 => f.write_str("V3"),
+        }
+    }
+}
+
+impl HashingScheme {
+    /// The scheme's byte in the final hash preimage.
+    fn version_byte(self) -> u8 {
+        match self {
+            Self::V2 => 0x02,
+            Self::V3 => 0x03,
+        }
+    }
+
+    /// Map the version the preparing participant reported.
+    ///
+    /// # Errors
+    ///
+    /// Errors for any version this implementation does not cover.
+    pub fn from_proto(version: i32) -> Result<Self> {
+        match HashingSchemeVersion::try_from(version) {
+            Ok(HashingSchemeVersion::V2) => Ok(Self::V2),
+            Ok(HashingSchemeVersion::V3) => Ok(Self::V3),
+            Ok(other) => anyhow::bail!(
+                "hashing scheme {name} is not supported; the transaction hash cannot be \
+                 verified, so it will not be signed",
+                name = other.as_str_name()
+            ),
+            Err(_) => anyhow::bail!(
+                "unknown hashing scheme version {version}; the transaction hash cannot be \
+                 verified, so it will not be signed"
+            ),
+        }
+    }
+}
+
+/// Recompute the hash a peer is asked to sign from the transaction itself.
+///
+/// # Errors
+///
+/// Errors if the transaction is malformed, or if it uses a feature the given
+/// scheme does not hash.
+pub fn compute_prepared_transaction_hash(
+    scheme: HashingScheme,
+    prepared: &PreparedTransaction,
+) -> Result<Vec<u8>> {
+    let transaction = required(prepared.transaction.as_ref(), "transaction")?;
+    let metadata = required(prepared.metadata.as_ref(), "metadata")?;
+
+    let transaction_hash = nodes::hash_transaction(scheme, transaction)?;
+    let metadata_hash = metadata::hash_metadata(scheme, metadata)?;
+
+    let mut encoder = Encoder::with_purpose();
+    encoder.byte(scheme.version_byte());
+    encoder.add_hash(&transaction_hash);
+    encoder.add_hash(&metadata_hash);
+    Ok(encoder.digest().to_vec())
+}
+
+/// Check that the hash a coordinator asks a peer to sign is really the hash of
+/// the transaction it sent alongside it.
+///
+/// # Errors
+///
+/// Errors if the response is malformed, if the scheme is one this
+/// implementation cannot reproduce, or if the recomputed hash differs from the
+/// supplied one — the case that means the coordinator is showing one
+/// transaction and asking for a signature over another.
+pub fn verify_prepared_submission(response: &PrepareSubmissionResponse) -> Result {
+    let scheme = HashingScheme::from_proto(response.hashing_scheme_version)?;
+    let prepared = required(
+        response.prepared_transaction.as_ref(),
+        "prepared transaction",
+    )?;
+    let recomputed = compute_prepared_transaction_hash(scheme, prepared)?;
+
+    if recomputed != response.prepared_transaction_hash {
+        anyhow::bail!(
+            "prepared transaction hash mismatch: the coordinator asked for a signature over \
+             {supplied} but the transaction it sent hashes to {recomputed} under scheme \
+             {scheme}",
+            supplied = hex::encode(&response.prepared_transaction_hash),
+            recomputed = hex::encode(&recomputed),
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use canton_proto_rs::com::daml::ledger::api::v2::{
+        Identifier, Value,
+        interactive::{
+            DamlTransaction, GlobalKey, GlobalKeyWithMaintainers, Metadata,
+            daml_transaction::{self, NodeSeed},
+            metadata::{InputContract, SubmitterInfo, input_contract},
+            transaction::v1::{self, Create, Exercise, Fetch, Rollback},
+        },
+        value,
+    };
+
+    use super::*;
+
+    // Fixtures mirroring Canton's `BaseNodeHashTest` / `HashUtilsTest`, so the
+    // expected hashes below are Canton's own, lifted from its test suite at
+    // tag v3.5.8. If this port drifts from Canton's encoding, these fail.
+    const CONTRACT_ID_1: &str =
+        "0007e7b5534931dfca8e1b485c105bae4e10808bd13ddc8e897f258015f9d921c5";
+    const CONTRACT_ID_2: &str =
+        "0059b59ad7a6b6066e77b91ced54b8282f0e24e7089944685cb8f22f32fcbc4e1b";
+    const DUMMY_ARG_CONTRACT_ID: &str =
+        "0097a092402108f5593bac7fb3c909cd316910197dd98d603042a45ab85c81e0fd";
+    const SEED_CREATE: &str = "926bbb6f341bc0092ae65d06c6e284024907148cc29543ef6bff0930f5d52c19";
+    const SEED_FETCH: &str = "4d2a522e9ee44e31b9bef2e3c8a07d43475db87463c6a13c4ea92f898ac8a930";
+    const SEED_EXERCISE: &str = "a867edafa1277f46f879ab92c373a15c2d75c5d86fec741705cee1eb01ef8c9e";
+    const SEED_ROLLBACK: &str = "5483d5df9b245e662c0e4368b8062e8a0fd24c17ce4ded1a0e452e4ee879dd81";
+    const GLOBAL_KEY_HASH: &str =
+        "4d1741d27564ab1f1e74873034760583a1a71edaa90dbad6be3a78c0bf3eec7c";
+    const PACKAGE_NAME_0: &str = "package-name-0";
+
+    fn parties(names: &[&str]) -> Vec<String> {
+        names.iter().map(|n| (*n).to_string()).collect()
+    }
+
+    fn text(value: &str) -> Value {
+        Value {
+            sum: Some(value::Sum::Text(value.to_string())),
+        }
+    }
+
+    fn identifier(module: &str, name: &str) -> Identifier {
+        Identifier {
+            package_id: "package".to_string(),
+            module_name: module.to_string(),
+            entity_name: name.to_string(),
+        }
+    }
+
+    fn seed(node_id: i32, hex_seed: &str) -> Result<NodeSeed> {
+        Ok(NodeSeed {
+            node_id,
+            seed: hex::decode(hex_seed)?,
+        })
+    }
+
+    fn global_key() -> Result<GlobalKeyWithMaintainers> {
+        Ok(GlobalKeyWithMaintainers {
+            key: Some(GlobalKey {
+                template_id: Some(identifier("module_key", "name")),
+                package_name: "package_name_key".to_string(),
+                key: Some(text("hello")),
+                hash: hex::decode(GLOBAL_KEY_HASH)?,
+            }),
+            maintainers: parties(&["david"]),
+        })
+    }
+
+    fn create_node(lf_version: &str, contract_id: &str) -> Create {
+        Create {
+            lf_version: lf_version.to_string(),
+            contract_id: contract_id.to_string(),
+            package_name: PACKAGE_NAME_0.to_string(),
+            template_id: Some(identifier("module", "name")),
+            argument: Some(text("hello")),
+            signatories: parties(&["alice", "bob"]),
+            stakeholders: parties(&["alice", "charlie"]),
+            key: None,
+        }
+    }
+
+    fn fetch_node(lf_version: &str, contract_id: &str) -> Fetch {
+        Fetch {
+            lf_version: lf_version.to_string(),
+            contract_id: contract_id.to_string(),
+            package_name: PACKAGE_NAME_0.to_string(),
+            template_id: Some(identifier("module", "name")),
+            signatories: parties(&["alice"]),
+            stakeholders: parties(&["charlie"]),
+            acting_parties: parties(&["alice", "bob"]),
+            interface_id: None,
+            key: None,
+            by_key: false,
+        }
+    }
+
+    fn exercise_node(lf_version: &str) -> Exercise {
+        Exercise {
+            lf_version: lf_version.to_string(),
+            contract_id: CONTRACT_ID_1.to_string(),
+            package_name: PACKAGE_NAME_0.to_string(),
+            template_id: Some(identifier("module", "name")),
+            signatories: parties(&["alice"]),
+            stakeholders: parties(&["charlie"]),
+            acting_parties: parties(&["alice", "bob"]),
+            interface_id: Some(identifier("interface_module", "interface_name")),
+            choice_id: "choice".to_string(),
+            chosen_value: Some(Value {
+                sum: Some(value::Sum::Int64(31380)),
+            }),
+            consuming: true,
+            children: vec!["0".to_string(), "2".to_string()],
+            exercise_result: Some(text("result")),
+            choice_observers: parties(&["david"]),
+            key: None,
+            by_key: false,
+            external_call_results: Vec::new(),
+        }
+    }
+
+    fn node(node_id: &str, node_type: v1::node::NodeType) -> daml_transaction::Node {
+        daml_transaction::Node {
+            node_id: node_id.to_string(),
+            versioned_node: Some(daml_transaction::node::VersionedNode::V1(v1::Node {
+                node_type: Some(node_type),
+            })),
+        }
+    }
+
+    /// Canton's `subNodesMap`: create(0), create2(1), fetch(2), fetch2(3),
+    /// exercise(4), rollback(5), with the exercise rooted at create+fetch and
+    /// the rollback at fetch2+exercise.
+    fn transaction(scheme: HashingScheme) -> Result<DamlTransaction> {
+        let lf_version = match scheme {
+            HashingScheme::V2 => "2.1",
+            HashingScheme::V3 => "2",
+        };
+        let (create, fetch, exercise) = match scheme {
+            HashingScheme::V2 => (
+                create_node(lf_version, CONTRACT_ID_1),
+                fetch_node(lf_version, CONTRACT_ID_1),
+                exercise_node(lf_version),
+            ),
+            // V3's suite adds a contract key to create/fetch and exercises
+            // by key.
+            HashingScheme::V3 => {
+                let mut create = create_node(lf_version, CONTRACT_ID_1);
+                create.key = Some(global_key()?);
+                let mut fetch = fetch_node(lf_version, CONTRACT_ID_1);
+                fetch.key = Some(global_key()?);
+                fetch.by_key = true;
+                let mut exercise = exercise_node(lf_version);
+                exercise.key = Some(global_key()?);
+                exercise.by_key = true;
+                (create, fetch, exercise)
+            }
+        };
+
+        Ok(DamlTransaction {
+            version: lf_version.to_string(),
+            roots: vec!["0".to_string(), "5".to_string()],
+            nodes: vec![
+                node("0", v1::node::NodeType::Create(create)),
+                node(
+                    "1",
+                    v1::node::NodeType::Create(create_node(lf_version, CONTRACT_ID_2)),
+                ),
+                node("2", v1::node::NodeType::Fetch(fetch)),
+                node(
+                    "3",
+                    v1::node::NodeType::Fetch(fetch_node(lf_version, CONTRACT_ID_2)),
+                ),
+                node("4", v1::node::NodeType::Exercise(exercise)),
+                node(
+                    "5",
+                    v1::node::NodeType::Rollback(Rollback {
+                        children: vec!["2".to_string(), "4".to_string()],
+                    }),
+                ),
+            ],
+            node_seeds: vec![
+                seed(0, SEED_CREATE)?,
+                seed(2, SEED_FETCH)?,
+                seed(4, SEED_EXERCISE)?,
+                seed(5, SEED_ROLLBACK)?,
+            ],
+        })
+    }
+
+    /// Canton's `HashUtilsTest.metadata`.
+    fn metadata(scheme: HashingScheme) -> Metadata {
+        let lf_version = match scheme {
+            HashingScheme::V2 => "2.1",
+            HashingScheme::V3 => "2",
+        };
+        let disclosed = |contract_id: &str, party: &str, created_at: u64| InputContract {
+            created_at,
+            event_blob: Vec::new(),
+            contract: Some(input_contract::Contract::V1(Create {
+                lf_version: lf_version.to_string(),
+                contract_id: contract_id.to_string(),
+                package_name: "PkgName".to_string(),
+                template_id: Some(Identifier {
+                    package_id: "-dummyPkg-".to_string(),
+                    module_name: "DummyModule".to_string(),
+                    entity_name: "dummyName".to_string(),
+                }),
+                argument: Some(Value {
+                    sum: Some(value::Sum::ContractId(DUMMY_ARG_CONTRACT_ID.to_string())),
+                }),
+                signatories: parties(&[party]),
+                stakeholders: parties(&[party]),
+                key: None,
+            })),
+        };
+
+        Metadata {
+            submitter_info: Some(SubmitterInfo {
+                act_as: parties(&["alice", "bob"]),
+                command_id: "command-id".to_string(),
+            }),
+            synchronizer_id: "synchronizer::id".to_string(),
+            mediator_group: 0,
+            transaction_uuid: "4c6471d3-4e09-49dd-addf-6cd90e19c583".to_string(),
+            preparation_time: 0,
+            input_contracts: vec![
+                disclosed(CONTRACT_ID_1, "alice", 864_000_000_000),
+                disclosed(CONTRACT_ID_2, "bob", 1_728_000_000_000),
+            ],
+            min_ledger_effective_time: Some(0xaaaa),
+            max_ledger_effective_time: Some(0xbbbb),
+            // Only hashed by V3; Canton's V3 suite sets it to 30 days.
+            max_record_time: Some(2_592_000_000_000),
+            ..Metadata::default()
+        }
+    }
+
+    fn prepared(scheme: HashingScheme) -> Result<PreparedTransaction> {
+        Ok(PreparedTransaction {
+            transaction: Some(transaction(scheme)?),
+            metadata: Some(metadata(scheme)),
+        })
+    }
+
+    // ---------------------------------------------------------------------
+    // Golden vectors from Canton v3.5.8's own hashing test suites.
+    // ---------------------------------------------------------------------
+
+    /// Per-node hashes, so a drift in one node kind names itself instead of
+    /// only showing up as a different transaction hash.
+    #[test]
+    fn matches_canton_v2_node_hashes() -> Result {
+        let transaction = transaction(HashingScheme::V2)?;
+        let hasher = nodes::NodeHasher::new(HashingScheme::V2, &transaction)?;
+        assert_eq!(
+            hex::encode(hasher.hash_node_id("0")?),
+            "6d2cfe58c2294000592034f4bdfe397fe246901bb8b63e3b9e041bb478e174b7",
+            "create node"
+        );
+        assert_eq!(
+            hex::encode(hasher.hash_node_id("2")?),
+            "c962c6098394f3d11cd6f0c795de9517d32a8e3e1979cec76cd2f66254efc610",
+            "fetch node"
+        );
+        assert_eq!(
+            hex::encode(hasher.hash_node_id("4")?),
+            "070970eb4b2de72561dafb67017ca33850650a8103e5134e16044ba78991f48c",
+            "exercise node"
+        );
+        assert_eq!(
+            hex::encode(hasher.hash_node_id("5")?),
+            "7264d5da2fd714427453bedc0d1cdb21f52ac7aec8d4bb5ac0598d25c5fcaed9",
+            "rollback node"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn matches_canton_v3_node_hashes() -> Result {
+        let transaction = transaction(HashingScheme::V3)?;
+        let hasher = nodes::NodeHasher::new(HashingScheme::V3, &transaction)?;
+        assert_eq!(
+            hex::encode(hasher.hash_node_id("0")?),
+            "0120d370509f54c07d8209f5af2d23f7f972997deb5fc5e0ebe886354395a3bc",
+            "create node"
+        );
+        assert_eq!(
+            hex::encode(hasher.hash_node_id("2")?),
+            "20437df1980bb7d4d94ad53181dc6005bae37b5990719070c48a3960e8dda3a4",
+            "fetch node"
+        );
+        assert_eq!(
+            hex::encode(hasher.hash_node_id("4")?),
+            "516c4689acabf9d1f0087a02a7dafad884d9080c48112a57a6d20b9f72d4b697",
+            "exercise node"
+        );
+        assert_eq!(
+            hex::encode(hasher.hash_node_id("5")?),
+            "ea61ab05f9ab9769ab5c91493a601ccad9e784bd4c0b3bc4b7777f0da68eab4d",
+            "rollback node"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn matches_canton_v2_transaction_hash() -> Result {
+        let transaction = transaction(HashingScheme::V2)?;
+        let hash = nodes::hash_transaction(HashingScheme::V2, &transaction)?;
+        assert_eq!(
+            hex::encode(hash),
+            "154f334d24a8a5e4d0ce51ac87d93821b3256f885f21d3f779a1640abf481983"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn matches_canton_v2_metadata_hash() -> Result {
+        let hash = metadata::hash_metadata(HashingScheme::V2, &metadata(HashingScheme::V2))?;
+        assert_eq!(
+            hex::encode(hash),
+            "6e89fcbcc9605179a47919b5e65a864e470e7a133f4f9f39b1e4545b223db769"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn matches_canton_v2_full_hash() -> Result {
+        let hash =
+            compute_prepared_transaction_hash(HashingScheme::V2, &prepared(HashingScheme::V2)?)?;
+        assert_eq!(
+            hex::encode(hash),
+            "8c311c848db25d36b36fbd59f9483714a11688c2214e3c7cae3e028763520250"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn matches_canton_v3_transaction_hash() -> Result {
+        let transaction = transaction(HashingScheme::V3)?;
+        let hash = nodes::hash_transaction(HashingScheme::V3, &transaction)?;
+        assert_eq!(
+            hex::encode(hash),
+            "36f0d1f4e9742a5cf54795fd1633f46b8235fafa93da006dafe10eb358d465c4"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn matches_canton_v3_metadata_hash() -> Result {
+        let hash = metadata::hash_metadata(HashingScheme::V3, &metadata(HashingScheme::V3))?;
+        assert_eq!(
+            hex::encode(hash),
+            "5a4c6aa89bb80d0af05a3f0614ba07bc7469795fff66d7b9e87c876eb0137e0a"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn matches_canton_v3_full_hash() -> Result {
+        let hash =
+            compute_prepared_transaction_hash(HashingScheme::V3, &prepared(HashingScheme::V3)?)?;
+        assert_eq!(
+            hex::encode(hash),
+            "db37e4e251b83196260900fd43aacf934e1893b7ac58db4c1bfa8ced432b3b84"
+        );
+        Ok(())
+    }
+
+    // ---------------------------------------------------------------------
+    // Adversarial cases: the tampering a compromised coordinator would try.
+    // ---------------------------------------------------------------------
+
+    fn response(scheme: HashingScheme) -> Result<PrepareSubmissionResponse> {
+        let prepared = prepared(scheme)?;
+        Ok(PrepareSubmissionResponse {
+            prepared_transaction_hash: compute_prepared_transaction_hash(scheme, &prepared)?,
+            prepared_transaction: Some(prepared),
+            hashing_scheme_version: match scheme {
+                HashingScheme::V2 => HashingSchemeVersion::V2 as i32,
+                HashingScheme::V3 => HashingSchemeVersion::V3 as i32,
+            },
+            hashing_details: None,
+            cost_estimation: None,
+        })
+    }
+
+    #[test]
+    fn accepts_a_faithful_response() -> Result {
+        verify_prepared_submission(&response(HashingScheme::V2)?)?;
+        verify_prepared_submission(&response(HashingScheme::V3)?)?;
+        Ok(())
+    }
+
+    /// The core attack: show a benign transaction, ask for a signature over
+    /// the hash of a different one.
+    #[test]
+    fn rejects_a_hash_that_does_not_belong_to_the_transaction() -> Result {
+        let mut response = response(HashingScheme::V2)?;
+        response.prepared_transaction_hash = vec![0x42; 32];
+        assert!(verify_prepared_submission(&response).is_err());
+        Ok(())
+    }
+
+    /// Swapping the payee on a create must change the hash.
+    #[test]
+    fn rejects_a_tampered_signatory() -> Result {
+        let mut response = response(HashingScheme::V2)?;
+        let prepared = required(response.prepared_transaction.as_mut(), "transaction")?;
+        let transaction = required(prepared.transaction.as_mut(), "transaction")?;
+        let node = required(transaction.nodes.first_mut(), "first node")?;
+        let Some(daml_transaction::node::VersionedNode::V1(inner)) = node.versioned_node.as_mut()
+        else {
+            anyhow::bail!("expected a v1 node");
+        };
+        let Some(v1::node::NodeType::Create(create)) = inner.node_type.as_mut() else {
+            anyhow::bail!("expected a create node");
+        };
+        create.signatories = parties(&["alice", "mallory"]);
+
+        assert!(verify_prepared_submission(&response).is_err());
+        Ok(())
+    }
+
+    /// Redirecting the transaction at a different synchronizer must change
+    /// the hash — metadata is signed too.
+    #[test]
+    fn rejects_tampered_metadata() -> Result {
+        let mut response = response(HashingScheme::V3)?;
+        let prepared = required(response.prepared_transaction.as_mut(), "transaction")?;
+        let metadata = required(prepared.metadata.as_mut(), "metadata")?;
+        metadata.synchronizer_id = "other::synchronizer".to_string();
+
+        assert!(verify_prepared_submission(&response).is_err());
+        Ok(())
+    }
+
+    /// A coordinator must not be able to buy a weaker check by claiming a
+    /// scheme we cannot reproduce.
+    #[test]
+    fn rejects_an_unsupported_scheme() -> Result {
+        let mut response = response(HashingScheme::V3)?;
+        response.hashing_scheme_version = HashingSchemeVersion::V4 as i32;
+        assert!(verify_prepared_submission(&response).is_err());
+
+        response.hashing_scheme_version = HashingSchemeVersion::Unspecified as i32;
+        assert!(verify_prepared_submission(&response).is_err());
+        Ok(())
+    }
+
+    /// Contract keys are not covered by V2, so a V2 payload carrying one must
+    /// be refused rather than hashed without it.
+    #[test]
+    fn rejects_v3_only_fields_under_v2() -> Result {
+        let mut prepared = prepared(HashingScheme::V2)?;
+        let transaction = required(prepared.transaction.as_mut(), "transaction")?;
+        let node = required(transaction.nodes.first_mut(), "first node")?;
+        let Some(daml_transaction::node::VersionedNode::V1(inner)) = node.versioned_node.as_mut()
+        else {
+            anyhow::bail!("expected a v1 node");
+        };
+        let Some(v1::node::NodeType::Create(create)) = inner.node_type.as_mut() else {
+            anyhow::bail!("expected a create node");
+        };
+        create.key = Some(global_key()?);
+
+        assert!(compute_prepared_transaction_hash(HashingScheme::V2, &prepared).is_err());
+        Ok(())
+    }
+
+    /// A cyclic tree must be reported, not followed until the stack runs out.
+    #[test]
+    fn rejects_a_cyclic_transaction_tree() -> Result {
+        let mut prepared = prepared(HashingScheme::V2)?;
+        let transaction = required(prepared.transaction.as_mut(), "transaction")?;
+        transaction.roots = vec!["5".to_string()];
+        transaction.nodes = vec![node(
+            "5",
+            v1::node::NodeType::Rollback(Rollback {
+                children: vec!["5".to_string()],
+            }),
+        )];
+
+        let error = compute_prepared_transaction_hash(HashingScheme::V2, &prepared)
+            .err()
+            .map(|e| e.to_string())
+            .unwrap_or_default();
+        assert!(error.contains("cyclically"), "unexpected error: {error}");
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_a_missing_node() -> Result {
+        let mut prepared = prepared(HashingScheme::V2)?;
+        let transaction = required(prepared.transaction.as_mut(), "transaction")?;
+        transaction.roots = vec!["nope".to_string()];
+        assert!(compute_prepared_transaction_hash(HashingScheme::V2, &prepared).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_duplicate_node_ids() -> Result {
+        let mut prepared = prepared(HashingScheme::V2)?;
+        let transaction = required(prepared.transaction.as_mut(), "transaction")?;
+        let duplicate = node(
+            "0",
+            v1::node::NodeType::Rollback(Rollback {
+                children: Vec::new(),
+            }),
+        );
+        transaction.nodes.push(duplicate);
+        assert!(compute_prepared_transaction_hash(HashingScheme::V2, &prepared).is_err());
+        Ok(())
+    }
+
+    /// An exercise node without its seed cannot be hashed the way Canton
+    /// does, so it must not be signed.
+    #[test]
+    fn rejects_an_exercise_without_a_seed() -> Result {
+        let mut prepared = prepared(HashingScheme::V2)?;
+        let transaction = required(prepared.transaction.as_mut(), "transaction")?;
+        transaction.node_seeds.retain(|seed| seed.node_id != 4);
+        assert!(compute_prepared_transaction_hash(HashingScheme::V2, &prepared).is_err());
+        Ok(())
+    }
+}

--- a/crates/decman/src/canton_hash/mod.rs
+++ b/crates/decman/src/canton_hash/mod.rs
@@ -626,6 +626,42 @@ mod tests {
         Ok(())
     }
 
+    /// A chain where every node names the same child twice is a DAG, not a
+    /// cycle, so the path guard lets it through. Without memoisation it costs
+    /// 2^depth work — this shape would not finish in the lifetime of the
+    /// universe, so the test completing at all is the assertion.
+    #[test]
+    fn hashes_a_doubling_dag_without_exponential_work() -> Result {
+        const LEVELS: usize = 64;
+
+        let mut nodes = Vec::with_capacity(LEVELS + 1);
+        for level in 0..LEVELS {
+            nodes.push(node(
+                &level.to_string(),
+                v1::node::NodeType::Rollback(Rollback {
+                    // The same child twice: 2^LEVELS paths through the tree,
+                    // but only LEVELS distinct nodes to hash.
+                    children: vec![(level + 1).to_string(), (level + 1).to_string()],
+                }),
+            ));
+        }
+        nodes.push(node(
+            &LEVELS.to_string(),
+            v1::node::NodeType::Create(create_node("2.1", CONTRACT_ID_1)),
+        ));
+
+        let transaction = DamlTransaction {
+            version: "2.1".to_string(),
+            roots: vec!["0".to_string()],
+            nodes,
+            node_seeds: vec![seed(LEVELS as i32, SEED_CREATE)?],
+        };
+
+        let hasher = nodes::NodeHasher::new(HashingScheme::V2, &transaction)?;
+        assert_eq!(hasher.hash_node_id("0")?.len(), 32);
+        Ok(())
+    }
+
     #[test]
     fn rejects_a_missing_node() -> Result {
         let mut prepared = prepared(HashingScheme::V2)?;

--- a/crates/decman/src/canton_hash/nodes.rs
+++ b/crates/decman/src/canton_hash/nodes.rs
@@ -4,7 +4,10 @@
 //! (`community/base/.../protocol/hash/`), cross-checked against the reference
 //! Python implementations Canton ships with the interactive-submission example.
 
-use std::collections::{HashMap, HashSet};
+use std::{
+    cell::RefCell,
+    collections::{HashMap, HashSet},
+};
 
 use canton_proto_rs::com::daml::ledger::api::v2::interactive::{
     DamlTransaction, GlobalKeyWithMaintainers,
@@ -43,6 +46,14 @@ pub(super) struct NodeHasher<'a> {
     scheme: HashingScheme,
     nodes: HashMap<&'a str, &'a Node>,
     seeds: HashMap<String, &'a [u8]>,
+    /// Completed node hashes, keyed by node id.
+    ///
+    /// A node's hash depends only on the node and the subtree below it, so it
+    /// is the same every time it is referenced. Without this, a transaction
+    /// whose nodes each name the same child twice costs 2^depth work — the
+    /// depth limit alone caps that at 2^100, which an untrusted coordinator
+    /// could use to stall a peer inside hash verification.
+    memo: RefCell<HashMap<String, [u8; 32]>>,
 }
 
 impl<'a> NodeHasher<'a> {
@@ -75,6 +86,7 @@ impl<'a> NodeHasher<'a> {
             scheme,
             nodes,
             seeds,
+            memo: RefCell::new(HashMap::new()),
         })
     }
 
@@ -94,6 +106,12 @@ impl<'a> NodeHasher<'a> {
         if depth > MAX_NODE_DEPTH {
             anyhow::bail!("transaction tree exceeds the {MAX_NODE_DEPTH} level depth limit");
         }
+        if let Some(hash) = self.memo.borrow().get(node_id) {
+            return Ok(*hash);
+        }
+        // The path set still guards recursion, so a genuine cycle is reported
+        // rather than served from the memo: a node only reaches the memo once
+        // its whole subtree has been hashed without revisiting it.
         if !path.insert(node_id.to_string()) {
             anyhow::bail!("transaction tree references node {node_id} cyclically");
         }
@@ -103,7 +121,9 @@ impl<'a> NodeHasher<'a> {
             .ok_or_else(|| anyhow::anyhow!("transaction references missing node {node_id}"))?;
         let encoded = self.encode_node(node, node_id, depth, path)?;
         path.remove(node_id);
-        Ok(sha256(&encoded))
+        let hash = sha256(&encoded);
+        self.memo.borrow_mut().insert(node_id.to_string(), hash);
+        Ok(hash)
     }
 
     /// Hash a create node that is not part of the transaction tree — the
@@ -114,6 +134,7 @@ impl<'a> NodeHasher<'a> {
             scheme,
             nodes: HashMap::new(),
             seeds: HashMap::new(),
+            memo: RefCell::new(HashMap::new()),
         };
         let mut encoder = hasher.new_node_encoder();
         hasher.encode_create(&mut encoder, create, None)?;

--- a/crates/decman/src/canton_hash/nodes.rs
+++ b/crates/decman/src/canton_hash/nodes.rs
@@ -1,0 +1,360 @@
+//! Transaction-node encoding for the interactive-submission hashing scheme.
+//!
+//! Port of Canton's `NodeHashBuilderCommon` plus the `v2` / `v3` overrides
+//! (`community/base/.../protocol/hash/`), cross-checked against the reference
+//! Python implementations Canton ships with the interactive-submission example.
+
+use std::collections::{HashMap, HashSet};
+
+use canton_proto_rs::com::daml::ledger::api::v2::interactive::{
+    DamlTransaction, GlobalKeyWithMaintainers,
+    daml_transaction::{NodeSeed, node::VersionedNode},
+    transaction::v1::{Create, Exercise, Fetch, Node, QueryByKey, Rollback, node::NodeType},
+};
+
+use crate::{
+    canton_hash::{
+        HashingScheme,
+        encoding::{Encoder, required, sha256},
+    },
+    error::Result,
+};
+
+/// Node tags. A node's kind is part of its encoding so two different node
+/// kinds can never hash alike.
+const CREATE_TAG: u8 = 0x00;
+const EXERCISE_TAG: u8 = 0x01;
+const FETCH_TAG: u8 = 0x02;
+const ROLLBACK_TAG: u8 = 0x03;
+const QUERY_BY_KEY_TAG: u8 = 0x04;
+
+/// V2 prefixes every node with the version of the protobuf used to encode it.
+/// V3 dropped the prefix (it carries no security value — see the comment on
+/// `NodeEncodingV1` in Canton's `v2/NodeHashBuilder.scala`).
+const NODE_ENCODING_V1: u8 = 0x01;
+
+/// Depth limit on the node tree. The transaction comes from a coordinator we
+/// are explicitly not trusting, so a pathological tree must fail rather than
+/// exhaust the stack. Canton's own transactions are far shallower.
+const MAX_NODE_DEPTH: usize = 100;
+
+/// Resolves node references while hashing a transaction tree.
+pub(super) struct NodeHasher<'a> {
+    scheme: HashingScheme,
+    nodes: HashMap<&'a str, &'a Node>,
+    seeds: HashMap<String, &'a [u8]>,
+}
+
+impl<'a> NodeHasher<'a> {
+    /// Index a transaction's nodes and seeds for lookup by node id.
+    ///
+    /// # Errors
+    ///
+    /// Errors if two nodes share a node id — the references in `roots` and in
+    /// `children` would then be ambiguous, and picking either one would mean
+    /// hashing something other than what the sender meant.
+    pub(super) fn new(scheme: HashingScheme, transaction: &'a DamlTransaction) -> Result<Self> {
+        let mut nodes = HashMap::with_capacity(transaction.nodes.len());
+        for node in &transaction.nodes {
+            let VersionedNode::V1(inner) = required(
+                node.versioned_node.as_ref(),
+                "versioned node (only v1 nodes are supported)",
+            )?;
+            if nodes.insert(node.node_id.as_str(), inner).is_some() {
+                anyhow::bail!("duplicate node id {id} in transaction", id = node.node_id);
+            }
+        }
+
+        let seeds = transaction
+            .node_seeds
+            .iter()
+            .map(|NodeSeed { node_id, seed }| (node_id.to_string(), seed.as_slice()))
+            .collect();
+
+        Ok(Self {
+            scheme,
+            nodes,
+            seeds,
+        })
+    }
+
+    /// Hash the node `node_id` refers to. This is how both root nodes and
+    /// child nodes enter an enclosing encoding: the node id itself is opaque
+    /// and is never hashed.
+    pub(super) fn hash_node_id(&self, node_id: &str) -> Result<[u8; 32]> {
+        self.hash_node_id_at(node_id, 0, &mut HashSet::new())
+    }
+
+    fn hash_node_id_at(
+        &self,
+        node_id: &str,
+        depth: usize,
+        path: &mut HashSet<String>,
+    ) -> Result<[u8; 32]> {
+        if depth > MAX_NODE_DEPTH {
+            anyhow::bail!("transaction tree exceeds the {MAX_NODE_DEPTH} level depth limit");
+        }
+        if !path.insert(node_id.to_string()) {
+            anyhow::bail!("transaction tree references node {node_id} cyclically");
+        }
+        let node = self
+            .nodes
+            .get(node_id)
+            .ok_or_else(|| anyhow::anyhow!("transaction references missing node {node_id}"))?;
+        let encoded = self.encode_node(node, node_id, depth, path)?;
+        path.remove(node_id);
+        Ok(sha256(&encoded))
+    }
+
+    /// Hash a create node that is not part of the transaction tree — the
+    /// input contracts carried in the metadata. Those have no node seed and
+    /// no children, so they need no node index.
+    pub(super) fn hash_detached_create(scheme: HashingScheme, create: &Create) -> Result<[u8; 32]> {
+        let hasher = Self {
+            scheme,
+            nodes: HashMap::new(),
+            seeds: HashMap::new(),
+        };
+        let mut encoder = hasher.new_node_encoder();
+        hasher.encode_create(&mut encoder, create, None)?;
+        Ok(encoder.digest())
+    }
+
+    /// V2 prefixes every node encoding — including the detached create nodes
+    /// in the metadata — with the node protobuf's encoding version.
+    fn new_node_encoder(&self) -> Encoder {
+        let mut encoder = Encoder::new();
+        if self.scheme == HashingScheme::V2 {
+            encoder.byte(NODE_ENCODING_V1);
+        }
+        encoder
+    }
+
+    fn encode_node(
+        &self,
+        node: &Node,
+        node_id: &str,
+        depth: usize,
+        path: &mut HashSet<String>,
+    ) -> Result<Vec<u8>> {
+        let mut encoder = self.new_node_encoder();
+        let node_type = required(node.node_type.as_ref(), "node type")?;
+        match node_type {
+            NodeType::Create(create) => {
+                self.encode_create(&mut encoder, create, self.seed(node_id))?;
+            }
+            NodeType::Fetch(fetch) => self.encode_fetch(&mut encoder, fetch)?,
+            NodeType::Exercise(exercise) => {
+                self.encode_exercise(&mut encoder, exercise, node_id, depth, path)?;
+            }
+            NodeType::Rollback(rollback) => {
+                self.encode_rollback(&mut encoder, rollback, depth, path)?;
+            }
+            NodeType::QueryByKey(query) => self.encode_query_by_key(&mut encoder, query)?,
+        }
+        Ok(encoder.into_bytes())
+    }
+
+    fn seed(&self, node_id: &str) -> Option<&'a [u8]> {
+        self.seeds.get(node_id).copied()
+    }
+
+    fn encode_create(
+        &self,
+        encoder: &mut Encoder,
+        create: &Create,
+        seed: Option<&[u8]>,
+    ) -> Result<()> {
+        encoder.string(&create.lf_version)?;
+        encoder.byte(CREATE_TAG);
+        match seed {
+            Some(seed) => {
+                encoder.byte(0x01);
+                encoder.add_hash(seed);
+            }
+            None => encoder.byte(0x00),
+        }
+        encoder.hex_string(&create.contract_id)?;
+        encoder.string(&create.package_name)?;
+        encoder.identifier(required(create.template_id.as_ref(), "create template id")?)?;
+        encoder.value(required(create.argument.as_ref(), "create argument")?)?;
+        encoder.string_set(&create.signatories)?;
+        encoder.string_set(&create.stakeholders)?;
+        self.encode_optional_key(encoder, create.key.as_ref(), "Create")
+    }
+
+    fn encode_fetch(&self, encoder: &mut Encoder, fetch: &Fetch) -> Result<()> {
+        encoder.string(&fetch.lf_version)?;
+        encoder.byte(FETCH_TAG);
+        encoder.hex_string(&fetch.contract_id)?;
+        encoder.string(&fetch.package_name)?;
+        encoder.identifier(required(fetch.template_id.as_ref(), "fetch template id")?)?;
+        encoder.string_set(&fetch.signatories)?;
+        encoder.string_set(&fetch.stakeholders)?;
+        encoder.optional(fetch.interface_id.as_ref(), Encoder::identifier)?;
+        encoder.string_set(&fetch.acting_parties)?;
+        self.encode_by_key(encoder, fetch.by_key, "Fetch")?;
+        self.encode_optional_key(encoder, fetch.key.as_ref(), "Fetch")
+    }
+
+    fn encode_exercise(
+        &self,
+        encoder: &mut Encoder,
+        exercise: &Exercise,
+        node_id: &str,
+        depth: usize,
+        path: &mut HashSet<String>,
+    ) -> Result<()> {
+        // External call results only exist on development-version nodes and
+        // are hashed from V4 on. Refuse rather than silently drop them from
+        // the hash: a field we do not hash is a field a coordinator can
+        // change without invalidating our signature.
+        if !exercise.external_call_results.is_empty() {
+            anyhow::bail!(
+                "exercise node carries external call results, which hashing scheme \
+                 {scheme} does not cover",
+                scheme = self.scheme
+            );
+        }
+        let seed = self
+            .seed(node_id)
+            .ok_or_else(|| anyhow::anyhow!("exercise node {node_id} has no node seed"))?;
+
+        encoder.string(&exercise.lf_version)?;
+        encoder.byte(EXERCISE_TAG);
+        encoder.add_hash(seed);
+        encoder.hex_string(&exercise.contract_id)?;
+        encoder.string(&exercise.package_name)?;
+        encoder.identifier(required(
+            exercise.template_id.as_ref(),
+            "exercise template id",
+        )?)?;
+        encoder.string_set(&exercise.signatories)?;
+        encoder.string_set(&exercise.stakeholders)?;
+        encoder.string_set(&exercise.acting_parties)?;
+        encoder.optional(exercise.interface_id.as_ref(), Encoder::identifier)?;
+        encoder.string(&exercise.choice_id)?;
+        encoder.value(required(
+            exercise.chosen_value.as_ref(),
+            "exercise chosen value",
+        )?)?;
+        encoder.bool(exercise.consuming);
+        encoder.optional(exercise.exercise_result.as_ref(), Encoder::value)?;
+        encoder.string_set(&exercise.choice_observers)?;
+        self.encode_by_key(encoder, exercise.by_key, "Exercise")?;
+        self.encode_optional_key(encoder, exercise.key.as_ref(), "Exercise")?;
+        self.encode_children(encoder, &exercise.children, depth, path)
+    }
+
+    fn encode_rollback(
+        &self,
+        encoder: &mut Encoder,
+        rollback: &Rollback,
+        depth: usize,
+        path: &mut HashSet<String>,
+    ) -> Result<()> {
+        encoder.byte(ROLLBACK_TAG);
+        self.encode_children(encoder, &rollback.children, depth, path)
+    }
+
+    fn encode_query_by_key(&self, encoder: &mut Encoder, query: &QueryByKey) -> Result<()> {
+        if self.scheme == HashingScheme::V2 {
+            anyhow::bail!("QueryByKey nodes are not supported by hashing scheme V2");
+        }
+        encoder.string(&query.lf_version)?;
+        encoder.byte(QUERY_BY_KEY_TAG);
+        encoder.string(&query.package_name)?;
+        encoder.identifier(required(query.template_id.as_ref(), "query template id")?)?;
+        encoder.bool(query.exhaustive);
+        encode_key_with_maintainers(encoder, required(query.key.as_ref(), "query key")?)?;
+        encoder.repeated(&query.result, |encoder, contract_id| {
+            encoder.hex_string(contract_id)
+        })
+    }
+
+    fn encode_children(
+        &self,
+        encoder: &mut Encoder,
+        children: &[String],
+        depth: usize,
+        path: &mut HashSet<String>,
+    ) -> Result<()> {
+        encoder.repeated(children, |encoder, child| {
+            let hash = self.hash_node_id_at(child, depth + 1, path)?;
+            encoder.add_hash(&hash);
+            Ok(())
+        })
+    }
+
+    /// Contract keys entered the hash in V3. A V2 payload carrying one would
+    /// hash without it, so refuse — exactly as Canton's V2 builder does.
+    fn encode_optional_key(
+        &self,
+        encoder: &mut Encoder,
+        key: Option<&GlobalKeyWithMaintainers>,
+        node_kind: &str,
+    ) -> Result<()> {
+        match self.scheme {
+            HashingScheme::V2 => {
+                if key.is_some() {
+                    anyhow::bail!(
+                        "{node_kind} node carries a contract key, which hashing scheme V2 \
+                         does not cover"
+                    );
+                }
+                Ok(())
+            }
+            HashingScheme::V3 => encoder.optional(key, encode_key_with_maintainers),
+        }
+    }
+
+    fn encode_by_key(&self, encoder: &mut Encoder, by_key: bool, node_kind: &str) -> Result<()> {
+        match self.scheme {
+            HashingScheme::V2 => {
+                if by_key {
+                    anyhow::bail!(
+                        "{node_kind} node is flagged by-key, which hashing scheme V2 does \
+                         not cover"
+                    );
+                }
+                Ok(())
+            }
+            HashingScheme::V3 => {
+                encoder.bool(by_key);
+                Ok(())
+            }
+        }
+    }
+}
+
+fn encode_key_with_maintainers(
+    encoder: &mut Encoder,
+    key: &GlobalKeyWithMaintainers,
+) -> Result<()> {
+    let global_key = required(key.key.as_ref(), "global key")?;
+    encoder.string(&global_key.package_name)?;
+    encoder.identifier(required(
+        global_key.template_id.as_ref(),
+        "key template id",
+    )?)?;
+    encoder.value(required(global_key.key.as_ref(), "key value")?)?;
+    encoder.add_hash(&global_key.hash);
+    encoder.string_set(&key.maintainers)
+}
+
+/// Hash the transaction tree: its serialization version followed by the hash
+/// of each root node.
+pub(super) fn hash_transaction(
+    scheme: HashingScheme,
+    transaction: &DamlTransaction,
+) -> Result<[u8; 32]> {
+    let hasher = NodeHasher::new(scheme, transaction)?;
+    let mut encoder = Encoder::with_purpose();
+    encoder.string(&transaction.version)?;
+    encoder.repeated(&transaction.roots, |encoder, root| {
+        let hash = hasher.hash_node_id(root)?;
+        encoder.add_hash(&hash);
+        Ok(())
+    })?;
+    Ok(encoder.digest())
+}

--- a/crates/decman/src/db/rows.rs
+++ b/crates/decman/src/db/rows.rs
@@ -190,6 +190,7 @@ pub struct PendingInvitationRow {
     pub prefix: Option<String>,
     pub participants: Option<String>,
     pub dar_filenames: Option<String>,
+    pub dar_hashes: Option<String>,
     pub kicked_participant: Option<String>,
     pub new_participant: Option<String>,
     pub new_threshold: Option<i64>,
@@ -237,6 +238,7 @@ impl PendingInvitationRow {
             prefix: inv.prefix.clone(),
             participants: encode_list(&inv.participants, "pending invitation participants")?,
             dar_filenames: encode_list(&inv.dar_filenames, "pending invitation dar_filenames")?,
+            dar_hashes: encode_list(&inv.dar_hashes, "pending invitation dar_hashes")?,
             kicked_participant: inv.kicked_participant.as_ref().map(|p| p.to_string()),
             new_participant: inv.new_participant.as_ref().map(|p| p.to_string()),
             new_threshold: inv.new_threshold.map(i64::from),
@@ -258,6 +260,7 @@ impl PendingInvitationRow {
             .with_context(|| format!("invalid invitation_type for id {}", self.id))?;
         let participants = decode_list(self.participants, &self.id, "participants")?;
         let dar_filenames = decode_list(self.dar_filenames, &self.id, "dar_filenames")?;
+        let dar_hashes = decode_list(self.dar_hashes, &self.id, "dar_hashes")?;
         let package_names = decode_list(self.package_names, &self.id, "package_names")?;
         let kicked_participant = self
             .kicked_participant
@@ -283,6 +286,7 @@ impl PendingInvitationRow {
             prefix: self.prefix,
             participants,
             dar_filenames,
+            dar_hashes,
             kicked_participant,
             new_participant,
             new_threshold: self.new_threshold.map(|v| v as i32),
@@ -460,6 +464,7 @@ mod tests {
             prefix: None,
             participants: None,
             dar_filenames: None,
+            dar_hashes: None,
             kicked_participant: None,
             new_participant: None,
             new_threshold: None,

--- a/crates/decman/src/db/sqlite.rs
+++ b/crates/decman/src/db/sqlite.rs
@@ -889,6 +889,7 @@ impl Commitable for sqlx::Transaction<'static, sqlx::Sqlite> {
                 prefix,
                 participants,
                 dar_filenames,
+                dar_hashes,
                 kicked_participant,
                 new_participant,
                 new_threshold,
@@ -896,7 +897,7 @@ impl Commitable for sqlx::Transaction<'static, sqlx::Sqlite> {
                 dec_party_id,
                 package_names,
                 workflow_instance
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ",
         )
         .bind(&row.id)
@@ -906,6 +907,7 @@ impl Commitable for sqlx::Transaction<'static, sqlx::Sqlite> {
         .bind(&row.prefix)
         .bind(&row.participants)
         .bind(&row.dar_filenames)
+        .bind(&row.dar_hashes)
         .bind(&row.kicked_participant)
         .bind(&row.new_participant)
         .bind(row.new_threshold)
@@ -2079,6 +2081,7 @@ mod tests {
                 CantonId::parse(&format!("node2::{TEST_NS}")).unwrap(),
             ],
             dar_filenames: Vec::new(),
+            dar_hashes: Vec::new(),
             kicked_participant: None,
             new_participant: None,
             new_threshold: None,
@@ -2096,6 +2099,7 @@ mod tests {
             prefix: None,
             participants: Vec::new(),
             dar_filenames: Vec::new(),
+            dar_hashes: Vec::new(),
             kicked_participant: Some(CantonId::parse(&format!("kicked::{TEST_NS}")).unwrap()),
             new_participant: None,
             new_threshold: Some(2),
@@ -2119,6 +2123,7 @@ mod tests {
             prefix: None,
             participants: Vec::new(),
             dar_filenames: vec!["app.dar".to_string(), "lib.dar".to_string()],
+            dar_hashes: Vec::new(),
             kicked_participant: None,
             new_participant: None,
             new_threshold: None,
@@ -2179,6 +2184,7 @@ mod tests {
                 CantonId::parse(&format!("node2::{TEST_NS}")).unwrap(),
             ],
             dar_filenames: Vec::new(),
+            dar_hashes: Vec::new(),
             kicked_participant: None,
             new_participant: None,
             new_threshold: None,
@@ -2761,6 +2767,7 @@ mod tests {
             prefix: Some("my-party".to_string()),
             participants: Vec::new(),
             dar_filenames: Vec::new(),
+            dar_hashes: Vec::new(),
             kicked_participant: None,
             new_participant: None,
             new_threshold: None,
@@ -2778,6 +2785,7 @@ mod tests {
             prefix: None,
             participants: Vec::new(),
             dar_filenames: vec!["app.dar".to_string()],
+            dar_hashes: Vec::new(),
             kicked_participant: None,
             new_participant: None,
             new_threshold: None,

--- a/crates/decman/src/lib.rs
+++ b/crates/decman/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod auth;
 pub mod build_info;
+pub mod canton_hash;
 pub mod config;
 pub mod consts;
 pub mod db;

--- a/crates/decman/src/server/handlers/invitations.rs
+++ b/crates/decman/src/server/handlers/invitations.rs
@@ -120,6 +120,7 @@ pub(crate) async fn insert_peer_run(
             "prefix": invitation.prefix,
             "participants": invitation.participants,
             "dar_filenames": invitation.dar_filenames,
+            "dar_hashes": invitation.dar_hashes,
             "participant_id": invitation.kicked_participant,
             "new_participant_id": invitation.new_participant,
             "new_threshold": invitation.new_threshold,

--- a/crates/decman/src/server/handlers/workflows.rs
+++ b/crates/decman/src/server/handlers/workflows.rs
@@ -2513,10 +2513,13 @@ pub async fn start_dars(
             .iter()
             .map(|f| f.filename.clone())
             .collect();
-        // Pin the content, not just the name: the invitation the operator
-        // sees carries the hash of the exact bytes the peers will be asked to
-        // upload and vet.
-        let dar_hashes: Vec<String> = dars_config
+        // Pin the content, not just the name: the invitation the operator sees
+        // carries the hash of the exact bytes the peers will be asked to upload
+        // and vet. An empty hash list is the wire signal for "coordinator
+        // predates the field", which makes peers fall back to checking
+        // filenames only — so a DAR we cannot decode has to fail the run rather
+        // than quietly downgrade every peer's check.
+        let dar_hashes: std::result::Result<Vec<String>, _> = dars_config
             .dar_files
             .iter()
             .map(|f| {
@@ -2524,23 +2527,23 @@ pub async fn start_dars(
                     .decode(&f.data)
                     .map(|bytes| workflow::validation::hash_dar(&bytes))
             })
-            .collect::<std::result::Result<_, _>>()
-            .unwrap_or_else(|e| {
-                tracing::warn!(
-                    "Could not hash the DARs for the invitation ({e}); peers will only be \
-                     able to check filenames"
-                );
-                Vec::new()
-            });
-        let invite_result = send_dars_invites(
-            &config,
-            &db,
-            &peer_ids,
-            &dar_filenames,
-            &dar_hashes,
-            &dars_config.instance_name,
-        )
-        .await;
+            .collect();
+        let invite_result = match dar_hashes {
+            Ok(dar_hashes) => {
+                send_dars_invites(
+                    &config,
+                    &db,
+                    &peer_ids,
+                    &dar_filenames,
+                    &dar_hashes,
+                    &dars_config.instance_name,
+                )
+                .await
+            }
+            Err(e) => Err(anyhow::anyhow!(
+                "Could not hash the DARs for the invitation: {e}"
+            )),
+        };
         if let Err(e) = invite_result {
             tracing::error!("Failed to send DARs invites: {e}");
             let mut status = dars_state_clone.status.write().await;

--- a/crates/decman/src/server/handlers/workflows.rs
+++ b/crates/decman/src/server/handlers/workflows.rs
@@ -7,6 +7,7 @@ use std::{
 use actix_web::{HttpRequest, HttpResponse, Responder, get, post, web};
 
 use anyhow::Context;
+use base64::{Engine, engine::general_purpose::STANDARD};
 use sqlx::SqlitePool;
 
 use super::parties::{
@@ -2512,11 +2513,31 @@ pub async fn start_dars(
             .iter()
             .map(|f| f.filename.clone())
             .collect();
+        // Pin the content, not just the name: the invitation the operator
+        // sees carries the hash of the exact bytes the peers will be asked to
+        // upload and vet.
+        let dar_hashes: Vec<String> = dars_config
+            .dar_files
+            .iter()
+            .map(|f| {
+                STANDARD
+                    .decode(&f.data)
+                    .map(|bytes| workflow::validation::hash_dar(&bytes))
+            })
+            .collect::<std::result::Result<_, _>>()
+            .unwrap_or_else(|e| {
+                tracing::warn!(
+                    "Could not hash the DARs for the invitation ({e}); peers will only be \
+                     able to check filenames"
+                );
+                Vec::new()
+            });
         let invite_result = send_dars_invites(
             &config,
             &db,
             &peer_ids,
             &dar_filenames,
+            &dar_hashes,
             &dars_config.instance_name,
         )
         .await;
@@ -2610,6 +2631,7 @@ async fn send_dars_invites(
     db: &SqlitePool,
     peer_ids: &[CantonId],
     dar_filenames: &[String],
+    dar_hashes: &[String],
     instance_name: &str,
 ) -> Result {
     let network_config = NetworkConfig::from_peers(db.get_all_peers().await?);
@@ -2617,6 +2639,7 @@ async fn send_dars_invites(
 
     let payload = DarsInvitePayload {
         dar_filenames: dar_filenames.to_vec(),
+        dar_hashes: dar_hashes.to_vec(),
         // Carry the member set so the peer card shows the same participant
         // list the coordinator shows.
         participants: peer_ids.to_vec(),

--- a/crates/decman/src/server/mod.rs
+++ b/crates/decman/src/server/mod.rs
@@ -541,6 +541,7 @@ impl WorkflowTriggers {
         let mut prefix = None;
         let mut participants = Vec::new();
         let mut dar_filenames = Vec::new();
+        let mut dar_hashes = Vec::new();
         let mut kicked_participant = None;
         let mut new_participant = None;
         let mut new_threshold = None;
@@ -558,6 +559,7 @@ impl WorkflowTriggers {
             }
             InvitationMeta::Dars(p) => {
                 dar_filenames = p.dar_filenames;
+                dar_hashes = p.dar_hashes;
                 participants = p.participants;
                 workflow_instance = p.workflow_instance;
             }
@@ -615,6 +617,7 @@ impl WorkflowTriggers {
             prefix,
             participants,
             dar_filenames,
+            dar_hashes,
             kicked_participant,
             new_participant,
             new_threshold,

--- a/crates/decman/src/utils.rs
+++ b/crates/decman/src/utils.rs
@@ -27,6 +27,7 @@ use canton_proto_rs::com::{
             GetIdRequest,
             identity_initialization_service_client::IdentityInitializationServiceClient,
         },
+        version::v1::{UntypedVersionedMessage, untyped_versioned_message},
     },
 };
 
@@ -101,6 +102,26 @@ pub fn read_first_message_from_bytes<M: Message + Default>(data: &[u8]) -> Resul
     let message_bytes = &cursor[..len];
     let message = M::decode(message_bytes)?;
     Ok(message)
+}
+
+/// Unwrap Canton's protocol-versioning envelope.
+///
+/// Canton wraps every protocol-versioned message in an
+/// `UntypedVersionedMessage`, so the bytes in e.g.
+/// `SignedTopologyTransaction::transaction` are the envelope, not the inner
+/// message. This peels one layer and decodes what is inside.
+///
+/// # Errors
+///
+/// Errors if the envelope or the message inside it fails to decode.
+pub fn decode_versioned<M: Message + Default>(bytes: &[u8]) -> Result<M> {
+    let versioned = UntypedVersionedMessage::decode(bytes)
+        .context("Failed to decode UntypedVersionedMessage envelope")?;
+    let inner = match versioned.wrapper {
+        Some(untyped_versioned_message::Wrapper::Data(data)) => data,
+        None => anyhow::bail!("UntypedVersionedMessage has no wrapper data"),
+    };
+    M::decode(inner.as_slice()).context("Failed to decode the versioned message payload")
 }
 
 /// Encode a single protobuf message as `varint(len)||proto` — the same

--- a/crates/decman/src/workflow/contracts/steps/sign.rs
+++ b/crates/decman/src/workflow/contracts/steps/sign.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use bytes::{Buf, BufMut, BytesMut};
 use canton_proto_rs::com::{
     daml::ledger::api::v2::interactive::PrepareSubmissionResponse,
@@ -20,6 +21,7 @@ use canton_proto_rs::com::{
 use sqlx::SqlitePool;
 
 use crate::{
+    canton_hash,
     canton_id::CantonId,
     config::NodeConfig,
     error::Result,
@@ -192,14 +194,27 @@ pub async fn sign_submissions(
     }
 
     // Decode the per-submission `varint(len)||proto` blobs.
+    //
+    // The coordinator prepared these, so the hash it wants signed is only
+    // trustworthy once we have recomputed it from the transaction beside it —
+    // otherwise it could show a harmless transaction and collect a signature
+    // over a different one. `verify_prepared_transaction` also pins the acting
+    // party, so a signature can only ever authorize the dec party this run is
+    // for.
     let mut prepared_submissions: Vec<PrepareSubmissionResponse> =
         Vec::with_capacity(submission_rows.len());
     for (ordinal, payload) in &submission_rows {
         let prepared_sub: PrepareSubmissionResponse =
             utils::read_first_message_from_bytes(payload)?;
+        verify_prepared_transaction(&prepared_sub, dec_party_id)
+            .with_context(|| format!("prepared submission {ordinal} failed validation"))?;
         tracing::debug!("Loaded prepared submission ordinal {ordinal}");
         prepared_submissions.push(prepared_sub);
     }
+    tracing::info!(
+        "Verified {count} prepared submission(s) against their transactions",
+        count = prepared_submissions.len()
+    );
 
     tracing::debug!(
         "Loaded {count} prepared submissions",
@@ -243,6 +258,43 @@ pub async fn sign_submissions(
     .await?;
 
     tracing::info!("Signatures saved successfully");
+    Ok(())
+}
+
+/// Check a coordinator-prepared submission before signing its hash.
+///
+/// Two things have to hold. The hash must be the hash of the transaction the
+/// coordinator sent — the Ledger API is explicit that a client must recompute
+/// it when the preparing participant is not trusted, and here it is the
+/// coordinator we are guarding against. And the transaction must act as the
+/// dec party this run is for, so a signature made with this node's key can
+/// only ever authorize that party.
+///
+/// # Errors
+///
+/// Errors if the hash does not belong to the transaction, if the hashing
+/// scheme is one this node cannot reproduce, or if the transaction acts as any
+/// party other than `dec_party_id`.
+fn verify_prepared_transaction(
+    prepared: &PrepareSubmissionResponse,
+    dec_party_id: &CantonId,
+) -> Result {
+    canton_hash::verify_prepared_submission(prepared)?;
+
+    let act_as = prepared
+        .prepared_transaction
+        .as_ref()
+        .and_then(|tx| tx.metadata.as_ref())
+        .and_then(|metadata| metadata.submitter_info.as_ref())
+        .map(|submitter| submitter.act_as.as_slice())
+        .unwrap_or_default();
+
+    let expected = dec_party_id.to_string();
+    if act_as != [expected.clone()] {
+        anyhow::bail!(
+            "prepared submission acts as {act_as:?}, but this run is for {expected} only"
+        );
+    }
     Ok(())
 }
 

--- a/crates/decman/src/workflow/contracts/steps/upload_dars.rs
+++ b/crates/decman/src/workflow/contracts/steps/upload_dars.rs
@@ -76,6 +76,12 @@ async fn upload_dar_bytes(
         .unwrap_or(filename)
         .to_string();
 
+    // `expected_main_package_id` is left unset: a peer already pins the whole
+    // DAR by SHA-256 against the hash in its accepted invitation
+    // (`workflow::validation::PeerExpectations::check_dars`) before it gets
+    // here, which covers every package in the file rather than just the main
+    // one. Deriving the main package id locally would need a DAR (zip) parser
+    // this crate does not carry.
     let request = tonic::Request::new(UploadDarRequest {
         dars: vec![UploadDarData {
             bytes: dar_data,

--- a/crates/decman/src/workflow/mod.rs
+++ b/crates/decman/src/workflow/mod.rs
@@ -367,6 +367,13 @@ pub async fn start_peer(
                         Ok(files) => files,
                         Err(e) => {
                             tracing::error!("Failed to decode DARs from coordinator: {e}");
+                            consecutive_step_failures += 1;
+                            if consecutive_step_failures >= MAX_CONSECUTIVE_STEP_FAILURES {
+                                anyhow::bail!(
+                                    "Aborting peer: coordinator's DAR payload will not decode: {e}"
+                                );
+                            }
+                            tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
                             continue;
                         }
                     }
@@ -388,8 +395,16 @@ pub async fn start_peer(
 
                 if let Err(e) = contracts::upload_dars_from_bytes(&node_config, dar_files).await {
                     tracing::error!("Step execution failed: {e}");
+                    consecutive_step_failures += 1;
+                    if consecutive_step_failures >= MAX_CONSECUTIVE_STEP_FAILURES {
+                        anyhow::bail!(
+                            "Aborting peer: {MAX_CONSECUTIVE_STEP_FAILURES} consecutive step failures: {e}"
+                        );
+                    }
+                    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
                     continue;
                 }
+                consecutive_step_failures = 0;
                 if let Err(e) = client.send_status(b"UploadDars completed".to_vec()).await {
                     tracing::error!("Failed to send completion status: {e}");
                 }
@@ -446,6 +461,11 @@ pub async fn start_peer(
                 tracing::info!("Executing: Sign DNS proposal");
                 if payload.is_empty() {
                     tracing::error!("No DNS proposal payload received from coordinator");
+                    consecutive_step_failures += 1;
+                    if consecutive_step_failures >= MAX_CONSECUTIVE_STEP_FAILURES {
+                        anyhow::bail!("Aborting peer: coordinator sent no DNS proposal to check");
+                    }
+                    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
                     continue;
                 }
                 match expectations
@@ -524,6 +544,11 @@ pub async fn start_peer(
                 tracing::info!("Executing: Sign P2P proposals");
                 if payload.is_empty() {
                     tracing::error!("No P2P proposal payload received from coordinator");
+                    consecutive_step_failures += 1;
+                    if consecutive_step_failures >= MAX_CONSECUTIVE_STEP_FAILURES {
+                        anyhow::bail!("Aborting peer: coordinator sent no P2P proposal to check");
+                    }
+                    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
                     continue;
                 }
                 // Absent means the DNS step ran on a build that did not record

--- a/crates/decman/src/workflow/mod.rs
+++ b/crates/decman/src/workflow/mod.rs
@@ -9,6 +9,7 @@ pub mod party_replication;
 pub mod state;
 pub mod storage;
 pub mod topology;
+pub mod validation;
 
 use std::sync::Arc;
 
@@ -33,6 +34,7 @@ use crate::{
     workflow::{
         state::WorkflowStep,
         storage::{WorkflowStorage, artifact_kinds},
+        validation::PeerExpectations,
     },
 };
 
@@ -240,26 +242,19 @@ pub async fn start_peer(
         coordinator.participant_id
     );
 
+    // The invitation the operator accepted, read back before the first
+    // command arrives. Every payload this loop is asked to act on is checked
+    // against it, so a coordinator cannot widen the run beyond what was
+    // agreed. Without it the peer cannot tell what it consented to, so the
+    // run fails rather than signing blind.
+    let coordinator_id = coordinator.participant_id.clone();
+    let expectations =
+        PeerExpectations::load(&db, &instance_name, &node_config, &coordinator_id).await?;
+    let peer_kind = expectations.kind;
+
     let client = NoiseClient::new(node_config.clone(), coordinator, coordinator_instance).await?;
 
     tracing::info!("Noise client initialized, entering command polling loop");
-
-    // Cache the workflow kind so each polled command can be mapped to a
-    // human-readable step (current_step / step_index) on this peer's
-    // workflow_runs row. Falling back to None just means the notification
-    // feed UI keeps showing the row's initial "Active" placeholder for this
-    // run, which is harmless.
-    let peer_kind: Option<WorkflowKind> = match db.get_workflow_run(&instance_name).await {
-        Ok(Some(run)) => Some(run.kind),
-        Ok(None) => {
-            tracing::warn!("peer step persist: no workflow_runs row for {instance_name}");
-            None
-        }
-        Err(e) => {
-            tracing::warn!("peer step persist: lookup failed for {instance_name}: {e}");
-            None
-        }
-    };
 
     // Command polling loop
     let mut consecutive_errors = 0;
@@ -331,9 +326,25 @@ pub async fn start_peer(
         let command = message.msg_type;
         let payload = message.payload;
 
-        if let Some(kind) = peer_kind {
-            persist_peer_step(&db, &instance_name, kind, command).await;
+        // Only commands that belong to the accepted workflow kind are
+        // executed. A Contracts invitation must not become a licence to sign
+        // a kick's topology transactions.
+        if !command_matches_kind(peer_kind, command) {
+            tracing::error!(
+                "Refusing {command:?}: the accepted invitation is for a {peer_kind:?} workflow"
+            );
+            consecutive_step_failures += 1;
+            if consecutive_step_failures >= MAX_CONSECUTIVE_STEP_FAILURES {
+                anyhow::bail!(
+                    "Aborting peer: coordinator sent {MAX_CONSECUTIVE_STEP_FAILURES} commands \
+                     that do not belong to the accepted {peer_kind:?} workflow"
+                );
+            }
+            tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+            continue;
         }
+
+        persist_peer_step(&db, &instance_name, peer_kind, command).await;
 
         match command {
             MessageType::Wait => {
@@ -360,6 +371,20 @@ pub async fn start_peer(
                         }
                     }
                 };
+
+                // Vetting a DAR makes this participant willing to execute its
+                // code, so the files must be the ones the operator accepted.
+                if let Err(e) = expectations.check_dars(&dar_files) {
+                    tracing::error!("Refusing the coordinator's DARs: {e}");
+                    consecutive_step_failures += 1;
+                    if consecutive_step_failures >= MAX_CONSECUTIVE_STEP_FAILURES {
+                        anyhow::bail!(
+                            "Aborting peer: coordinator's DARs do not match the invitation: {e}"
+                        );
+                    }
+                    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+                    continue;
+                }
 
                 if let Err(e) = contracts::upload_dars_from_bytes(&node_config, dar_files).await {
                     tracing::error!("Step execution failed: {e}");
@@ -423,6 +448,37 @@ pub async fn start_peer(
                     tracing::error!("No DNS proposal payload received from coordinator");
                     continue;
                 }
+                match expectations
+                    .check_onboarding_dns(&db, &instance_name, &payload)
+                    .await
+                {
+                    // Remember the namespace we authorized so the P2P
+                    // proposal that follows can be pinned to the same party.
+                    Ok(namespace) => {
+                        if let Err(e) = db
+                            .write_artifact(
+                                &instance_name,
+                                artifact_kinds::ACCEPTED_DNS_NAMESPACE,
+                                None,
+                                namespace.as_bytes(),
+                            )
+                            .await
+                        {
+                            tracing::warn!("Failed to record the signed DNS namespace: {e}");
+                        }
+                    }
+                    Err(e) => {
+                        tracing::error!("Refusing the coordinator's DNS proposal: {e}");
+                        consecutive_step_failures += 1;
+                        if consecutive_step_failures >= MAX_CONSECUTIVE_STEP_FAILURES {
+                            anyhow::bail!(
+                                "Aborting peer: DNS proposal does not match the accepted invitation: {e}"
+                            );
+                        }
+                        tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+                        continue;
+                    }
+                }
                 if let Err(e) =
                     onboarding::sign_dns_proposals(&node_config, &db, &instance_name, &payload)
                         .await
@@ -453,6 +509,30 @@ pub async fn start_peer(
                 tracing::info!("Executing: Sign P2P proposals");
                 if payload.is_empty() {
                     tracing::error!("No P2P proposal payload received from coordinator");
+                    continue;
+                }
+                let signed_namespace = db
+                    .read_artifact(&instance_name, artifact_kinds::ACCEPTED_DNS_NAMESPACE, None)
+                    .await
+                    .unwrap_or_default()
+                    .and_then(|bytes| String::from_utf8(bytes).ok());
+                if let Err(e) = expectations
+                    .check_onboarding_p2p(
+                        &db,
+                        &instance_name,
+                        &payload,
+                        signed_namespace.as_deref(),
+                    )
+                    .await
+                {
+                    tracing::error!("Refusing the coordinator's P2P proposal: {e}");
+                    consecutive_step_failures += 1;
+                    if consecutive_step_failures >= MAX_CONSECUTIVE_STEP_FAILURES {
+                        anyhow::bail!(
+                            "Aborting peer: P2P proposal does not match the accepted invitation: {e}"
+                        );
+                    }
+                    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
                     continue;
                 }
                 if let Err(e) =
@@ -538,6 +618,17 @@ pub async fn start_peer(
                     };
 
                 let dec_party_id = contracts_config.decentralized_party_id.clone();
+                if let Err(e) = expectations.check_dec_party(&dec_party_id) {
+                    tracing::error!("Refusing the coordinator's contracts config: {e}");
+                    consecutive_step_failures += 1;
+                    if consecutive_step_failures >= MAX_CONSECUTIVE_STEP_FAILURES {
+                        anyhow::bail!(
+                            "Aborting peer: contracts config does not match the accepted invitation: {e}"
+                        );
+                    }
+                    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+                    continue;
+                }
 
                 // Persist the prepared submissions sent by the coordinator into
                 // this peer's workflow_artifacts so sign_submissions can
@@ -605,6 +696,21 @@ pub async fn start_peer(
                     }
                 };
 
+                if let Err(e) = expectations
+                    .check_party_proposals(&db, &instance_name, &items[1], &items[2])
+                    .await
+                {
+                    tracing::error!("Refusing the coordinator's kick proposals: {e}");
+                    consecutive_step_failures += 1;
+                    if consecutive_step_failures >= MAX_CONSECUTIVE_STEP_FAILURES {
+                        anyhow::bail!(
+                            "Aborting peer: kick proposals do not match the accepted invitation: {e}"
+                        );
+                    }
+                    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+                    continue;
+                }
+
                 let kick_data = utils::encode_length_prefixed(&[&items[1], &items[2]]);
                 if let Err(e) =
                     kick::sign_proposals(&node_config, &db, &instance_name, &kick_data).await
@@ -657,6 +763,21 @@ pub async fn start_peer(
                         }
                     };
 
+                if let Err(e) = expectations
+                    .check_party_proposals(&db, &instance_name, &items[1], &items[2])
+                    .await
+                {
+                    tracing::error!("Refusing the coordinator's change-threshold proposals: {e}");
+                    consecutive_step_failures += 1;
+                    if consecutive_step_failures >= MAX_CONSECUTIVE_STEP_FAILURES {
+                        anyhow::bail!(
+                            "Aborting peer: change-threshold proposals do not match the accepted invitation: {e}"
+                        );
+                    }
+                    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+                    continue;
+                }
+
                 let proposal_data = utils::encode_length_prefixed(&[&items[1], &items[2]]);
                 if let Err(e) = change_threshold::sign_proposals(
                     &node_config,
@@ -696,6 +817,12 @@ pub async fn start_peer(
                 let Some(add_party_config) = decode_add_party_config(&payload) else {
                     continue;
                 };
+                if let Err(e) =
+                    expectations.check_dec_party(&add_party_config.decentralized_party_id)
+                {
+                    tracing::error!("Refusing the coordinator's add-party config: {e}");
+                    continue;
+                }
                 if !is_new_member(&node_config, &add_party_config) {
                     send_skip_status(&client, "GenerateAddPartyKeys").await;
                     continue;
@@ -754,6 +881,26 @@ pub async fn start_peer(
                 let Some(add_party_config) = decode_add_party_config(&items[0]) else {
                     continue;
                 };
+
+                let add_party_check = async {
+                    expectations.check_dec_party(&add_party_config.decentralized_party_id)?;
+                    expectations.check_new_participant(&add_party_config.new_participant_id)?;
+                    expectations
+                        .check_party_proposals(&db, &instance_name, &items[1], &items[2])
+                        .await
+                }
+                .await;
+                if let Err(e) = add_party_check {
+                    tracing::error!("Refusing the coordinator's add-party proposals: {e}");
+                    consecutive_step_failures += 1;
+                    if consecutive_step_failures >= MAX_CONSECUTIVE_STEP_FAILURES {
+                        anyhow::bail!(
+                            "Aborting peer: add-party proposals do not match the accepted invitation: {e}"
+                        );
+                    }
+                    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+                    continue;
+                }
 
                 let proposal_data = utils::encode_length_prefixed(&[&items[1], &items[2]]);
                 if let Err(e) =
@@ -843,6 +990,12 @@ pub async fn start_peer(
                 let Some(add_party_config) = decode_add_party_config(&items[0]) else {
                     continue;
                 };
+                if let Err(e) =
+                    expectations.check_dec_party(&add_party_config.decentralized_party_id)
+                {
+                    tracing::error!("Refusing the coordinator's ACS import: {e}");
+                    continue;
+                }
                 if !is_new_member(&node_config, &add_party_config) {
                     send_skip_status(&client, "ImportAcs").await;
                     continue;
@@ -884,6 +1037,12 @@ pub async fn start_peer(
                 let Some(add_party_config) = decode_add_party_config(&payload) else {
                     continue;
                 };
+                if let Err(e) =
+                    expectations.check_dec_party(&add_party_config.decentralized_party_id)
+                {
+                    tracing::error!("Refusing the coordinator's clearing request: {e}");
+                    continue;
+                }
                 if !is_new_member(&node_config, &add_party_config) {
                     send_skip_status(&client, "ClearOnboardingFlag").await;
                     continue;
@@ -970,6 +1129,18 @@ pub async fn start_peer(
                     // Skip marker: the flag already cleared without a
                     // signing round (e.g. a single-owner-threshold party).
                     send_skip_status(&client, "SignClearOnboarding").await;
+                    continue;
+                }
+
+                if let Err(e) = expectations.check_clear_onboarding(&items[1]) {
+                    tracing::error!("Refusing the coordinator's clearing proposal: {e}");
+                    consecutive_step_failures += 1;
+                    if consecutive_step_failures >= MAX_CONSECUTIVE_STEP_FAILURES {
+                        anyhow::bail!(
+                            "Aborting peer: clearing proposal does not match the accepted invitation: {e}"
+                        );
+                    }
+                    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
                     continue;
                 }
 
@@ -1066,6 +1237,19 @@ fn extract_party_id_from_p2p_payload(payload: &[u8]) -> Result<CantonId> {
         topology_mapping::Mapping::PartyToParticipant(p2p) => CantonId::parse(&p2p.party),
         other => anyhow::bail!("Expected PartyToParticipant mapping, got {other:?}"),
     }
+}
+
+/// Whether a command belongs to the workflow kind the operator accepted.
+///
+/// `Wait`, `Ping` and `Disconnect` are protocol control messages that carry no
+/// payload and drive no step, so they are allowed for every kind. Everything
+/// else must map to a real step of `kind`: an accepted invitation authorizes
+/// one workflow, not a channel the coordinator can drive anywhere.
+fn command_matches_kind(kind: WorkflowKind, command: MessageType) -> bool {
+    matches!(
+        command,
+        MessageType::Wait | MessageType::Ping | MessageType::Disconnect
+    ) || peer_step_for_command(kind, command).is_some()
 }
 
 /// Map an inbound coordinator command to the peer's view of step
@@ -1220,6 +1404,53 @@ async fn save_prepared_submissions_from_payload(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// An accepted invitation authorizes one workflow. A command belonging to
+    /// another kind is the coordinator reaching past what the operator agreed
+    /// to, and must be refused before any signing step sees its payload.
+    #[test]
+    fn refuses_commands_from_another_workflow_kind() {
+        assert!(!command_matches_kind(
+            WorkflowKind::Contracts,
+            MessageType::SignKick
+        ));
+        assert!(!command_matches_kind(
+            WorkflowKind::Dars,
+            MessageType::SignSubmissions
+        ));
+        assert!(!command_matches_kind(
+            WorkflowKind::Onboarding,
+            MessageType::SignAddParty
+        ));
+        assert!(!command_matches_kind(
+            WorkflowKind::ChangeThreshold,
+            MessageType::UploadDars
+        ));
+    }
+
+    #[test]
+    fn allows_a_kinds_own_commands_and_the_control_messages() {
+        assert!(command_matches_kind(
+            WorkflowKind::Onboarding,
+            MessageType::SignDns
+        ));
+        assert!(command_matches_kind(
+            WorkflowKind::Kick,
+            MessageType::SignKick
+        ));
+        for kind in [
+            WorkflowKind::Onboarding,
+            WorkflowKind::Kick,
+            WorkflowKind::Contracts,
+            WorkflowKind::Dars,
+            WorkflowKind::AddParty,
+            WorkflowKind::ChangeThreshold,
+        ] {
+            assert!(command_matches_kind(kind, MessageType::Wait));
+            assert!(command_matches_kind(kind, MessageType::Ping));
+            assert!(command_matches_kind(kind, MessageType::Disconnect));
+        }
+    }
 
     #[test]
     fn peer_step_maps_known_commands_and_rejects_the_rest() {

--- a/crates/decman/src/workflow/mod.rs
+++ b/crates/decman/src/workflow/mod.rs
@@ -455,6 +455,10 @@ pub async fn start_peer(
                     // Remember the namespace we authorized so the P2P
                     // proposal that follows can be pinned to the same party.
                     Ok(namespace) => {
+                        // The P2P proposal is pinned to this namespace in the
+                        // next step. Signing DNS without recording it would
+                        // leave that cross-check silently disabled, so a write
+                        // failure fails the step instead.
                         if let Err(e) = db
                             .write_artifact(
                                 &instance_name,
@@ -464,7 +468,18 @@ pub async fn start_peer(
                             )
                             .await
                         {
-                            tracing::warn!("Failed to record the signed DNS namespace: {e}");
+                            tracing::error!(
+                                "Refusing to sign DNS: the accepted namespace could not be \
+                                 recorded, so the P2P cross-check would be lost: {e}"
+                            );
+                            consecutive_step_failures += 1;
+                            if consecutive_step_failures >= MAX_CONSECUTIVE_STEP_FAILURES {
+                                anyhow::bail!(
+                                    "Aborting peer: cannot record the accepted DNS namespace: {e}"
+                                );
+                            }
+                            tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+                            continue;
                         }
                     }
                     Err(e) => {
@@ -511,11 +526,32 @@ pub async fn start_peer(
                     tracing::error!("No P2P proposal payload received from coordinator");
                     continue;
                 }
-                let signed_namespace = db
+                // Absent means the DNS step ran on a build that did not record
+                // the namespace yet — the mixed-version case, which degrades to
+                // the prefix check with a warning inside check_onboarding_p2p.
+                // A read error is different: it hides whether a namespace was
+                // recorded at all, so it fails the step rather than skipping
+                // the cross-check.
+                let signed_namespace = match db
                     .read_artifact(&instance_name, artifact_kinds::ACCEPTED_DNS_NAMESPACE, None)
                     .await
-                    .unwrap_or_default()
-                    .and_then(|bytes| String::from_utf8(bytes).ok());
+                {
+                    Ok(recorded) => recorded.and_then(|bytes| String::from_utf8(bytes).ok()),
+                    Err(e) => {
+                        tracing::error!(
+                            "Refusing to sign P2P: cannot read the DNS namespace this run \
+                             accepted, so the cross-check cannot be applied: {e}"
+                        );
+                        consecutive_step_failures += 1;
+                        if consecutive_step_failures >= MAX_CONSECUTIVE_STEP_FAILURES {
+                            anyhow::bail!(
+                                "Aborting peer: cannot read the accepted DNS namespace: {e}"
+                            );
+                        }
+                        tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+                        continue;
+                    }
+                };
                 if let Err(e) = expectations
                     .check_onboarding_p2p(
                         &db,

--- a/crates/decman/src/workflow/mod.rs
+++ b/crates/decman/src/workflow/mod.rs
@@ -857,6 +857,13 @@ pub async fn start_peer(
                     expectations.check_dec_party(&add_party_config.decentralized_party_id)
                 {
                     tracing::error!("Refusing the coordinator's add-party config: {e}");
+                    consecutive_step_failures += 1;
+                    if consecutive_step_failures >= MAX_CONSECUTIVE_STEP_FAILURES {
+                        anyhow::bail!(
+                            "Aborting peer: the add-party config does not match the accepted invitation: {e}"
+                        );
+                    }
+                    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
                     continue;
                 }
                 if !is_new_member(&node_config, &add_party_config) {
@@ -1030,6 +1037,13 @@ pub async fn start_peer(
                     expectations.check_dec_party(&add_party_config.decentralized_party_id)
                 {
                     tracing::error!("Refusing the coordinator's ACS import: {e}");
+                    consecutive_step_failures += 1;
+                    if consecutive_step_failures >= MAX_CONSECUTIVE_STEP_FAILURES {
+                        anyhow::bail!(
+                            "Aborting peer: the ACS import does not match the accepted invitation: {e}"
+                        );
+                    }
+                    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
                     continue;
                 }
                 if !is_new_member(&node_config, &add_party_config) {
@@ -1077,6 +1091,13 @@ pub async fn start_peer(
                     expectations.check_dec_party(&add_party_config.decentralized_party_id)
                 {
                     tracing::error!("Refusing the coordinator's clearing request: {e}");
+                    consecutive_step_failures += 1;
+                    if consecutive_step_failures >= MAX_CONSECUTIVE_STEP_FAILURES {
+                        anyhow::bail!(
+                            "Aborting peer: the clearing request does not match the accepted invitation: {e}"
+                        );
+                    }
+                    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
                     continue;
                 }
                 if !is_new_member(&node_config, &add_party_config) {

--- a/crates/decman/src/workflow/mod.rs
+++ b/crates/decman/src/workflow/mod.rs
@@ -899,8 +899,16 @@ pub async fn start_peer(
                 let Some(add_party_config) = decode_add_party_config(&payload) else {
                     continue;
                 };
-                if let Err(e) =
-                    expectations.check_dec_party(&add_party_config.decentralized_party_id)
+                // Both the party and the new member are pinned before
+                // `is_new_member` reads `new_participant_id` to decide this
+                // node's role: naming this peer there would otherwise make it
+                // take the new member's part in a run it joined as an existing
+                // member.
+                if let Err(e) = expectations
+                    .check_dec_party(&add_party_config.decentralized_party_id)
+                    .and_then(|()| {
+                        expectations.check_new_participant(&add_party_config.new_participant_id)
+                    })
                 {
                     tracing::error!("Refusing the coordinator's add-party config: {e}");
                     consecutive_step_failures += 1;
@@ -1079,8 +1087,16 @@ pub async fn start_peer(
                 let Some(add_party_config) = decode_add_party_config(&items[0]) else {
                     continue;
                 };
-                if let Err(e) =
-                    expectations.check_dec_party(&add_party_config.decentralized_party_id)
+                // Both the party and the new member are pinned before
+                // `is_new_member` reads `new_participant_id` to decide this
+                // node's role: naming this peer there would otherwise make it
+                // take the new member's part in a run it joined as an existing
+                // member.
+                if let Err(e) = expectations
+                    .check_dec_party(&add_party_config.decentralized_party_id)
+                    .and_then(|()| {
+                        expectations.check_new_participant(&add_party_config.new_participant_id)
+                    })
                 {
                     tracing::error!("Refusing the coordinator's ACS import: {e}");
                     consecutive_step_failures += 1;
@@ -1133,8 +1149,16 @@ pub async fn start_peer(
                 let Some(add_party_config) = decode_add_party_config(&payload) else {
                     continue;
                 };
-                if let Err(e) =
-                    expectations.check_dec_party(&add_party_config.decentralized_party_id)
+                // Both the party and the new member are pinned before
+                // `is_new_member` reads `new_participant_id` to decide this
+                // node's role: naming this peer there would otherwise make it
+                // take the new member's part in a run it joined as an existing
+                // member.
+                if let Err(e) = expectations
+                    .check_dec_party(&add_party_config.decentralized_party_id)
+                    .and_then(|()| {
+                        expectations.check_new_participant(&add_party_config.new_participant_id)
+                    })
                 {
                     tracing::error!("Refusing the coordinator's clearing request: {e}");
                     consecutive_step_failures += 1;

--- a/crates/decman/src/workflow/mod.rs
+++ b/crates/decman/src/workflow/mod.rs
@@ -431,6 +431,22 @@ pub async fn start_peer(
                     }
                 };
 
+                // The prefix names the vault keys this step creates or reuses,
+                // so it is pinned before any key material is touched.
+                if let Err(e) =
+                    expectations.check_onboarding_config(&onboarding_config.party_id_prefix)
+                {
+                    tracing::error!("Refusing the coordinator's onboarding config: {e}");
+                    consecutive_step_failures += 1;
+                    if consecutive_step_failures >= MAX_CONSECUTIVE_STEP_FAILURES {
+                        anyhow::bail!(
+                            "Aborting peer: onboarding config does not match the accepted invitation: {e}"
+                        );
+                    }
+                    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+                    continue;
+                }
+
                 if let Err(e) =
                     onboarding::generate_keys(&node_config, &db, &instance_name, &onboarding_config)
                         .await

--- a/crates/decman/src/workflow/mod.rs
+++ b/crates/decman/src/workflow/mod.rs
@@ -536,7 +536,28 @@ pub async fn start_peer(
                     .read_artifact(&instance_name, artifact_kinds::ACCEPTED_DNS_NAMESPACE, None)
                     .await
                 {
-                    Ok(recorded) => recorded.and_then(|bytes| String::from_utf8(bytes).ok()),
+                    // Nothing recorded is the mixed-version case. Bytes that
+                    // are not valid UTF-8 are not: something WAS recorded and
+                    // cannot be read back, so treating it as absent would drop
+                    // the cross-check on corrupt state.
+                    Ok(None) => None,
+                    Ok(Some(bytes)) => match String::from_utf8(bytes) {
+                        Ok(namespace) => Some(namespace),
+                        Err(e) => {
+                            tracing::error!(
+                                "Refusing to sign P2P: the recorded DNS namespace is not \
+                                 readable, so the cross-check cannot be applied: {e}"
+                            );
+                            consecutive_step_failures += 1;
+                            if consecutive_step_failures >= MAX_CONSECUTIVE_STEP_FAILURES {
+                                anyhow::bail!(
+                                    "Aborting peer: the recorded DNS namespace is corrupt: {e}"
+                                );
+                            }
+                            tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+                            continue;
+                        }
+                    },
                     Err(e) => {
                         tracing::error!(
                             "Refusing to sign P2P: cannot read the DNS namespace this run \

--- a/crates/decman/src/workflow/onboarding/steps/proposals/create.rs
+++ b/crates/decman/src/workflow/onboarding/steps/proposals/create.rs
@@ -376,7 +376,7 @@ pub(crate) fn decode_keys_payload(payload: &[u8]) -> Result<Vec<SigningPublicKey
 ///    - Hash the UTF-8 bytes of the string itself
 ///
 /// The decentralized namespace is returned in multihash format with "1220" prefix
-fn compute_decentralized_namespace(namespaces: &HashSet<String>) -> String {
+pub(crate) fn compute_decentralized_namespace(namespaces: &HashSet<String>) -> String {
     use sha2::{Digest, Sha256};
 
     // HashPurpose.DecentralizedNamespaceNamespace = 37

--- a/crates/decman/src/workflow/storage.rs
+++ b/crates/decman/src/workflow/storage.rs
@@ -39,6 +39,10 @@ pub mod artifact_kinds {
     /// path after the workflow finishes so it can return the new party id to
     /// the UI without round-tripping through the file system.
     pub const PARTY_ID: &str = "party_id";
+    /// Decentralized namespace a peer validated and signed in the onboarding
+    /// SignDns step. Plaintext UTF-8 hex. Read back in SignP2p so the two
+    /// proposals a peer signs are pinned to the same party.
+    pub const ACCEPTED_DNS_NAMESPACE: &str = "accepted_dns_namespace";
 
     // Contracts (workflow_artifacts during a run)
     pub const PREPARED_SUBMISSION: &str = "prepared_submission";

--- a/crates/decman/src/workflow/validation.rs
+++ b/crates/decman/src/workflow/validation.rs
@@ -380,12 +380,19 @@ impl PeerExpectations {
     /// accepted file is missing, or if a file's content does not hash to the
     /// value the invitation pinned.
     pub fn check_dars(&self, files: &[(String, Vec<u8>)]) -> Result {
+        // An invitation that named no DARs authorizes no DARs. Only the hash
+        // list is treated leniently for an older coordinator — `dar_filenames`
+        // has been on the invite since the workflow existed, so an empty one
+        // paired with actual DAR bytes is a coordinator installing code the
+        // operator never saw, not a version skew.
         if self.dar_filenames.is_empty() {
-            tracing::warn!(
-                "accepted Dars invitation listed no filenames; skipping the DAR content \
-                 check (the coordinator predates the field)"
+            if files.is_empty() {
+                return Ok(());
+            }
+            anyhow::bail!(
+                "coordinator sent {count} DAR(s) but the accepted invitation named none",
+                count = files.len()
             );
-            return Ok(());
         }
 
         // Both sides are compared as sets, so a repeated name would collapse and
@@ -1152,6 +1159,24 @@ mod tests {
                 .is_err()
         );
         Ok(())
+    }
+
+    /// The hole this closes: an invitation naming no DARs, accepted as
+    /// harmless, followed by DAR bytes the peer would have uploaded and vetted
+    /// without any check at all.
+    #[test]
+    fn rejects_dars_no_invitation_named() -> Result {
+        let a = canton_id("p1", 1)?;
+        let expectations = expectations(vec![a.clone()], a);
+        assert!(expectations.dar_filenames.is_empty());
+        assert!(
+            expectations
+                .check_dars(&[("surprise.dar".to_string(), b"arbitrary-code".to_vec())])
+                .is_err()
+        );
+        // Nothing accepted and nothing sent stays fine — that is a Dars run
+        // with no files, not a bypass.
+        expectations.check_dars(&[])
     }
 
     /// An older coordinator sends filenames but no hashes: the filename check

--- a/crates/decman/src/workflow/validation.rs
+++ b/crates/decman/src/workflow/validation.rs
@@ -225,9 +225,12 @@ impl PeerExpectations {
                 found = party.prefix
             ),
             Some(_) => {}
-            None => tracing::warn!(
-                "accepted onboarding invitation carried no party prefix; skipping the \
-                 prefix check on the P2P proposal"
+            // `prefix` is required on every onboarding invite, so an absent one
+            // means the invite never parsed — leaving the coordinator to choose
+            // the party's prefix.
+            None => anyhow::bail!(
+                "accepted onboarding invitation carries no party prefix, so the proposed \
+                 party cannot be checked against it"
             ),
         }
 
@@ -245,6 +248,7 @@ impl PeerExpectations {
         }
 
         self.check_p2p_membership(&mapping)?;
+        self.check_onboarding_markers(&mapping)?;
         self.check_p2p_thresholds(&mapping)?;
         self.check_own_daml_key(storage, instance_name, &mapping)
             .await
@@ -326,6 +330,7 @@ impl PeerExpectations {
             );
         }
         self.check_p2p_membership(&mapping)?;
+        self.check_onboarding_markers(&mapping)?;
         self.check_p2p_thresholds(&mapping)?;
 
         tracing::info!(
@@ -515,6 +520,17 @@ impl PeerExpectations {
             if !hosts.insert(id.clone()) {
                 anyhow::bail!("P2P proposal lists participant {id} twice");
             }
+            // Every proposal this tool builds hosts at Confirmation. Submission
+            // would let that participant submit for the party directly, so a
+            // silent upgrade is a change to who can act, not a detail.
+            if participant.permission != enums::ParticipantPermission::Confirmation as i32 {
+                anyhow::bail!(
+                    "P2P proposal hosts {id} with permission {permission}, not Confirmation",
+                    permission = enums::ParticipantPermission::try_from(participant.permission)
+                        .map(|p| p.as_str_name().to_string())
+                        .unwrap_or_else(|_| format!("unknown ({})", participant.permission))
+                );
+            }
         }
 
         if hosts != self.members {
@@ -547,6 +563,29 @@ impl PeerExpectations {
             && !hosts.contains(added)
         {
             anyhow::bail!("P2P proposal does not host {added}, the participant being added");
+        }
+        Ok(())
+    }
+
+    /// The onboarding marker decides who is still importing an ACS. Dropping it
+    /// activates the new member before its import finishes; moving it to an
+    /// existing host suspends that host instead. So exactly the accepted new
+    /// participant carries it, and on a run that adds nobody, no one does.
+    ///
+    /// Not applied to the clearing proposal, whose purpose is to remove the
+    /// marker — [`check_clear_onboarding`](Self::check_clear_onboarding)
+    /// requires its absence instead.
+    fn check_onboarding_markers(&self, mapping: &PartyToParticipant) -> Result {
+        for participant in &mapping.participants {
+            let id = CantonId::parse(&participant.participant_uid)?;
+            let expected = self.new_participant.as_ref() == Some(&id);
+            if participant.onboarding.is_some() != expected {
+                anyhow::bail!(
+                    "P2P proposal marks {id} as onboarding: {found}, but the accepted \
+                     invitation calls for {expected}",
+                    found = participant.onboarding.is_some()
+                );
+            }
         }
         Ok(())
     }
@@ -588,13 +627,22 @@ impl PeerExpectations {
                 anyhow::bail!("proposed threshold {threshold} differs from the accepted {expected}")
             }
             Some(_) => Ok(()),
-            None => {
+            // Only the onboarding invite's threshold is optional on the wire
+            // (`Option<i32>`, absent from coordinators that predate it). Kick,
+            // add-party and change-threshold all require it, so an absent one
+            // there would let the coordinator pick any in-range value.
+            None if self.kind == WorkflowKind::Onboarding => {
                 tracing::warn!(
-                    "accepted invitation carried no threshold; only the range check was \
-                     applied to the proposed {threshold}"
+                    "accepted onboarding invitation carried no threshold; only the range \
+                     check was applied to the proposed {threshold}"
                 );
                 Ok(())
             }
+            None => anyhow::bail!(
+                "accepted {kind:?} invitation carries no threshold, so the proposed \
+                 {threshold} cannot be checked against it",
+                kind = self.kind
+            ),
         }
     }
 
@@ -1016,6 +1064,100 @@ mod tests {
 
     /// A stripped `party_signing_keys` is not a missing threshold — it is a
     /// mapping that would leave the party unable to authorize anything.
+    /// Submission permission lets a participant submit for the party directly.
+    /// Every proposal this tool builds hosts at Confirmation, so an upgrade is
+    /// a change to who can act, not a formatting detail.
+    #[test]
+    fn rejects_a_host_upgraded_to_submission() -> Result {
+        let (a, b) = (canton_id("p1", 1)?, canton_id("p2", 2)?);
+        let expectations = expectations(vec![a.clone(), b.clone()], a.clone());
+        let mut mapping = p2p("dec::x", &[a, b], 2);
+        mapping.participants[1].permission = enums::ParticipantPermission::Submission as i32;
+        assert!(expectations.check_p2p_membership(&mapping).is_err());
+        Ok(())
+    }
+
+    /// Dropping the marker activates the new member before its ACS import
+    /// finishes; moving it to an existing host suspends that host instead.
+    #[test]
+    fn rejects_a_misplaced_onboarding_marker() -> Result {
+        let (a, b, joining) = (
+            canton_id("p1", 1)?,
+            canton_id("p2", 2)?,
+            canton_id("p3", 3)?,
+        );
+        let mut expectations = expectations(vec![a.clone(), b.clone(), joining.clone()], a.clone());
+        expectations.new_participant = Some(joining.clone());
+
+        // Marker on the wrong host.
+        let mut moved = p2p("dec::x", &[a.clone(), b.clone(), joining.clone()], 2);
+        moved.participants[1].onboarding = Some(hosting_participant::Onboarding::default());
+        assert!(expectations.check_onboarding_markers(&moved).is_err());
+
+        // Marker missing entirely.
+        let dropped = p2p("dec::x", &[a.clone(), b.clone(), joining.clone()], 2);
+        assert!(expectations.check_onboarding_markers(&dropped).is_err());
+
+        // Marker exactly where the invitation puts it.
+        let mut correct = p2p("dec::x", &[a, b, joining], 2);
+        correct.participants[2].onboarding = Some(hosting_participant::Onboarding::default());
+        expectations.check_onboarding_markers(&correct)
+    }
+
+    /// A run that adds nobody must not introduce an onboarding marker either.
+    #[test]
+    fn rejects_an_onboarding_marker_on_a_run_that_adds_nobody() -> Result {
+        let (a, b) = (canton_id("p1", 1)?, canton_id("p2", 2)?);
+        let expectations = expectations(vec![a.clone(), b.clone()], a.clone());
+        assert!(expectations.new_participant.is_none());
+        let mut mapping = p2p("dec::x", &[a, b], 2);
+        mapping.participants[0].onboarding = Some(hosting_participant::Onboarding::default());
+        assert!(expectations.check_onboarding_markers(&mapping).is_err());
+        Ok(())
+    }
+
+    /// Only the onboarding invite's threshold is optional on the wire. For the
+    /// other kinds an absent one would let the coordinator pick any in-range
+    /// value.
+    #[test]
+    fn rejects_an_absent_threshold_except_for_onboarding() -> Result {
+        let a = canton_id("p1", 1)?;
+        let mut expectations = expectations(vec![a.clone()], a);
+        expectations.threshold = None;
+
+        expectations.kind = WorkflowKind::Kick;
+        assert!(expectations.check_threshold(2, 3).is_err());
+        expectations.kind = WorkflowKind::AddParty;
+        assert!(expectations.check_threshold(2, 3).is_err());
+
+        expectations.kind = WorkflowKind::Onboarding;
+        expectations.check_threshold(2, 3)
+    }
+
+    /// The prefix is required on every onboarding invite, so an absent one
+    /// means the invite never parsed — and the coordinator would name the party.
+    #[tokio::test]
+    async fn rejects_an_onboarding_p2p_when_no_prefix_was_accepted() -> Result {
+        let a = canton_id("p1", 1)?;
+        let mut expectations = expectations(vec![a.clone()], a.clone());
+        expectations.kind = WorkflowKind::Onboarding;
+        assert!(expectations.prefix.is_none());
+
+        let payload = encode_proposal(topology_mapping::Mapping::PartyToParticipant(p2p(
+            &canton_id("anything", 5)?.to_string(),
+            &[a],
+            1,
+        )));
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:").await?;
+        assert!(
+            expectations
+                .check_onboarding_p2p(&pool, "run", &payload, None)
+                .await
+                .is_err()
+        );
+        Ok(())
+    }
+
     #[test]
     fn rejects_a_proposal_with_no_party_signing_keys() -> Result {
         let (a, b) = (canton_id("p1", 1)?, canton_id("p2", 2)?);

--- a/crates/decman/src/workflow/validation.rs
+++ b/crates/decman/src/workflow/validation.rs
@@ -284,15 +284,23 @@ impl PeerExpectations {
                 expected = dec_party_id.namespace.to_hex()
             );
         }
-        if namespace_def.owners.len() != self.members.len() {
+        // Canton treats the owners as a set, so a repeated namespace would keep
+        // the vector length the invitation expects while shrinking the real
+        // owner set — and with it the number of distinct signatures the
+        // threshold represents.
+        let owners: BTreeSet<&String> = namespace_def.owners.iter().collect();
+        if owners.len() != namespace_def.owners.len() {
+            anyhow::bail!("DNS proposal repeats an owner namespace");
+        }
+        if owners.len() != self.members.len() {
             anyhow::bail!(
                 "DNS proposal has {found} owners but the accepted invitation names \
                  {expected} members",
-                found = namespace_def.owners.len(),
+                found = owners.len(),
                 expected = self.members.len()
             );
         }
-        self.check_threshold(namespace_def.threshold, namespace_def.owners.len())?;
+        self.check_threshold(namespace_def.threshold, owners.len())?;
 
         // Losing our namespace from the owner set would leave this node hosting
         // a party it can no longer authorize changes to. The lookup itself is
@@ -380,8 +388,17 @@ impl PeerExpectations {
             return Ok(());
         }
 
+        // Both sides are compared as sets, so a repeated name would collapse and
+        // mask a missing or extra file. Refuse the ambiguity rather than pick a
+        // reading of it.
         let accepted: BTreeSet<&str> = self.dar_filenames.iter().map(String::as_str).collect();
+        if accepted.len() != self.dar_filenames.len() {
+            anyhow::bail!("accepted invitation names the same DAR twice");
+        }
         let received: BTreeSet<&str> = files.iter().map(|(name, _)| name.as_str()).collect();
+        if received.len() != files.len() {
+            anyhow::bail!("coordinator sent the same DAR filename twice");
+        }
         if let Some(unexpected) = received.difference(&accepted).next() {
             anyhow::bail!("coordinator sent DAR {unexpected}, which the invitation did not name");
         }
@@ -389,12 +406,23 @@ impl PeerExpectations {
             anyhow::bail!("coordinator did not send DAR {missing} named by the invitation");
         }
 
-        if self.dar_hashes.len() != self.dar_filenames.len() {
+        // Only a wholly absent hash list means "coordinator predates the field".
+        // A partial one cannot be matched up with the filenames, so treating it
+        // as legacy would silently drop the content pin.
+        if self.dar_hashes.is_empty() {
             tracing::warn!(
                 "accepted Dars invitation carried no DAR hashes; the filenames match but \
                  the content cannot be pinned (the coordinator predates the field)"
             );
             return Ok(());
+        }
+        if self.dar_hashes.len() != self.dar_filenames.len() {
+            anyhow::bail!(
+                "accepted invitation carries {hashes} DAR hash(es) for {names} filename(s), \
+                 so the content cannot be pinned",
+                hashes = self.dar_hashes.len(),
+                names = self.dar_filenames.len()
+            );
         }
 
         for (filename, data) in files {
@@ -997,6 +1025,90 @@ mod tests {
         let payload = encode_proposal(topology_mapping::Mapping::PartyToParticipant(mapping));
 
         assert!(expectations.check_clear_onboarding(&payload).is_err());
+        Ok(())
+    }
+
+    /// Canton reads the owners as a set, so a repeated namespace keeps the
+    /// length the invitation expects while shrinking the real owner set — and
+    /// the threshold then stands for fewer distinct signatures than agreed.
+    #[tokio::test]
+    async fn rejects_duplicate_dns_owners() -> Result {
+        let (a, b) = (canton_id("p1", 1)?, canton_id("p2", 2)?);
+        let party = canton_id("dec", 7)?;
+        let mut expectations = expectations(vec![a.clone(), b.clone()], a.clone());
+        expectations.dec_party_id = Some(party.clone());
+
+        let dns = encode_proposal(topology_mapping::Mapping::DecentralizedNamespaceDefinition(
+            DecentralizedNamespaceDefinition {
+                decentralized_namespace: party.namespace.to_hex(),
+                threshold: 2,
+                // Two entries, one distinct owner.
+                owners: vec!["same".to_string(), "same".to_string()],
+            },
+        ));
+        let p2p_payload = encode_proposal(topology_mapping::Mapping::PartyToParticipant(p2p(
+            &party.to_string(),
+            &[a, b],
+            2,
+        )));
+
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:").await?;
+        let error = expectations
+            .check_party_proposals(&pool, "run", &dns, &p2p_payload)
+            .await
+            .err()
+            .map(|e| e.to_string())
+            .unwrap_or_default();
+        assert!(
+            error.contains("repeats an owner"),
+            "unexpected error: {error}"
+        );
+        Ok(())
+    }
+
+    /// A repeated filename collapses in the set comparison and would mask a
+    /// missing or extra file, so the ambiguity is refused outright.
+    #[test]
+    fn rejects_duplicate_dar_filenames() -> Result {
+        let a = canton_id("p1", 1)?;
+        let mut expectations = expectations(vec![a.clone()], a);
+        expectations.dar_filenames = vec!["gov.dar".to_string(), "gov.dar".to_string()];
+        expectations.dar_hashes = vec![hash_dar(b"gov-bytes"), hash_dar(b"gov-bytes")];
+        assert!(
+            expectations
+                .check_dars(&[("gov.dar".to_string(), b"gov-bytes".to_vec())])
+                .is_err()
+        );
+
+        expectations.dar_filenames = vec!["a.dar".to_string(), "b.dar".to_string()];
+        expectations.dar_hashes = vec![hash_dar(b"a"), hash_dar(b"b")];
+        assert!(
+            expectations
+                .check_dars(&[
+                    ("a.dar".to_string(), b"a".to_vec()),
+                    ("a.dar".to_string(), b"a".to_vec()),
+                ])
+                .is_err()
+        );
+        Ok(())
+    }
+
+    /// Only a wholly absent hash list means "older coordinator". A partial one
+    /// cannot be lined up with the filenames, so it must not read as legacy.
+    #[test]
+    fn rejects_a_partial_dar_hash_list() -> Result {
+        let a = canton_id("p1", 1)?;
+        let mut expectations = expectations(vec![a.clone()], a);
+        expectations.dar_filenames = vec!["a.dar".to_string(), "b.dar".to_string()];
+        expectations.dar_hashes = vec![hash_dar(b"a")];
+        assert!(
+            expectations
+                .check_dars(&[
+                    ("a.dar".to_string(), b"a".to_vec()),
+                    ("b.dar".to_string(), b"b".to_vec()),
+                ])
+                .is_err()
+        );
         Ok(())
     }
 

--- a/crates/decman/src/workflow/validation.rs
+++ b/crates/decman/src/workflow/validation.rs
@@ -469,14 +469,17 @@ impl PeerExpectations {
                  is for {expected}"
             ),
             Some(_) => Ok(()),
-            None => {
-                tracing::warn!(
-                    "accepted {kind:?} invitation carried no dec party id; skipping the \
-                     party check on the coordinator's config",
-                    kind = self.kind
-                );
-                Ok(())
-            }
+            // Every invitation kind that reaches this check carries the dec
+            // party as a required field, so an absent one is not version skew —
+            // it means the invite never parsed and the peer cannot say what its
+            // operator agreed to. `check_party_proposals` already refuses that;
+            // this refuses it too rather than accepting whatever party the
+            // coordinator names.
+            None => anyhow::bail!(
+                "accepted {kind:?} invitation carries no dec party id, so the coordinator's \
+                 config cannot be checked against it",
+                kind = self.kind
+            ),
         }
     }
 
@@ -493,13 +496,13 @@ impl PeerExpectations {
                  {expected}"
             ),
             Some(_) => Ok(()),
-            None => {
-                tracing::warn!(
-                    "accepted add-party invitation named no new participant; skipping the \
-                     check on the coordinator's config"
-                );
-                Ok(())
-            }
+            // `new_participant` is required on every add-party invite, so an
+            // absent one means the invite never parsed — not that it predates
+            // the field. Without it the coordinator would pick who joins.
+            None => anyhow::bail!(
+                "accepted add-party invitation names no new participant, so the coordinator's \
+                 choice cannot be checked against it"
+            ),
         }
     }
 
@@ -559,13 +562,16 @@ impl PeerExpectations {
             Some(signing_keys) => {
                 self.check_threshold(i32::try_from(signing_keys.threshold)?, self.members.len())
             }
-            None => {
-                tracing::warn!(
-                    "P2P proposal carries no party signing keys, so their threshold cannot \
-                     be checked"
-                );
-                Ok(())
-            }
+            // Signing a mapping with no party signing keys does not merely
+            // leave a threshold unchecked — it submits a party that can no
+            // longer authorize anything. Every mapping this tool produces
+            // carries them (onboarding sets them, and the kick / add-party /
+            // change-threshold / clearing proposals all derive from the current
+            // on-chain mapping), so an absent set is a stripped proposal.
+            None => anyhow::bail!(
+                "P2P proposal carries no party signing keys, which would leave the party \
+                 unable to authorize anything"
+            ),
         }
     }
 
@@ -1008,6 +1014,43 @@ mod tests {
         Ok(())
     }
 
+    /// A stripped `party_signing_keys` is not a missing threshold — it is a
+    /// mapping that would leave the party unable to authorize anything.
+    #[test]
+    fn rejects_a_proposal_with_no_party_signing_keys() -> Result {
+        let (a, b) = (canton_id("p1", 1)?, canton_id("p2", 2)?);
+        let expectations = expectations(vec![a.clone(), b.clone()], a.clone());
+        let mapping = p2p("dec::x", &[a, b], 2);
+        assert!(mapping.party_signing_keys.is_none());
+        assert!(expectations.check_p2p_thresholds(&mapping).is_err());
+        Ok(())
+    }
+
+    /// The party is required on every invitation kind that reaches this check,
+    /// so an absent one means the invite never parsed — the peer cannot say
+    /// what it agreed to and must not accept the coordinator's word for it.
+    #[test]
+    fn rejects_a_config_when_no_party_was_accepted() -> Result {
+        let a = canton_id("p1", 1)?;
+        let expectations = expectations(vec![a.clone()], a);
+        assert!(expectations.dec_party_id.is_none());
+        assert!(expectations.check_dec_party(&canton_id("any", 4)?).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_an_add_party_config_when_no_participant_was_accepted() -> Result {
+        let a = canton_id("p1", 1)?;
+        let expectations = expectations(vec![a.clone()], a);
+        assert!(expectations.new_participant.is_none());
+        assert!(
+            expectations
+                .check_new_participant(&canton_id("any", 4)?)
+                .is_err()
+        );
+        Ok(())
+    }
+
     #[test]
     fn accepts_matching_hosting_and_signing_thresholds() -> Result {
         let (a, b) = (canton_id("p1", 1)?, canton_id("p2", 2)?);
@@ -1028,10 +1071,21 @@ mod tests {
         expectations.dec_party_id = Some(party.clone());
 
         let mut mapping = p2p(&party.to_string(), &[a, b], 2);
+        // Keep the mapping otherwise valid so the assertion below is about the
+        // onboarding flag, not about an earlier check tripping first.
+        mapping.party_signing_keys = Some(SigningKeysWithThreshold {
+            keys: Vec::new(),
+            threshold: 2,
+        });
         mapping.participants[1].onboarding = Some(hosting_participant::Onboarding::default());
         let payload = encode_proposal(topology_mapping::Mapping::PartyToParticipant(mapping));
 
-        assert!(expectations.check_clear_onboarding(&payload).is_err());
+        let error = expectations
+            .check_clear_onboarding(&payload)
+            .err()
+            .map(|e| e.to_string())
+            .unwrap_or_default();
+        assert!(error.contains("still flags"), "unexpected error: {error}");
         Ok(())
     }
 

--- a/crates/decman/src/workflow/validation.rs
+++ b/crates/decman/src/workflow/validation.rs
@@ -1,0 +1,1060 @@
+//! Peer-side validation of coordinator payloads against the accepted invitation.
+//!
+//! A peer authenticates the coordinator over the Noise channel and its
+//! operator accepts one invitation per workflow run. Everything after that is
+//! automatic, so without this module the peer signs whatever the coordinator
+//! sends: a topology transaction for any party, with any owner set and any
+//! threshold, or a DAR it never agreed to install.
+//!
+//! The invitation the operator accepted is the peer's statement of intent, and
+//! it is persisted on the peer's `workflow_runs` row. [`PeerExpectations`]
+//! reads it back and every signing step checks its payload against it. A
+//! mismatch is refused — the peer never signs something the operator did not
+//! agree to.
+//!
+//! Checks that the invitation can already answer are always enforced. Fields
+//! added later (the DAR hashes) are enforced when the coordinator sends them
+//! and warned about when it does not, so a network mid-upgrade keeps working.
+
+use std::collections::BTreeSet;
+
+use canton_proto_rs::com::digitalasset::canton::{
+    crypto::v30::SigningPublicKey,
+    protocol::v30::{
+        DecentralizedNamespaceDefinition, PartyToParticipant, SignedTopologyTransaction,
+        TopologyTransaction, enums, topology_mapping,
+    },
+};
+use sha2::{Digest, Sha256};
+use sqlx::SqlitePool;
+
+use crate::{
+    canton_id::CantonId,
+    config::NodeConfig,
+    db::schema::SchemaRead,
+    error::Result,
+    server::WorkflowKind,
+    utils,
+    workflow::{
+        onboarding::steps::proposals::create::{
+            compute_decentralized_namespace, decode_keys_payload,
+        },
+        storage::{WorkflowStorage, artifact_kinds, identity_kinds},
+    },
+};
+
+/// What the operator agreed to when they accepted the invitation.
+///
+/// Built from the peer's own `workflow_runs` row, which
+/// [`crate::server::handlers::invitations::insert_peer_run`] writes at accept
+/// time from the invitation payload. That row — not anything the coordinator
+/// sends later — is the reference every check compares against.
+#[derive(Clone, Debug)]
+pub struct PeerExpectations {
+    /// The workflow kind the operator accepted. Commands belonging to any
+    /// other kind are refused outright.
+    pub kind: WorkflowKind,
+    /// The full member set: the participants named in the invitation plus the
+    /// coordinator itself (onboarding and kick invitations list only the
+    /// invitees; add-party and change-threshold already include the
+    /// coordinator, so the union is the same set either way).
+    pub members: BTreeSet<CantonId>,
+    /// The dec party the run targets. Absent for onboarding, where the party
+    /// does not exist yet.
+    pub dec_party_id: Option<CantonId>,
+    /// Onboarding only: the party id prefix the coordinator proposed.
+    pub prefix: Option<String>,
+    /// The threshold the topology should end up with.
+    pub threshold: Option<i32>,
+    /// Kick only: the participant being removed.
+    pub kicked_participant: Option<CantonId>,
+    /// Add-party only: the participant being added.
+    pub new_participant: Option<CantonId>,
+    /// Dars only: the filenames the operator agreed to install.
+    pub dar_filenames: Vec<String>,
+    /// Dars only: SHA-256 of each accepted DAR, index-aligned with
+    /// `dar_filenames`. Empty when the coordinator predates the field.
+    pub dar_hashes: Vec<String>,
+    /// This node's own participant id.
+    pub self_id: CantonId,
+}
+
+/// The invitation fields `insert_peer_run` stores on the run row.
+#[derive(serde::Deserialize)]
+struct PeerRunConfig {
+    #[serde(default)]
+    prefix: Option<String>,
+    #[serde(default)]
+    participants: Vec<CantonId>,
+    #[serde(default)]
+    dar_filenames: Vec<String>,
+    #[serde(default)]
+    dar_hashes: Vec<String>,
+    /// The kicked participant, stored under the coordinator's field name.
+    #[serde(default)]
+    participant_id: Option<CantonId>,
+    #[serde(default)]
+    new_participant_id: Option<CantonId>,
+    #[serde(default)]
+    new_threshold: Option<i32>,
+}
+
+impl PeerExpectations {
+    /// Load the accepted invitation for a peer run.
+    ///
+    /// # Errors
+    ///
+    /// Errors if the run row is missing or its stored invitation cannot be
+    /// decoded. Both mean the peer cannot tell what its operator agreed to,
+    /// and a peer that cannot check a payload must not sign it.
+    pub async fn load(
+        db: &SqlitePool,
+        instance_name: &str,
+        node_config: &NodeConfig,
+        coordinator_id: &CantonId,
+    ) -> Result<Self> {
+        let run = db.get_workflow_run(instance_name).await?.ok_or_else(|| {
+            anyhow::anyhow!("no workflow run {instance_name} to validate against")
+        })?;
+
+        let config: PeerRunConfig = serde_json::from_str(&run.config_json).map_err(|e| {
+            anyhow::anyhow!("cannot decode the accepted invitation for {instance_name}: {e}")
+        })?;
+
+        let mut members: BTreeSet<CantonId> = config.participants.into_iter().collect();
+        members.insert(coordinator_id.clone());
+
+        Ok(Self {
+            kind: run.kind,
+            members,
+            dec_party_id: run.dec_party_id,
+            prefix: config.prefix,
+            threshold: config.new_threshold,
+            kicked_participant: config.participant_id,
+            new_participant: config.new_participant_id,
+            dar_filenames: config.dar_filenames,
+            dar_hashes: config.dar_hashes,
+            self_id: node_config.participant_id().clone(),
+        })
+    }
+
+    /// Validate the DNS proposal of an onboarding run.
+    ///
+    /// The party does not exist yet, so there is no party id to pin against.
+    /// What the peer can pin is the owner set it was invited into: one owner
+    /// per accepted member, its own namespace among them, the threshold the
+    /// invitation advertised, and a decentralized namespace that really is the
+    /// hash of those owners (so the coordinator cannot name an unrelated
+    /// namespace and have peers authorize it).
+    ///
+    /// # Errors
+    ///
+    /// Errors on any mismatch with the accepted invitation.
+    pub async fn check_onboarding_dns(
+        &self,
+        storage: &SqlitePool,
+        instance_name: &str,
+        payload: &[u8],
+    ) -> Result<String> {
+        let namespace_def = decode_namespace_definition(payload)?;
+
+        let owners: BTreeSet<String> = namespace_def.owners.iter().cloned().collect();
+        if owners.len() != namespace_def.owners.len() {
+            anyhow::bail!("DNS proposal repeats an owner namespace");
+        }
+        if owners.len() != self.members.len() {
+            anyhow::bail!(
+                "DNS proposal has {found} owners but the accepted invitation names \
+                 {expected} members",
+                found = owners.len(),
+                expected = self.members.len()
+            );
+        }
+
+        let own_namespace = self.own_namespace(storage, instance_name).await?;
+        if !owners.contains(&own_namespace) {
+            anyhow::bail!(
+                "DNS proposal does not include this node's namespace {own_namespace} \
+                 among its owners"
+            );
+        }
+
+        self.check_threshold(namespace_def.threshold, owners.len())?;
+
+        let owner_set: std::collections::HashSet<String> = owners.iter().cloned().collect();
+        let computed = compute_decentralized_namespace(&owner_set);
+        if computed != namespace_def.decentralized_namespace {
+            anyhow::bail!(
+                "DNS proposal claims namespace {claimed} but its owner set hashes to \
+                 {computed}",
+                claimed = namespace_def.decentralized_namespace
+            );
+        }
+
+        tracing::info!(
+            "DNS proposal matches the accepted invitation: {count} owners, threshold {threshold}",
+            count = owners.len(),
+            threshold = namespace_def.threshold
+        );
+        Ok(namespace_def.decentralized_namespace)
+    }
+
+    /// Validate the P2P proposal of an onboarding run.
+    ///
+    /// `dns_namespace` is the namespace this peer validated and signed in the
+    /// DNS step; the party id must be built from it, so the two proposals
+    /// cannot describe different parties.
+    ///
+    /// # Errors
+    ///
+    /// Errors on any mismatch with the accepted invitation.
+    pub async fn check_onboarding_p2p(
+        &self,
+        storage: &SqlitePool,
+        instance_name: &str,
+        payload: &[u8],
+        dns_namespace: Option<&str>,
+    ) -> Result {
+        let mapping = decode_party_to_participant(payload)?;
+        let party = CantonId::parse(&mapping.party)?;
+
+        match &self.prefix {
+            Some(prefix) if prefix != &party.prefix => anyhow::bail!(
+                "P2P proposal is for party prefix {found} but the accepted invitation \
+                 named {prefix}",
+                found = party.prefix
+            ),
+            Some(_) => {}
+            None => tracing::warn!(
+                "accepted onboarding invitation carried no party prefix; skipping the \
+                 prefix check on the P2P proposal"
+            ),
+        }
+
+        match dns_namespace {
+            Some(namespace) if namespace != party.namespace.to_hex() => anyhow::bail!(
+                "P2P proposal targets namespace {found} but this node signed DNS for \
+                 {namespace}",
+                found = party.namespace.to_hex()
+            ),
+            Some(_) => {}
+            None => tracing::warn!(
+                "no signed DNS namespace on record for {instance_name}; skipping the \
+                 namespace cross-check on the P2P proposal"
+            ),
+        }
+
+        self.check_p2p_membership(&mapping)?;
+        self.check_p2p_thresholds(&mapping)?;
+        self.check_own_daml_key(storage, instance_name, &mapping)
+            .await
+    }
+
+    /// Validate the DNS + P2P proposal pair of a kick, add-party or
+    /// change-threshold run.
+    ///
+    /// These run against a party that already exists, so the invitation pins
+    /// the party id itself: both mappings must target exactly that party, with
+    /// exactly the accepted member set and the accepted threshold.
+    ///
+    /// # Errors
+    ///
+    /// Errors on any mismatch with the accepted invitation.
+    pub async fn check_party_proposals(
+        &self,
+        storage: &SqlitePool,
+        instance_name: &str,
+        dns_payload: &[u8],
+        p2p_payload: &[u8],
+    ) -> Result {
+        let dec_party_id = self.dec_party_id.as_ref().ok_or_else(|| {
+            anyhow::anyhow!(
+                "accepted {kind:?} invitation carries no dec party id, so the proposals \
+                 cannot be checked against it",
+                kind = self.kind
+            )
+        })?;
+
+        let namespace_def = decode_namespace_definition(dns_payload)?;
+        if namespace_def.decentralized_namespace != dec_party_id.namespace.to_hex() {
+            anyhow::bail!(
+                "DNS proposal targets namespace {found} but the accepted invitation is for \
+                 {expected}",
+                found = namespace_def.decentralized_namespace,
+                expected = dec_party_id.namespace.to_hex()
+            );
+        }
+        if namespace_def.owners.len() != self.members.len() {
+            anyhow::bail!(
+                "DNS proposal has {found} owners but the accepted invitation names \
+                 {expected} members",
+                found = namespace_def.owners.len(),
+                expected = self.members.len()
+            );
+        }
+        self.check_threshold(namespace_def.threshold, namespace_def.owners.len())?;
+
+        // Losing our namespace from the owner set would leave this node hosting
+        // a party it can no longer authorize changes to. The lookup itself is
+        // best-effort — a party onboarded before the identity table existed may
+        // have no local record — but a namespace we *can* resolve must be there.
+        match self.own_namespace(storage, instance_name).await {
+            Ok(own_namespace) if !namespace_def.owners.contains(&own_namespace) => anyhow::bail!(
+                "DNS proposal drops this node's namespace {own_namespace} from the owner set"
+            ),
+            Ok(_) => {}
+            Err(e) => tracing::warn!(
+                "cannot resolve this node's namespace ({e}); skipping the owner-set \
+                 membership check on the DNS proposal"
+            ),
+        }
+
+        let mapping = decode_party_to_participant(p2p_payload)?;
+        if mapping.party != dec_party_id.to_string() {
+            anyhow::bail!(
+                "P2P proposal is for party {found} but the accepted invitation is for \
+                 {dec_party_id}",
+                found = mapping.party
+            );
+        }
+        self.check_p2p_membership(&mapping)?;
+        self.check_p2p_thresholds(&mapping)?;
+
+        tracing::info!(
+            "{kind:?} proposals match the accepted invitation for {dec_party_id}",
+            kind = self.kind
+        );
+        Ok(())
+    }
+
+    /// Validate the add-party onboarding-flag clearing proposal: same party,
+    /// same members, same threshold, and every hosting participant actually
+    /// clear of the onboarding flag.
+    ///
+    /// # Errors
+    ///
+    /// Errors on any mismatch with the accepted invitation.
+    pub fn check_clear_onboarding(&self, payload: &[u8]) -> Result {
+        let dec_party_id = self.dec_party_id.as_ref().ok_or_else(|| {
+            anyhow::anyhow!("accepted add-party invitation carries no dec party id")
+        })?;
+        let mapping = decode_party_to_participant(payload)?;
+
+        if mapping.party != dec_party_id.to_string() {
+            anyhow::bail!(
+                "clearing proposal is for party {found} but the accepted invitation is for \
+                 {dec_party_id}",
+                found = mapping.party
+            );
+        }
+        self.check_p2p_membership(&mapping)?;
+        self.check_p2p_thresholds(&mapping)?;
+
+        if let Some(still_onboarding) = mapping
+            .participants
+            .iter()
+            .find(|participant| participant.onboarding.is_some())
+        {
+            anyhow::bail!(
+                "clearing proposal still flags {participant} as onboarding",
+                participant = still_onboarding.participant_uid
+            );
+        }
+        Ok(())
+    }
+
+    /// Validate the DAR files a coordinator sends before they are uploaded and
+    /// vetted on this node's participant.
+    ///
+    /// # Errors
+    ///
+    /// Errors if a file was not named in the accepted invitation, if an
+    /// accepted file is missing, or if a file's content does not hash to the
+    /// value the invitation pinned.
+    pub fn check_dars(&self, files: &[(String, Vec<u8>)]) -> Result {
+        if self.dar_filenames.is_empty() {
+            tracing::warn!(
+                "accepted Dars invitation listed no filenames; skipping the DAR content \
+                 check (the coordinator predates the field)"
+            );
+            return Ok(());
+        }
+
+        let accepted: BTreeSet<&str> = self.dar_filenames.iter().map(String::as_str).collect();
+        let received: BTreeSet<&str> = files.iter().map(|(name, _)| name.as_str()).collect();
+        if let Some(unexpected) = received.difference(&accepted).next() {
+            anyhow::bail!("coordinator sent DAR {unexpected}, which the invitation did not name");
+        }
+        if let Some(missing) = accepted.difference(&received).next() {
+            anyhow::bail!("coordinator did not send DAR {missing} named by the invitation");
+        }
+
+        if self.dar_hashes.len() != self.dar_filenames.len() {
+            tracing::warn!(
+                "accepted Dars invitation carried no DAR hashes; the filenames match but \
+                 the content cannot be pinned (the coordinator predates the field)"
+            );
+            return Ok(());
+        }
+
+        for (filename, data) in files {
+            let expected = self
+                .dar_filenames
+                .iter()
+                .zip(&self.dar_hashes)
+                .find(|(name, _)| *name == filename)
+                .map(|(_, hash)| hash)
+                .ok_or_else(|| anyhow::anyhow!("no accepted hash for DAR {filename}"))?;
+            let actual = hex::encode(Sha256::digest(data));
+            if &actual != expected {
+                anyhow::bail!(
+                    "DAR {filename} hashes to {actual} but the invitation pinned {expected}"
+                );
+            }
+        }
+
+        tracing::info!(
+            "all {count} DAR(s) match the accepted invitation",
+            count = files.len()
+        );
+        Ok(())
+    }
+
+    /// The dec party a coordinator names in a workflow config must be the one
+    /// the operator accepted. Without this a peer would happily sign with its
+    /// keys for a party it never agreed to act for.
+    ///
+    /// # Errors
+    ///
+    /// Errors if the party differs from the accepted one.
+    pub fn check_dec_party(&self, party: &CantonId) -> Result {
+        match &self.dec_party_id {
+            Some(expected) if expected != party => anyhow::bail!(
+                "coordinator sent a config for party {party} but the accepted invitation \
+                 is for {expected}"
+            ),
+            Some(_) => Ok(()),
+            None => {
+                tracing::warn!(
+                    "accepted {kind:?} invitation carried no dec party id; skipping the \
+                     party check on the coordinator's config",
+                    kind = self.kind
+                );
+                Ok(())
+            }
+        }
+    }
+
+    /// The participant an add-party run introduces must be the one named in
+    /// the accepted invitation.
+    ///
+    /// # Errors
+    ///
+    /// Errors if the participant differs from the accepted one.
+    pub fn check_new_participant(&self, participant: &CantonId) -> Result {
+        match &self.new_participant {
+            Some(expected) if expected != participant => anyhow::bail!(
+                "coordinator is adding {participant} but the accepted invitation names \
+                 {expected}"
+            ),
+            Some(_) => Ok(()),
+            None => {
+                tracing::warn!(
+                    "accepted add-party invitation named no new participant; skipping the \
+                     check on the coordinator's config"
+                );
+                Ok(())
+            }
+        }
+    }
+
+    /// The hosting-participant set must be exactly the accepted members, and
+    /// this node must be one of them.
+    fn check_p2p_membership(&self, mapping: &PartyToParticipant) -> Result {
+        let mut hosts = BTreeSet::new();
+        for participant in &mapping.participants {
+            let id = CantonId::parse(&participant.participant_uid)?;
+            if !hosts.insert(id.clone()) {
+                anyhow::bail!("P2P proposal lists participant {id} twice");
+            }
+        }
+
+        if hosts != self.members {
+            let extra: Vec<String> = hosts
+                .difference(&self.members)
+                .map(CantonId::to_string)
+                .collect();
+            let missing: Vec<String> = self
+                .members
+                .difference(&hosts)
+                .map(CantonId::to_string)
+                .collect();
+            anyhow::bail!(
+                "P2P proposal host set does not match the accepted invitation \
+                 (unexpected: {extra:?}, missing: {missing:?})"
+            );
+        }
+        if !hosts.contains(&self.self_id) {
+            anyhow::bail!(
+                "P2P proposal does not host this node ({self_id})",
+                self_id = self.self_id
+            );
+        }
+        if let Some(kicked) = &self.kicked_participant
+            && hosts.contains(kicked)
+        {
+            anyhow::bail!("P2P proposal still hosts {kicked}, the participant being kicked");
+        }
+        if let Some(added) = &self.new_participant
+            && !hosts.contains(added)
+        {
+            anyhow::bail!("P2P proposal does not host {added}, the participant being added");
+        }
+        Ok(())
+    }
+
+    /// A `PartyToParticipant` mapping carries two thresholds: how many hosting
+    /// participants must confirm, and how many of the party's signing keys
+    /// authorize a transaction for it. Both are pinned — leaving the signing
+    /// threshold unchecked would let a coordinator raise a hosting threshold
+    /// the operator agreed to while quietly dropping the signing one to 1.
+    fn check_p2p_thresholds(&self, mapping: &PartyToParticipant) -> Result {
+        self.check_threshold(i32::try_from(mapping.threshold)?, self.members.len())?;
+        match &mapping.party_signing_keys {
+            Some(signing_keys) => {
+                self.check_threshold(i32::try_from(signing_keys.threshold)?, self.members.len())
+            }
+            None => {
+                tracing::warn!(
+                    "P2P proposal carries no party signing keys, so their threshold cannot \
+                     be checked"
+                );
+                Ok(())
+            }
+        }
+    }
+
+    /// The threshold must be the one the invitation advertised, and in any
+    /// case a sane value for the owner count — a threshold of 0 or one above
+    /// the owner count would either need no signatures or deadlock the party.
+    fn check_threshold(&self, threshold: i32, owner_count: usize) -> Result {
+        let owner_count = i32::try_from(owner_count)?;
+        if !(1..=owner_count).contains(&threshold) {
+            anyhow::bail!("proposed threshold {threshold} is outside 1..={owner_count}");
+        }
+        match self.threshold {
+            Some(expected) if expected != threshold => {
+                anyhow::bail!("proposed threshold {threshold} differs from the accepted {expected}")
+            }
+            Some(_) => Ok(()),
+            None => {
+                tracing::warn!(
+                    "accepted invitation carried no threshold; only the range check was \
+                     applied to the proposed {threshold}"
+                );
+                Ok(())
+            }
+        }
+    }
+
+    /// This node's Daml signing key must be among the party's signing keys, or
+    /// it would be a member that cannot sign for the party it just authorized.
+    async fn check_own_daml_key(
+        &self,
+        storage: &SqlitePool,
+        instance_name: &str,
+        mapping: &PartyToParticipant,
+    ) -> Result {
+        let keys = self.own_keys(storage, instance_name).await?;
+        let own_daml_fingerprint = utils::compute_fingerprint(&keys[1]);
+        let signing_keys = mapping
+            .party_signing_keys
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("P2P proposal carries no party signing keys"))?;
+
+        if !signing_keys
+            .keys
+            .iter()
+            .any(|key| utils::compute_fingerprint(key) == own_daml_fingerprint)
+        {
+            anyhow::bail!(
+                "P2P proposal does not carry this node's Daml signing key \
+                 {own_daml_fingerprint}"
+            );
+        }
+        Ok(())
+    }
+
+    /// This node's namespace fingerprint for the run: from the keys it
+    /// generated during onboarding, falling back to the long-lived identity
+    /// row when the run's artefacts are already gone.
+    async fn own_namespace(&self, storage: &SqlitePool, instance_name: &str) -> Result<String> {
+        let keys = self.own_keys(storage, instance_name).await?;
+        Ok(utils::compute_fingerprint(&keys[0]))
+    }
+
+    /// This node's `[namespace_key, daml_key]` bundle.
+    async fn own_keys(
+        &self,
+        storage: &SqlitePool,
+        instance_name: &str,
+    ) -> Result<Vec<SigningPublicKey>> {
+        let self_id = self.self_id.to_string();
+        let payload = match storage
+            .read_artifact(
+                instance_name,
+                artifact_kinds::PEER_PUBLIC_KEYS,
+                Some(&self_id),
+            )
+            .await?
+        {
+            Some(payload) => payload,
+            None => {
+                let dec_party_id = self.dec_party_id.as_ref().ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "this node's public keys are not on the {instance_name} run and \
+                         there is no dec party to look them up under"
+                    )
+                })?;
+                storage
+                    .read_identity(dec_party_id, identity_kinds::PEER_PUBLIC_KEYS, &self_id)
+                    .await?
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "this node's public keys are unknown for {dec_party_id}, so the \
+                             proposal cannot be checked against them"
+                        )
+                    })?
+            }
+        };
+
+        let keys = decode_keys_payload(&payload)?;
+        if keys.len() != 2 {
+            anyhow::bail!(
+                "expected 2 public keys for this node, found {count}",
+                count = keys.len()
+            );
+        }
+        Ok(keys)
+    }
+}
+
+/// Unwrap a coordinator-supplied `varint(len)||SignedTopologyTransaction`
+/// blob down to the topology mapping it carries.
+///
+/// Only an add-or-replace is ever signed. A `Remove` carrying the right party
+/// and the right members would pass every other check while tearing the
+/// mapping down, so the operation is pinned here, before anything else looks
+/// at the mapping.
+fn decode_topology_mapping(payload: &[u8]) -> Result<topology_mapping::Mapping> {
+    let signed: SignedTopologyTransaction = utils::read_first_message_from_bytes(payload)?;
+    let transaction = utils::decode_versioned::<TopologyTransaction>(&signed.transaction)?;
+
+    if transaction.operation != enums::TopologyChangeOp::AddReplace as i32 {
+        anyhow::bail!(
+            "topology transaction is a {operation:?} operation, not an add-or-replace",
+            operation = enums::TopologyChangeOp::try_from(transaction.operation)
+                .map(|op| op.as_str_name().to_string())
+                .unwrap_or_else(|_| format!("unknown ({})", transaction.operation))
+        );
+    }
+
+    transaction
+        .mapping
+        .and_then(|mapping| mapping.mapping)
+        .ok_or_else(|| anyhow::anyhow!("topology transaction carries no mapping"))
+}
+
+fn decode_namespace_definition(payload: &[u8]) -> Result<DecentralizedNamespaceDefinition> {
+    match decode_topology_mapping(payload)? {
+        topology_mapping::Mapping::DecentralizedNamespaceDefinition(def) => Ok(def),
+        other => anyhow::bail!(
+            "expected a DecentralizedNamespaceDefinition, got {kind}",
+            kind = mapping_name(&other)
+        ),
+    }
+}
+
+fn decode_party_to_participant(payload: &[u8]) -> Result<PartyToParticipant> {
+    match decode_topology_mapping(payload)? {
+        topology_mapping::Mapping::PartyToParticipant(mapping) => Ok(mapping),
+        other => anyhow::bail!(
+            "expected a PartyToParticipant mapping, got {kind}",
+            kind = mapping_name(&other)
+        ),
+    }
+}
+
+/// A short name for a mapping the peer refuses to sign, so the error says what
+/// arrived without dumping the whole protobuf.
+fn mapping_name(mapping: &topology_mapping::Mapping) -> &'static str {
+    use topology_mapping::Mapping;
+    match mapping {
+        Mapping::NamespaceDelegation(_) => "NamespaceDelegation",
+        Mapping::DecentralizedNamespaceDefinition(_) => "DecentralizedNamespaceDefinition",
+        Mapping::OwnerToKeyMapping(_) => "OwnerToKeyMapping",
+        Mapping::PartyToParticipant(_) => "PartyToParticipant",
+        Mapping::SynchronizerTrustCertificate(_) => "SynchronizerTrustCertificate",
+        Mapping::ParticipantPermission(_) => "ParticipantPermission",
+        Mapping::PartyHostingLimits(_) => "PartyHostingLimits",
+        Mapping::VettedPackages(_) => "VettedPackages",
+        Mapping::SynchronizerParametersState(_) => "SynchronizerParametersState",
+        Mapping::MediatorSynchronizerState(_) => "MediatorSynchronizerState",
+        Mapping::SequencerSynchronizerState(_) => "SequencerSynchronizerState",
+        Mapping::SequencingDynamicParametersState(_) => "SequencingDynamicParametersState",
+        Mapping::SynchronizerUpgradeAnnouncement(_) => "SynchronizerUpgradeAnnouncement",
+        Mapping::SequencerConnectionSuccessor(_) => "SequencerConnectionSuccessor",
+        _ => "an unrecognized mapping",
+    }
+}
+
+/// SHA-256 of a DAR's bytes, hex encoded — the value a coordinator pins in the
+/// invitation and a peer recomputes before it uploads and vets the file.
+pub fn hash_dar(data: &[u8]) -> String {
+    hex::encode(Sha256::digest(data))
+}
+
+#[cfg(test)]
+mod tests {
+    use canton_proto_rs::com::digitalasset::canton::{
+        crypto::v30::SigningKeysWithThreshold,
+        protocol::v30::{
+            TopologyMapping, enums,
+            party_to_participant::{HostingParticipant, hosting_participant},
+        },
+        version::v1::{UntypedVersionedMessage, untyped_versioned_message},
+    };
+    use prost::Message;
+
+    use super::*;
+
+    fn canton_id(prefix: &str, byte: u8) -> Result<CantonId> {
+        let mut namespace = vec![0x12, 0x20];
+        namespace.extend(std::iter::repeat_n(byte, 32));
+        CantonId::parse(&format!("{prefix}::{hex}", hex = hex::encode(namespace)))
+    }
+
+    fn expectations(members: Vec<CantonId>, self_id: CantonId) -> PeerExpectations {
+        PeerExpectations {
+            kind: WorkflowKind::ChangeThreshold,
+            members: members.into_iter().collect(),
+            dec_party_id: None,
+            prefix: None,
+            threshold: Some(2),
+            kicked_participant: None,
+            new_participant: None,
+            dar_filenames: Vec::new(),
+            dar_hashes: Vec::new(),
+            self_id,
+        }
+    }
+
+    fn p2p(party: &str, hosts: &[CantonId], threshold: u32) -> PartyToParticipant {
+        PartyToParticipant {
+            party: party.to_string(),
+            threshold,
+            participants: hosts
+                .iter()
+                .map(|id| HostingParticipant {
+                    participant_uid: id.to_string(),
+                    permission: enums::ParticipantPermission::Confirmation as i32,
+                    onboarding: None,
+                })
+                .collect(),
+            party_signing_keys: None,
+        }
+    }
+
+    /// Wrap a mapping the way the coordinator ships it, so the decode path is
+    /// exercised end to end rather than around.
+    fn encode_proposal(mapping: topology_mapping::Mapping) -> Vec<u8> {
+        encode_proposal_with_op(mapping, enums::TopologyChangeOp::AddReplace as i32)
+    }
+
+    fn encode_proposal_with_op(mapping: topology_mapping::Mapping, operation: i32) -> Vec<u8> {
+        let transaction = TopologyTransaction {
+            operation,
+            serial: 1,
+            mapping: Some(TopologyMapping {
+                mapping: Some(mapping),
+            }),
+        };
+        let signed = SignedTopologyTransaction {
+            transaction: UntypedVersionedMessage {
+                version: 30,
+                wrapper: Some(untyped_versioned_message::Wrapper::Data(
+                    transaction.encode_to_vec(),
+                )),
+            }
+            .encode_to_vec(),
+            ..Default::default()
+        };
+        utils::encode_length_prefixed_message(&signed)
+    }
+
+    #[test]
+    fn accepts_a_matching_host_set() -> Result {
+        let (a, b) = (canton_id("p1", 1)?, canton_id("p2", 2)?);
+        let expectations = expectations(vec![a.clone(), b.clone()], a.clone());
+        expectations.check_p2p_membership(&p2p("dec::x", &[a, b], 2))
+    }
+
+    /// The attack this whole module exists for: a coordinator proposing a
+    /// party hosted somewhere the operator never agreed to.
+    #[test]
+    fn rejects_an_unexpected_host() -> Result {
+        let (a, b, mallory) = (
+            canton_id("p1", 1)?,
+            canton_id("p2", 2)?,
+            canton_id("evil", 9)?,
+        );
+        let expectations = expectations(vec![a.clone(), b.clone()], a.clone());
+        assert!(
+            expectations
+                .check_p2p_membership(&p2p("dec::x", &[a, b, mallory], 2))
+                .is_err()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_dropping_a_member() -> Result {
+        let (a, b) = (canton_id("p1", 1)?, canton_id("p2", 2)?);
+        let expectations = expectations(vec![a.clone(), b], a.clone());
+        assert!(
+            expectations
+                .check_p2p_membership(&p2p("dec::x", &[a], 1))
+                .is_err()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_a_proposal_that_does_not_host_this_node() -> Result {
+        let (a, b, c) = (
+            canton_id("p1", 1)?,
+            canton_id("p2", 2)?,
+            canton_id("p3", 3)?,
+        );
+        let expectations = expectations(vec![b.clone(), c.clone()], a);
+        assert!(
+            expectations
+                .check_p2p_membership(&p2p("dec::x", &[b, c], 2))
+                .is_err()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_a_kicked_participant_that_is_still_hosted() -> Result {
+        let (a, b, kicked) = (
+            canton_id("p1", 1)?,
+            canton_id("p2", 2)?,
+            canton_id("p3", 3)?,
+        );
+        let mut expectations = expectations(vec![a.clone(), b.clone(), kicked.clone()], a.clone());
+        expectations.kicked_participant = Some(kicked.clone());
+        assert!(
+            expectations
+                .check_p2p_membership(&p2p("dec::x", &[a, b, kicked], 2))
+                .is_err()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_a_duplicated_host() -> Result {
+        let a = canton_id("p1", 1)?;
+        let expectations = expectations(vec![a.clone()], a.clone());
+        assert!(
+            expectations
+                .check_p2p_membership(&p2p("dec::x", &[a.clone(), a], 1))
+                .is_err()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_a_threshold_the_invitation_did_not_advertise() -> Result {
+        let a = canton_id("p1", 1)?;
+        let expectations = expectations(vec![a.clone()], a);
+        assert!(expectations.check_threshold(1, 3).is_err());
+        Ok(())
+    }
+
+    /// A threshold of zero would let any single signer act for the party.
+    #[test]
+    fn rejects_an_out_of_range_threshold() -> Result {
+        let a = canton_id("p1", 1)?;
+        let mut expectations = expectations(vec![a.clone()], a);
+        expectations.threshold = Some(0);
+        assert!(expectations.check_threshold(0, 3).is_err());
+        expectations.threshold = Some(4);
+        assert!(expectations.check_threshold(4, 3).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn accepts_the_advertised_threshold() -> Result {
+        let a = canton_id("p1", 1)?;
+        let expectations = expectations(vec![a.clone()], a);
+        expectations.check_threshold(2, 3)
+    }
+
+    #[tokio::test]
+    async fn rejects_proposals_for_another_party() -> Result {
+        let (a, b) = (canton_id("p1", 1)?, canton_id("p2", 2)?);
+        let mut expectations = expectations(vec![a.clone(), b.clone()], a.clone());
+        expectations.dec_party_id = Some(canton_id("ours", 7)?);
+        let their_party = canton_id("theirs", 8)?;
+
+        let dns = encode_proposal(topology_mapping::Mapping::DecentralizedNamespaceDefinition(
+            DecentralizedNamespaceDefinition {
+                decentralized_namespace: their_party.namespace.to_hex(),
+                threshold: 2,
+                owners: vec!["one".to_string(), "two".to_string()],
+            },
+        ));
+        let p2p_payload = encode_proposal(topology_mapping::Mapping::PartyToParticipant(p2p(
+            &their_party.to_string(),
+            &[a, b],
+            2,
+        )));
+
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:").await?;
+        assert!(
+            expectations
+                .check_party_proposals(&pool, "run", &dns, &p2p_payload)
+                .await
+                .is_err()
+        );
+        Ok(())
+    }
+
+    /// A payload that decodes to some other topology mapping must be refused
+    /// outright rather than signed because it happened to parse.
+    #[test]
+    fn rejects_a_mapping_of_the_wrong_kind() -> Result {
+        let payload = encode_proposal(topology_mapping::Mapping::PartyToParticipant(p2p(
+            "dec::x",
+            &[canton_id("p1", 1)?],
+            1,
+        )));
+        assert!(decode_namespace_definition(&payload).is_err());
+        Ok(())
+    }
+
+    /// A Remove that names the accepted party and members would pass every
+    /// content check while tearing the mapping down, so the operation itself
+    /// is pinned.
+    #[test]
+    fn rejects_a_remove_operation() -> Result {
+        let payload = encode_proposal_with_op(
+            topology_mapping::Mapping::PartyToParticipant(p2p("dec::x", &[canton_id("p1", 1)?], 1)),
+            enums::TopologyChangeOp::Remove as i32,
+        );
+        assert!(decode_party_to_participant(&payload).is_err());
+        Ok(())
+    }
+
+    /// The signing threshold decides how many member keys authorize a
+    /// transaction for the party. Dropping it to 1 while the hosting
+    /// threshold looks right would hand any single member the party.
+    #[test]
+    fn rejects_a_weakened_party_signing_threshold() -> Result {
+        let (a, b) = (canton_id("p1", 1)?, canton_id("p2", 2)?);
+        let expectations = expectations(vec![a.clone(), b.clone()], a.clone());
+        let mut mapping = p2p("dec::x", &[a, b], 2);
+        mapping.party_signing_keys = Some(SigningKeysWithThreshold {
+            keys: Vec::new(),
+            threshold: 1,
+        });
+        assert!(expectations.check_p2p_thresholds(&mapping).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn accepts_matching_hosting_and_signing_thresholds() -> Result {
+        let (a, b) = (canton_id("p1", 1)?, canton_id("p2", 2)?);
+        let expectations = expectations(vec![a.clone(), b.clone()], a.clone());
+        let mut mapping = p2p("dec::x", &[a, b], 2);
+        mapping.party_signing_keys = Some(SigningKeysWithThreshold {
+            keys: Vec::new(),
+            threshold: 2,
+        });
+        expectations.check_p2p_thresholds(&mapping)
+    }
+
+    #[test]
+    fn rejects_a_clearing_proposal_that_still_flags_onboarding() -> Result {
+        let (a, b) = (canton_id("p1", 1)?, canton_id("p2", 2)?);
+        let party = canton_id("dec", 7)?;
+        let mut expectations = expectations(vec![a.clone(), b.clone()], a.clone());
+        expectations.dec_party_id = Some(party.clone());
+
+        let mut mapping = p2p(&party.to_string(), &[a, b], 2);
+        mapping.participants[1].onboarding = Some(hosting_participant::Onboarding::default());
+        let payload = encode_proposal(topology_mapping::Mapping::PartyToParticipant(mapping));
+
+        assert!(expectations.check_clear_onboarding(&payload).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn accepts_dars_matching_the_pinned_hashes() -> Result {
+        let a = canton_id("p1", 1)?;
+        let mut expectations = expectations(vec![a.clone()], a);
+        expectations.dar_filenames = vec!["gov.dar".to_string()];
+        expectations.dar_hashes = vec![hash_dar(b"gov-bytes")];
+        expectations.check_dars(&[("gov.dar".to_string(), b"gov-bytes".to_vec())])
+    }
+
+    /// Same filename, different bytes: the DAR the operator saw named is not
+    /// the DAR that arrived.
+    #[test]
+    fn rejects_a_swapped_dar() -> Result {
+        let a = canton_id("p1", 1)?;
+        let mut expectations = expectations(vec![a.clone()], a);
+        expectations.dar_filenames = vec!["gov.dar".to_string()];
+        expectations.dar_hashes = vec![hash_dar(b"gov-bytes")];
+        assert!(
+            expectations
+                .check_dars(&[("gov.dar".to_string(), b"malicious-bytes".to_vec())])
+                .is_err()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_an_extra_dar() -> Result {
+        let a = canton_id("p1", 1)?;
+        let mut expectations = expectations(vec![a.clone()], a);
+        expectations.dar_filenames = vec!["gov.dar".to_string()];
+        expectations.dar_hashes = vec![hash_dar(b"gov-bytes")];
+        assert!(
+            expectations
+                .check_dars(&[
+                    ("gov.dar".to_string(), b"gov-bytes".to_vec()),
+                    ("extra.dar".to_string(), b"whatever".to_vec()),
+                ])
+                .is_err()
+        );
+        Ok(())
+    }
+
+    /// An older coordinator sends filenames but no hashes: the filename check
+    /// still applies, the content check is skipped with a warning.
+    #[test]
+    fn tolerates_an_invitation_without_dar_hashes() -> Result {
+        let a = canton_id("p1", 1)?;
+        let mut expectations = expectations(vec![a.clone()], a);
+        expectations.dar_filenames = vec!["gov.dar".to_string()];
+        expectations.check_dars(&[("gov.dar".to_string(), b"anything".to_vec())])?;
+        assert!(
+            expectations
+                .check_dars(&[("other.dar".to_string(), b"anything".to_vec())])
+                .is_err()
+        );
+        Ok(())
+    }
+}

--- a/crates/decman/src/workflow/validation.rs
+++ b/crates/decman/src/workflow/validation.rs
@@ -138,6 +138,35 @@ impl PeerExpectations {
         })
     }
 
+    /// Validate the onboarding config the coordinator sends before this node
+    /// generates keys.
+    ///
+    /// `generate_keys` derives the vault key names from `party_id_prefix`, so
+    /// an unchecked prefix lets a coordinator have this node create keys under
+    /// a name the operator never accepted — or reuse the keys already sitting
+    /// under another party's prefix, and authorize a namespace delegation for
+    /// it. The prefix is pinned before any of that happens.
+    ///
+    /// # Errors
+    ///
+    /// Errors if the prefix differs from the accepted one, or if the accepted
+    /// invitation carries none.
+    pub fn check_onboarding_config(&self, party_id_prefix: &str) -> Result {
+        let accepted = self.prefix.as_deref().ok_or_else(|| {
+            anyhow::anyhow!(
+                "accepted onboarding invitation carries no party prefix, so the \
+                 coordinator's config cannot be checked against it"
+            )
+        })?;
+        if accepted != party_id_prefix {
+            anyhow::bail!(
+                "coordinator asked for keys under prefix {party_id_prefix} but the accepted \
+                 invitation names {accepted}"
+            );
+        }
+        Ok(())
+    }
+
     /// Validate the DNS proposal of an onboarding run.
     ///
     /// The party does not exist yet, so there is no party id to pin against.
@@ -171,7 +200,15 @@ impl PeerExpectations {
             );
         }
 
-        let own_namespace = self.own_namespace(storage, instance_name).await?;
+        let own_namespace = self
+            .own_namespace(storage, instance_name)
+            .await?
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "this node's public keys are not on the {instance_name} run, so the DNS \
+                     proposal cannot be checked against them"
+                )
+            })?;
         if !owners.contains(&own_namespace) {
             anyhow::bail!(
                 "DNS proposal does not include this node's namespace {own_namespace} \
@@ -234,17 +271,24 @@ impl PeerExpectations {
             ),
         }
 
-        match dns_namespace {
-            Some(namespace) if namespace != party.namespace.to_hex() => anyhow::bail!(
+        // The command gate checks the workflow kind, not the step order, so a
+        // coordinator can send SignP2p before SignDns. Absent therefore means
+        // "this run has not signed a DNS proposal", which the coordinator
+        // controls — not "an older build did not record it". Treating it as
+        // legacy let a coordinator skip DNS and have the peer sign a party
+        // with any namespace whose prefix happened to match.
+        let Some(namespace) = dns_namespace else {
+            anyhow::bail!(
+                "no DNS namespace recorded for {instance_name}: this run has not signed a \
+                 DNS proposal, so the P2P proposal cannot be pinned to one"
+            );
+        };
+        if namespace != party.namespace.to_hex() {
+            anyhow::bail!(
                 "P2P proposal targets namespace {found} but this node signed DNS for \
                  {namespace}",
                 found = party.namespace.to_hex()
-            ),
-            Some(_) => {}
-            None => tracing::warn!(
-                "no signed DNS namespace on record for {instance_name}; skipping the \
-                 namespace cross-check on the P2P proposal"
-            ),
+            );
         }
 
         self.check_p2p_membership(&mapping)?;
@@ -310,14 +354,19 @@ impl PeerExpectations {
         // a party it can no longer authorize changes to. The lookup itself is
         // best-effort — a party onboarded before the identity table existed may
         // have no local record — but a namespace we *can* resolve must be there.
-        match self.own_namespace(storage, instance_name).await {
-            Ok(own_namespace) if !namespace_def.owners.contains(&own_namespace) => anyhow::bail!(
-                "DNS proposal drops this node's namespace {own_namespace} from the owner set"
-            ),
-            Ok(_) => {}
-            Err(e) => tracing::warn!(
-                "cannot resolve this node's namespace ({e}); skipping the owner-set \
-                 membership check on the DNS proposal"
+        // A lookup or decode failure is an error, not a legacy party: letting
+        // it through would hand a coordinator this peer's signature on a
+        // proposal that drops its own namespace.
+        match self.own_namespace(storage, instance_name).await? {
+            Some(own_namespace) if !namespace_def.owners.contains(&own_namespace) => {
+                anyhow::bail!(
+                    "DNS proposal drops this node's namespace {own_namespace} from the owner set"
+                )
+            }
+            Some(_) => {}
+            None => tracing::warn!(
+                "this node's keys are unrecorded for this party (onboarded before the \
+                 identity table existed); skipping the owner-set membership check"
             ),
         }
 
@@ -654,7 +703,15 @@ impl PeerExpectations {
         instance_name: &str,
         mapping: &PartyToParticipant,
     ) -> Result {
-        let keys = self.own_keys(storage, instance_name).await?;
+        let keys = self
+            .own_keys(storage, instance_name)
+            .await?
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "this node's public keys are not on the {instance_name} run, so the P2P \
+                     proposal cannot be checked against them"
+                )
+            })?;
         let own_daml_fingerprint = utils::compute_fingerprint(&keys[1]);
         let signing_keys = mapping
             .party_signing_keys
@@ -677,9 +734,15 @@ impl PeerExpectations {
     /// This node's namespace fingerprint for the run: from the keys it
     /// generated during onboarding, falling back to the long-lived identity
     /// row when the run's artefacts are already gone.
-    async fn own_namespace(&self, storage: &SqlitePool, instance_name: &str) -> Result<String> {
-        let keys = self.own_keys(storage, instance_name).await?;
-        Ok(utils::compute_fingerprint(&keys[0]))
+    async fn own_namespace(
+        &self,
+        storage: &SqlitePool,
+        instance_name: &str,
+    ) -> Result<Option<String>> {
+        Ok(self
+            .own_keys(storage, instance_name)
+            .await?
+            .map(|keys| utils::compute_fingerprint(&keys[0])))
     }
 
     /// This node's `[namespace_key, daml_key]` bundle.
@@ -687,9 +750,9 @@ impl PeerExpectations {
         &self,
         storage: &SqlitePool,
         instance_name: &str,
-    ) -> Result<Vec<SigningPublicKey>> {
+    ) -> Result<Option<Vec<SigningPublicKey>>> {
         let self_id = self.self_id.to_string();
-        let payload = match storage
+        let stored = match storage
             .read_artifact(
                 instance_name,
                 artifact_kinds::PEER_PUBLIC_KEYS,
@@ -697,24 +760,24 @@ impl PeerExpectations {
             )
             .await?
         {
-            Some(payload) => payload,
-            None => {
-                let dec_party_id = self.dec_party_id.as_ref().ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "this node's public keys are not on the {instance_name} run and \
-                         there is no dec party to look them up under"
-                    )
-                })?;
-                storage
-                    .read_identity(dec_party_id, identity_kinds::PEER_PUBLIC_KEYS, &self_id)
-                    .await?
-                    .ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "this node's public keys are unknown for {dec_party_id}, so the \
-                             proposal cannot be checked against them"
-                        )
-                    })?
-            }
+            Some(payload) => Some(payload),
+            // No run artefact and no dec party to look under, or no identity
+            // row for one: the keys are genuinely unrecorded. That is the
+            // pre-identity-table party, and the only case a caller may treat
+            // leniently. A read that *fails*, or a payload that will not
+            // decode, is an error and stays one.
+            None => match self.dec_party_id.as_ref() {
+                Some(dec_party_id) => {
+                    storage
+                        .read_identity(dec_party_id, identity_kinds::PEER_PUBLIC_KEYS, &self_id)
+                        .await?
+                }
+                None => None,
+            },
+        };
+
+        let Some(payload) = stored else {
+            return Ok(None);
         };
 
         let keys = decode_keys_payload(&payload)?;
@@ -724,7 +787,7 @@ impl PeerExpectations {
                 count = keys.len()
             );
         }
-        Ok(keys)
+        Ok(Some(keys))
     }
 }
 
@@ -1132,6 +1195,61 @@ mod tests {
 
         expectations.kind = WorkflowKind::Onboarding;
         expectations.check_threshold(2, 3)
+    }
+
+    /// `generate_keys` derives the vault key names from the prefix, so an
+    /// unchecked one lets a coordinator have this node create keys under a name
+    /// the operator never accepted — or reuse the keys already sitting under
+    /// another party's prefix.
+    #[test]
+    fn rejects_key_generation_under_an_unaccepted_prefix() -> Result {
+        let a = canton_id("p1", 1)?;
+        let mut expectations = expectations(vec![a.clone()], a);
+        expectations.kind = WorkflowKind::Onboarding;
+        expectations.prefix = Some("treasury".to_string());
+
+        assert!(
+            expectations
+                .check_onboarding_config("someone-elses-party")
+                .is_err()
+        );
+        expectations.check_onboarding_config("treasury")?;
+
+        // No accepted prefix at all is not a licence to pick one.
+        expectations.prefix = None;
+        assert!(expectations.check_onboarding_config("treasury").is_err());
+        Ok(())
+    }
+
+    /// The command gate checks the workflow kind, not the step order, so a
+    /// coordinator can send SignP2p before SignDns. With no namespace recorded
+    /// the peer must refuse rather than fall back to the prefix check.
+    #[tokio::test]
+    async fn rejects_a_p2p_proposal_before_any_dns_was_signed() -> Result {
+        let a = canton_id("p1", 1)?;
+        let mut expectations = expectations(vec![a.clone()], a.clone());
+        expectations.kind = WorkflowKind::Onboarding;
+        expectations.prefix = Some("treasury".to_string());
+
+        let party = format!("treasury::{}", canton_id("x", 9)?.namespace.to_hex());
+        let payload = encode_proposal(topology_mapping::Mapping::PartyToParticipant(p2p(
+            &party,
+            &[a],
+            1,
+        )));
+
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:").await?;
+        let error = expectations
+            .check_onboarding_p2p(&pool, "run", &payload, None)
+            .await
+            .err()
+            .map(|e| e.to_string())
+            .unwrap_or_default();
+        assert!(
+            error.contains("has not signed a DNS proposal"),
+            "unexpected error: {error}"
+        );
+        Ok(())
     }
 
     /// The prefix is required on every onboarding invite, so an absent one

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -176,6 +176,56 @@ Coordinator                           Peer
     |--- Disconnect --------------------->|
 ```
 
+### Coordinator / Peer Trust Model
+
+A coordinator drives the protocol; a peer executes what it is told. The two are
+not equally trusted, and the boundary matters because a peer's Canton
+participant holds keys that can authorize topology changes for the
+decentralized party.
+
+**What the coordinator is trusted for.** Sequencing the run: deciding which
+step happens when, aggregating signatures, and submitting the result. It also
+builds the payloads — the topology proposals, the DAR bytes, the prepared
+ledger submissions.
+
+**What the coordinator is not trusted for.** The *content* of those payloads. A
+coordinator that is compromised, or simply running modified code, can put
+anything in them. The Noise channel proves who the coordinator is, not that
+what it sends is what the peer's operator agreed to.
+
+**Where the peer's consent lives.** The invitation. The operator sees the
+party, the members, the threshold, the participant being added or removed and
+the DAR filenames and hashes, and accepts once per run. That invitation is
+persisted on the peer's `workflow_runs` row and is the reference for
+everything that follows (`workflow::validation::PeerExpectations`).
+
+**What the peer checks before it signs or installs anything:**
+
+- The command belongs to the accepted workflow kind. A Contracts invitation
+  cannot be used to drive a kick.
+- Topology proposals decode to the expected mapping kind, target the accepted
+  party, carry exactly the accepted member set, keep this node's namespace
+  among the owners, and use the accepted threshold. For onboarding — where the
+  party does not exist yet — the peer instead checks that the decentralized
+  namespace really is the hash of the proposed owner set, and that the P2P
+  proposal is for the namespace it signed in the DNS step.
+- Prepared ledger submissions are re-hashed locally from the transaction that
+  accompanies them (`canton_hash`), so a signature can only ever authorize the
+  transaction the peer can inspect, and that transaction must act as the
+  accepted party. A hashing scheme this node cannot reproduce is refused
+  rather than signed blind.
+- DAR files match the filenames *and* the SHA-256 hashes named in the
+  invitation, so a coordinator cannot get different code vetted under an
+  accepted name.
+
+Any mismatch fails the step. Repeated mismatches abort the peer run.
+
+**Known limits.** A coordinator on an older version may send an invitation
+without the DAR hashes; the peer then checks filenames only and logs a warning,
+so a network mid-upgrade keeps working. Governance confirm/execute is not
+covered here and does not need to be: the peer builds those commands locally
+and the Daml layer re-validates them against the on-ledger proposal.
+
 ## Communication Protocol
 
 ### Wire Format

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -220,11 +220,34 @@ everything that follows (`workflow::validation::PeerExpectations`).
 
 Any mismatch fails the step. Repeated mismatches abort the peer run.
 
-**Known limits.** A coordinator on an older version may send an invitation
-without the DAR hashes; the peer then checks filenames only and logs a warning,
-so a network mid-upgrade keeps working. Governance confirm/execute is not
-covered here and does not need to be: the peer builds those commands locally
-and the Daml layer re-validates them against the on-ledger proposal.
+**What this does not cover.** The checks bound what a coordinator can obtain a
+signature for; they do not make the coordinator trustworthy. Three gaps remain,
+and they are load-bearing enough to state rather than imply:
+
+- **A peer cannot verify the other members' namespaces or signing keys.** It
+  only ever sends its own key bundle to the coordinator and never sees the
+  others', so it can confirm that it was not excluded but not that the rest of
+  the owner set and key set belong to the members named in the invitation. A
+  DNS proposal needs `threshold` signatures rather than all of them, so a
+  namespace or key belonging to a member that does not sign this round can be
+  substituted without any signer noticing. Closable for kick / add-party /
+  change-threshold by comparing against the current on-chain state
+  (DLC-link/decentralization-manager#420, #422); not closable for onboarding
+  without a protocol change, because no on-chain state exists yet.
+- **The contracts workflow constrains who a transaction acts as, not what it
+  does.** The peer recomputes the hash and pins `act_as` to the accepted dec
+  party, so it can only ever authorize the transaction it can read — but the
+  accepted package names are never compared against the transaction's nodes, so
+  any create or exercise acting as that party passes
+  (DLC-link/decentralization-manager#423).
+- **An older coordinator may send an invitation without the DAR hashes.** The
+  peer then checks filenames only and logs a warning, so a network mid-upgrade
+  keeps working. This is the only leniency left for an absent field, alongside
+  the onboarding threshold; every other absent pin fails closed.
+
+Governance confirm/execute is not covered here and does not need to be: the peer
+builds those commands locally and the Daml layer re-validates them against the
+on-ledger proposal.
 
 ## Communication Protocol
 


### PR DESCRIPTION
Closes HOM-7725.

A peer authenticates the coordinator over the Noise channel, and its operator accepts one invitation per run. After that the daemon signed whatever the coordinator sent: the payload content was never checked against what the operator agreed to.

The accepted invitation is now the reference for the whole run. `workflow::validation::PeerExpectations` reads it back off the peer's own `workflow_runs` row, and every step checks its payload against it.

## What a peer checks now

- **Workflow kind.** A command that does not belong to the accepted workflow is refused before any signing step sees its payload.
- **Topology transactions.** Must be an add-or-replace of the expected mapping kind, for the accepted party, with the accepted member set, this node's namespace still among the DNS owners, and both the hosting and the party-signing threshold as advertised.
- **Onboarding.** No party exists yet, so the decentralized namespace is pinned to the hash of the proposed owner set, and the P2P proposal must name the namespace the peer signed in the DNS step.
- **Prepared submissions.** The hash is recomputed locally from the transaction beside it, and the transaction must act as the accepted party only.
- **DAR files.** Filenames and SHA-256 must both match the invitation.

Any mismatch fails the step; repeated mismatches abort the peer run. Governance confirm/execute is unchanged — the peer already builds those commands locally and the Daml layer revalidates them against the on-ledger proposal.

## `canton_hash`

The Ledger API states that `prepared_transaction_hash` is a convenience and that a client must recompute it when the preparing participant is not trusted. Here the preparing participant is the coordinator, so `crates/decman/src/canton_hash/` implements Canton's interactive-submission hashing scheme for V2 and V3 (PV34 supports V2, PV35 both).

It is pinned by the golden vectors from Canton v3.5.8's own `NodeHashTest` / `MetadataHashTest` — per-node, transaction, metadata and full prepared-transaction hashes all match byte for byte. An unsupported scheme version, or a node feature a scheme does not cover, is refused rather than hashed around, so the failure direction is always toward not signing.

## Compatibility

`DarsInvitePayload` gained `dar_hashes`, persisted via migration `000016`. An invitation from a coordinator that predates the field carries none; the peer then checks filenames only and logs a warning, so a network part-way through an upgrade keeps working. Checks the current invitation can already answer are always enforced.

## Notes for review

- `expected_main_package_id` on the DAR upload stays unset. The peer pins the whole DAR by SHA-256 from the invitation instead, which covers every package in the file rather than only the main one and needs no DAR archive parser. A comment at the call site records this.
- The skipped G8 integration scenario still has no raw-Noise injection harness. Adversarial coverage here is at the unit level, against the validation and hash code: a tampered signatory, a proposal for another party, an extra host, a dropped member, a still-hosted kicked participant, a weakened party-signing threshold, a swapped DAR, a hash that does not belong to its transaction, tampered metadata, a remove operation, and a cyclic transaction tree.
- Per-step operator approval is deliberately out of scope. The accept-once flow is unchanged.

## Verification

- 51 new unit tests; `cargo test --workspace --lib` green (664).
- `cargo clippy --workspace --all-targets --all-features` clean.
- `cargo fmt --all --check` clean.
- No integration-test run yet — worth a full IT pass before merge, since this touches every peer signing path.
