### PR TITLE
fix(ui): count joined peers while a run waits for them

### DIFF
--- a/crates/common/src/types.rs
+++ b/crates/common/src/types.rs
@@ -353,6 +353,12 @@ impl std::str::FromStr for WorkflowRole {
     }
 }
 
+/// `current_step` of the first step of every workflow kind, where the
+/// coordinator waits for its invitees to join. Progress on this step is
+/// [`WorkflowRun::connected_peers`], not `completed_peers` — nothing completes
+/// a step that carries no command.
+pub const WAITING_FOR_PEERS_STEP: &str = "WaitingForPeers";
+
 /// A single persisted workflow run — control-plane state for either the
 /// coordinator side or an peer side. The matching artefacts live in
 /// `workflow_artifacts` and are looked up by `instance_name`.
@@ -386,6 +392,13 @@ pub struct WorkflowRun {
     pub coordinator_name: Option<String>,
     pub expected_peers: Vec<CantonId>,
     pub completed_peers: Vec<CantonId>,
+    /// Peers that have joined this run — the set the `WaitingForPeers` gate
+    /// counts, and the only progress a run has to show before its first
+    /// peer-gated step. Live in-memory state merged in by the API layer from
+    /// the workflow registry (not a DB column), so it is empty for a run this
+    /// node does not currently coordinate.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub connected_peers: Vec<CantonId>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub dec_party_id: Option<CantonId>,
     /// Dec party prefix associated with this run (e.g. "UAT"). Populated by

--- a/crates/decman-cli/src/ui.rs
+++ b/crates/decman-cli/src/ui.rs
@@ -10,7 +10,8 @@ use ratatui::widgets::{
 
 use common::types::{
     ConnectionStatus, DecentralizedParty, PackageInfo, PeerErrorKind, PeerPackageComparison,
-    PendingInvitation, Permission, VettedPackageInfo, WorkflowProgress, WorkflowRun,
+    PendingInvitation, Permission, VettedPackageInfo, WAITING_FOR_PEERS_STEP, WorkflowProgress,
+    WorkflowRole, WorkflowRun,
 };
 
 use crate::api::{
@@ -2456,6 +2457,27 @@ fn detail_kv(label: &str, value: String) -> Line<'static> {
     Line::from(vec![detail_label(label), Span::raw(value)])
 }
 
+/// The peer count for a run's detail popup, or `None` when there is nothing
+/// truthful to show. Coordinator-only: a peer-side row never learns what the
+/// other peers did, so its counter would sit at 0 for the whole run. While the
+/// coordinator waits, the peers that joined are the progress — a waiting step
+/// carries no command, so nothing completes it — and from the next step on it
+/// is the peers that completed the current one.
+fn peers_progress(run: &WorkflowRun) -> Option<String> {
+    if run.role != WorkflowRole::Coordinator || run.expected_peers.is_empty() {
+        return None;
+    }
+    let (done, label) = if run.current_step == WAITING_FOR_PEERS_STEP {
+        (run.connected_peers.len(), "joined")
+    } else {
+        (run.completed_peers.len(), "done")
+    };
+    Some(format!(
+        "{done}/{total} {label}",
+        total = run.expected_peers.len()
+    ))
+}
+
 /// An indented detail value line (for list items).
 fn detail_item(value: String) -> Line<'static> {
     Line::from(vec![
@@ -2512,15 +2534,8 @@ fn run_detail_lines(run: &WorkflowRun) -> Vec<Line<'static>> {
         lines.push(detail_kv("Participants", String::new()));
         lines.extend(run.participants.iter().map(|p| detail_item(p.to_string())));
     }
-    if !run.completed_peers.is_empty() || !run.expected_peers.is_empty() {
-        lines.push(detail_kv(
-            "Peers",
-            format!(
-                "{done}/{total} done",
-                done = run.completed_peers.len(),
-                total = run.expected_peers.len()
-            ),
-        ));
+    if let Some(peers) = peers_progress(run) {
+        lines.push(detail_kv("Peers", peers));
     }
     if !run.package_names.is_empty() {
         lines.push(detail_kv("Packages", run.package_names.join(", ")));
@@ -2766,6 +2781,7 @@ mod tests {
                 coordinator_name: None,
                 expected_peers: Vec::new(),
                 completed_peers: Vec::new(),
+                connected_peers: Vec::new(),
                 dec_party_id: None,
                 prefix: None,
                 participants: Vec::new(),
@@ -2794,6 +2810,7 @@ mod tests {
                 coordinator_name: None,
                 expected_peers: Vec::new(),
                 completed_peers: Vec::new(),
+                connected_peers: Vec::new(),
                 dec_party_id: None,
                 prefix: None,
                 participants: Vec::new(),
@@ -3248,6 +3265,51 @@ mod tests {
     }
 
     #[test]
+    fn peers_progress_counts_joins_while_waiting_then_completions() {
+        let mut run = WorkflowRun {
+            instance_name: "beth-network-creation".to_owned(),
+            kind: WorkflowKind::Onboarding,
+            role: WorkflowRole::Coordinator,
+            status: WorkflowProgress::InProgress,
+            current_step: WAITING_FOR_PEERS_STEP.to_owned(),
+            step_index: 0,
+            step_total: 7,
+            config_json: String::new(),
+            coordinator_pubkey: None,
+            coordinator_instance: None,
+            coordinator_name: None,
+            expected_peers: vec![canton_id("p1"), canton_id("p2"), canton_id("p3")],
+            completed_peers: vec![canton_id("p1")],
+            connected_peers: vec![canton_id("p1"), canton_id("p2")],
+            dec_party_id: None,
+            prefix: Some("beth-network".to_owned()),
+            participants: Vec::new(),
+            previous_threshold: None,
+            new_threshold: None,
+            kicked_participant: None,
+            added_participant: None,
+            package_names: Vec::new(),
+            dar_filenames: Vec::new(),
+            error: None,
+            dismissed: false,
+            created_at: 0,
+            updated_at: 0,
+        };
+
+        // Waiting: the joins are the progress. Reporting `completed_peers` here
+        // is what showed a zero to an operator whose peers had accepted.
+        assert_eq!(peers_progress(&run).as_deref(), Some("2/3 joined"));
+
+        // Past the gate, completions of the current step take over.
+        run.current_step = "SignDns".to_owned();
+        assert_eq!(peers_progress(&run).as_deref(), Some("1/3 done"));
+
+        // A peer-side row has no such knowledge, so it shows no count at all.
+        run.role = WorkflowRole::Peer;
+        assert_eq!(peers_progress(&run), None);
+    }
+
+    #[test]
     fn feed_detail_popup_renders_run_fields_and_error() {
         let run = WorkflowRun {
             instance_name: "onboarding-treasury-abc".to_owned(),
@@ -3263,6 +3325,7 @@ mod tests {
             coordinator_name: None,
             expected_peers: Vec::new(),
             completed_peers: Vec::new(),
+            connected_peers: Vec::new(),
             dec_party_id: None,
             prefix: Some("treasury".to_owned()),
             participants: Vec::new(),

--- a/crates/decman/frontend/src/components/NotificationsView.tsx
+++ b/crates/decman/frontend/src/components/NotificationsView.tsx
@@ -1530,6 +1530,22 @@ const WorkflowRunCard = ({
     }
   };
 
+  // Only the coordinator knows what the other peers did: a peer-side row never
+  // gets a count and would show a permanent 0. While the coordinator waits, the
+  // peers that joined are the progress — nothing "completes" a step that
+  // carries no command — and from the next step on it is the peers that
+  // completed the current one.
+  const showsPeerCount =
+    isInProgress &&
+    run.role === "Coordinator" &&
+    (run.expected_peers?.length ?? 0) > 0;
+  const waitingForPeers = run.current_step === "WaitingForPeers";
+  const peerCountLine = showsPeerCount
+    ? waitingForPeers
+      ? `${run.connected_peers?.length ?? 0} of ${run.expected_peers.length} peers joined`
+      : `${run.completed_peers?.length ?? 0} of ${run.expected_peers.length} peers responded`
+    : null;
+
   const fromLine = run.role === "Coordinator"
     ? "started by you"
     : run.coordinator_name
@@ -1682,17 +1698,9 @@ const WorkflowRunCard = ({
       title={run.prefix ? `${run.kind} · ${run.prefix}` : run.kind}
       facts={
         <>
-          {(fromLine ||
-            (isInProgress && (run.expected_peers?.length ?? 0) > 0)) && (
+          {(fromLine || peerCountLine) && (
             <Typography sx={{ fontSize: 13, color: "text.secondary" }}>
-              {[
-                fromLine,
-                isInProgress && (run.expected_peers?.length ?? 0) > 0
-                  ? `${run.completed_peers?.length ?? 0} of ${run.expected_peers.length} peers responded`
-                  : null,
-              ]
-                .filter(Boolean)
-                .join(" · ")}
+              {[fromLine, peerCountLine].filter(Boolean).join(" · ")}
             </Typography>
           )}
           {isInProgress && run.step_total > 0 && (

--- a/crates/decman/src/db/rows.rs
+++ b/crates/decman/src/db/rows.rs
@@ -421,6 +421,7 @@ impl WorkflowRunRow {
             coordinator_name: None,
             expected_peers,
             completed_peers,
+            connected_peers: Vec::new(),
             dec_party_id,
             // `prefix` + `participants` + thresholds + package/dar names are
             // derived from `config_json` at the API layer; the DB doesn't store

--- a/crates/decman/src/db/sqlite.rs
+++ b/crates/decman/src/db/sqlite.rs
@@ -2248,6 +2248,7 @@ mod tests {
                 CantonId::parse(&format!("b::{TEST_NS}")).unwrap(),
             ],
             completed_peers: Vec::new(),
+            connected_peers: Vec::new(),
             dec_party_id: None,
             prefix: None,
             participants: Vec::new(),

--- a/crates/decman/src/noise/server.rs
+++ b/crates/decman/src/noise/server.rs
@@ -95,6 +95,20 @@ impl ActiveWorkflow {
             Self::ChangeThreshold(s) => s.handle_command(peer_id, message).await,
         }
     }
+
+    /// The peers that have joined this run. `WaitingForPeers` gates on this
+    /// set rather than on `completed_peers`, so it is the join progress the
+    /// runs API reports while a run waits for its invitees.
+    pub async fn connected_peers(&self) -> HashSet<CantonId> {
+        match self {
+            Self::Onboarding(s) => s.workflow_state.connected_peers().await,
+            Self::Kick(s) => s.workflow_state.connected_peers().await,
+            Self::Contracts(s) => s.workflow_state.connected_peers().await,
+            Self::Dars(s) => s.workflow_state.connected_peers().await,
+            Self::AddParty(s) => s.workflow_state.connected_peers().await,
+            Self::ChangeThreshold(s) => s.workflow_state.connected_peers().await,
+        }
+    }
 }
 
 /// Peer quorum: `m - 1` (the coordinator signs itself), clamped to

--- a/crates/decman/src/server/handlers/invitations.rs
+++ b/crates/decman/src/server/handlers/invitations.rs
@@ -136,6 +136,7 @@ pub(crate) async fn insert_peer_run(
         // invite (all four kinds send one).
         expected_peers: invitation.participants.clone(),
         completed_peers: Vec::new(),
+        connected_peers: Vec::new(),
         // Kick + contracts invites carry the target dec party; others don't.
         dec_party_id: invitation.dec_party_id.clone(),
         prefix: None,

--- a/crates/decman/src/server/handlers/workflows.rs
+++ b/crates/decman/src/server/handlers/workflows.rs
@@ -99,6 +99,7 @@ where
         coordinator_name: None,
         expected_peers: invitees.to_vec(),
         completed_peers: Vec::new(),
+        connected_peers: Vec::new(),
         dec_party_id,
         prefix: None,
         participants: Vec::new(),
@@ -2986,16 +2987,22 @@ pub async fn list_workflows(data: web::Data<AppState>) -> impl Responder {
         .map(|p| (p.public_key, p.name))
         .collect();
 
-    let resolved: Vec<WorkflowRun> = runs
-        .into_iter()
-        .map(|mut r| {
-            if let Some(pk) = r.coordinator_pubkey.as_deref() {
-                r.coordinator_name = pubkey_to_name.get(pk).cloned();
-            }
-            enrich_from_config_json(&mut r);
-            r
-        })
-        .collect();
+    let mut resolved: Vec<WorkflowRun> = Vec::with_capacity(runs.len());
+    for mut r in runs {
+        if let Some(pk) = r.coordinator_pubkey.as_deref() {
+            r.coordinator_name = pubkey_to_name.get(pk).cloned();
+        }
+        enrich_from_config_json(&mut r);
+        // Who has joined lives only in the live coordinator's `WorkflowState`;
+        // the row itself carries no such column. Merge it in so a run parked on
+        // WaitingForPeers can show real progress instead of a permanent zero.
+        if let Some(active) = data.workflows.route(&r.instance_name) {
+            let mut joined: Vec<CantonId> = active.connected_peers().await.into_iter().collect();
+            joined.sort();
+            r.connected_peers = joined;
+        }
+        resolved.push(r);
+    }
 
     HttpResponse::Ok().json(WorkflowRunsResponse { runs: resolved })
 }
@@ -3707,6 +3714,7 @@ mod tests {
             coordinator_name: None,
             expected_peers,
             completed_peers: Vec::new(),
+            connected_peers: Vec::new(),
             dec_party_id: None,
             prefix: None,
             participants: Vec::new(),

--- a/crates/decman/src/server/types.rs
+++ b/crates/decman/src/server/types.rs
@@ -1105,6 +1105,7 @@ mod tests {
             coordinator_name: None,
             expected_peers: vec![peer_a.clone(), peer_b.clone()],
             completed_peers: vec![peer_a],
+            connected_peers: vec![peer_b],
             dec_party_id: Some(CantonId::parse(&dec_party_id_str).unwrap()),
             prefix: None,
             participants: Vec::new(),
@@ -1143,6 +1144,17 @@ mod tests {
             .expect("completed_peers must be a JSON array");
         assert_eq!(completed.len(), 1);
         assert!(completed[0].is_string());
+
+        let connected = json
+            .get("connected_peers")
+            .and_then(Value::as_array)
+            .expect("connected_peers must be a JSON array");
+        assert_eq!(connected.len(), 1);
+        assert!(
+            connected[0].is_string(),
+            "connected_peers entry must be a string, got {}",
+            connected[0]
+        );
 
         // dec_party_id (Option<CantonId>) must serialize as a plain string,
         // not as a nested object with prefix/namespace fields.

--- a/crates/decman/src/workflow/state.rs
+++ b/crates/decman/src/workflow/state.rs
@@ -186,6 +186,15 @@ impl<S: WorkflowStep + 'static> WorkflowState<S> {
         }
     }
 
+    /// The peers that have connected to this run.
+    ///
+    /// Transient, like the set itself: a restart empties it and the peers'
+    /// next poll refills it. This is what the `WaitingForPeers` gate counts,
+    /// so it is also the only join progress the API can report on that step.
+    pub async fn connected_peers(&self) -> HashSet<CantonId> {
+        self.connected_peers.read().await.clone()
+    }
+
     /// The peers this run marked complete for the current step.
     ///
     /// Restored by [`Self::from_persisted`], unlike `peer_data`, so a resumed
@@ -519,6 +528,31 @@ mod tests {
 
         state.peer_connected(peer(2)).await;
         assert_eq!(state.current_step().await, TestStep::Sign);
+    }
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn connected_peers_is_the_progress_while_waiting(pool: SqlitePool) {
+        let state = WorkflowState::new(
+            pool,
+            "test-run".to_string(),
+            TestStep::WaitPeers,
+            vec![peer(1), peer(2), peer(3)],
+            None,
+        );
+
+        state.peer_connected(peer(1)).await;
+        state.peer_connected(peer(2)).await;
+
+        // Two of three joined, so the run still waits — and `completed_peers`
+        // is empty, because a waiting step carries no command for a peer to
+        // complete. Reporting it as run progress is what showed "0 responded"
+        // to an operator whose peers had in fact accepted.
+        assert_eq!(state.current_step().await, TestStep::WaitPeers);
+        assert!(state.completed_peers().await.is_empty());
+        let joined = state.connected_peers().await;
+        assert_eq!(joined.len(), 2);
+        assert!(joined.contains(&peer(1)));
+        assert!(joined.contains(&peer(2)));
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]


### PR DESCRIPTION
## Problem

An onboarding run sat on `WaitingForPeers` with 2 of 3 peers accepted, and the card still said "0 of 3 peers responded".

The card counts `completed_peers`. `WaitingForPeers` gates on `connected_peers`, and that step carries no command, so nothing ever completes it. The counter is structurally 0 for the whole first step. Peer-side rows are worse: they always persist an empty completed set, so their counter reads 0 for the entire run.

The run itself was correct. Onboarding requires every invited peer (`resolve_peer_threshold` returns `None` for it), so 2 of 3 keeps waiting as designed. The "Threshold" on the card is the party signing threshold, not the join gate.

## Change

- `WorkflowState::connected_peers()` and `ActiveWorkflow::connected_peers()` expose the live join set.
- `GET /workflows` merges it into every run this node still coordinates. New `connected_peers` field on `WorkflowRun`, live state only, no DB column and no migration.
- Web UI: "2 of 3 peers joined" while waiting, "N of 3 peers responded" from the next step on. No counter on peer-side rows.
- CLI detail popup: same rule, extracted into `peers_progress`.

After a restart the count starts at 0 until the peers poll again, which is what the gate itself sees.

## Tests

- `connected_peers_is_the_progress_while_waiting`: joins are counted while `completed_peers` is empty.
- `workflow_run_serializes_canton_ids_as_plain_strings`: covers the new field's wire shape.
- `peers_progress_counts_joins_while_waiting_then_completions`: waiting, then working, then peer-side.

`cargo clippy --all-targets --all-features -D warnings` and `tsc -b` are clean.
