### PR TITLE
perf(ci): cut fixed sleeps and serialization from the integration test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,18 @@ on:
   workflow_call:
   workflow_dispatch:
 
+# One in-flight CI run per PR: Integration Tests holds a 30-minute
+# `ubuntu-very-big` runner, so a superseded commit keeps a big machine busy
+# producing a result nobody reads.
+#
+# `cancel-in-progress` is gated on the event so only PR runs are ever killed —
+# a push to main and a release (which reaches this file via `workflow_call`
+# from release.yml) must always finish. The gate, not the group, is what keeps
+# releases safe.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_NET_GIT_FETCH_WITH_CLI: true

--- a/crates/decman/src/consts.rs
+++ b/crates/decman/src/consts.rs
@@ -92,6 +92,32 @@ pub const DECLINE_NOTIFY_BACKOFF_SECS: u64 = 2;
 
 pub const MAX_CONSECUTIVE_NO_WORKFLOW_POLLS: usize = 4;
 
+/// Delay before a peer re-polls the coordinator after a `Wait` reply, in
+/// milliseconds.
+/// Default value; the actual delay is read via [`peer_wait_poll_delay_ms`].
+pub const PEER_WAIT_POLL_DELAY_MS: u64 = 2000;
+
+/// How long a peer waits before asking the coordinator for its next command
+/// again, configurable via the `DECPM_PEER_WAIT_POLL_DELAY_MS` env var.
+/// Defaults to [`PEER_WAIT_POLL_DELAY_MS`] (2000) when unset or unparseable.
+///
+/// This is the cadence of the peer event loop in `workflow/mod.rs`: whenever
+/// the coordinator has no command ready it answers `Wait`, and the peer sleeps
+/// this long before asking again. It therefore quantizes every multi-step
+/// workflow — a run that needs N polls cannot finish faster than N times this
+/// value, whatever the work actually costs.
+///
+/// 2s is right against a real synchronizer, where each coordinator step is a
+/// 10-30s Canton round trip and the poll is noise. On a single-container
+/// localnet the step lands in milliseconds, so the quantization *is* the
+/// runtime; the integration-test harness lowers it.
+pub fn peer_wait_poll_delay_ms() -> u64 {
+    std::env::var("DECPM_PEER_WAIT_POLL_DELAY_MS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(PEER_WAIT_POLL_DELAY_MS)
+}
+
 /// Canton protocol version used for key export and topology operations.
 /// Bumped 34 -> 35 alongside the localnet 0.6.7 -> 0.6.11 test target; the
 /// network (testnet) has live-upgraded to protocol version 35.

--- a/crates/decman/src/consts.rs
+++ b/crates/decman/src/consts.rs
@@ -101,7 +101,25 @@ pub const CANTON_PROTOCOL_VERSION: i32 = 35;
 /// After topology becomes effective, Canton needs time to propagate updates
 /// to the sequencer's topology state. Without this wait, transactions may be
 /// rejected with LOCAL_VERDICT_TIMEOUT.
+///
+/// Default value; the actual delay is read via
+/// [`topology_propagation_delay_secs`].
 pub const TOPOLOGY_PROPAGATION_DELAY_SECS: u64 = 30;
+
+/// Post-submission topology propagation wait, configurable via the
+/// `DECPM_TOPOLOGY_PROPAGATION_DELAY_SECS` env var. Defaults to
+/// [`TOPOLOGY_PROPAGATION_DELAY_SECS`] (30) when unset or unparseable.
+///
+/// The 30s default is sized for a real multi-node synchronizer, where the
+/// sequencer's topology state settles well after the transaction becomes
+/// effective. A single-container localnet settles in under a second, so the
+/// integration-test harness lowers it.
+pub fn topology_propagation_delay_secs() -> u64 {
+    std::env::var("DECPM_TOPOLOGY_PROPAGATION_DELAY_SECS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(TOPOLOGY_PROPAGATION_DELAY_SECS)
+}
 
 // Base directory names (relative to root directory)
 /// Data directory name (contains the Noise key, SQLite database, and DARs)

--- a/crates/decman/src/workflow/mod.rs
+++ b/crates/decman/src/workflow/mod.rs
@@ -25,7 +25,9 @@ use crate::{
     auth::WorkflowAuth,
     canton_id::CantonId,
     config::{NetworkConfig, NodeConfig, Peer},
-    consts::{MAX_CONSECUTIVE_NO_WORKFLOW_POLLS, MAX_CONSECUTIVE_STEP_FAILURES},
+    consts::{
+        MAX_CONSECUTIVE_NO_WORKFLOW_POLLS, MAX_CONSECUTIVE_STEP_FAILURES, peer_wait_poll_delay_ms,
+    },
     db::schema::{Commitable, SchemaRead, SchemaWrite},
     error::Result,
     noise::{MessageType, NoiseError, client::NoiseClient, server::ActiveWorkflow},
@@ -350,7 +352,8 @@ pub async fn start_peer(
             MessageType::Wait => {
                 tracing::trace!("Received command: Wait");
                 // Coordinator says to wait, poll again after delay
-                tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+                tokio::time::sleep(tokio::time::Duration::from_millis(peer_wait_poll_delay_ms()))
+                    .await;
             }
             MessageType::Disconnect => {
                 tracing::info!("Received disconnect command, shutting down");

--- a/crates/decman/src/workflow/onboarding/steps/proposals/submit.rs
+++ b/crates/decman/src/workflow/onboarding/steps/proposals/submit.rs
@@ -17,7 +17,7 @@ use crate::{
     canton_id::CantonId,
     config::NodeConfig,
     consts::{
-        TOPOLOGY_PROPAGATION_DELAY_SECS, topology_retry_delay_secs, topology_retry_max_attempts,
+        topology_propagation_delay_secs, topology_retry_delay_secs, topology_retry_max_attempts,
     },
     error::Result,
     utils,
@@ -294,7 +294,7 @@ pub async fn submit_final_proposals(
         tracing::info!("P2P mapping is already effective");
     }
 
-    let propagation_delay = time::Duration::from_secs(TOPOLOGY_PROPAGATION_DELAY_SECS);
+    let propagation_delay = time::Duration::from_secs(topology_propagation_delay_secs());
     tracing::info!("Waiting {propagation_delay:?} for Canton to propagate topology updates...");
     time::sleep(propagation_delay).await;
     tracing::info!("Topology propagation wait complete");

--- a/crates/decman/src/workflow/topology.rs
+++ b/crates/decman/src/workflow/topology.rs
@@ -32,7 +32,7 @@ use crate::{
     canton_id::CantonId,
     config::NodeConfig,
     consts::{
-        TOPOLOGY_PROPAGATION_DELAY_SECS, topology_retry_delay_secs, topology_retry_max_attempts,
+        topology_propagation_delay_secs, topology_retry_delay_secs, topology_retry_max_attempts,
     },
     error::Result,
     utils,
@@ -501,7 +501,7 @@ where
     confirm_p2p().await?;
     tracing::info!("P2P {label} confirmed in topology");
 
-    let propagation_delay = Duration::from_secs(TOPOLOGY_PROPAGATION_DELAY_SECS);
+    let propagation_delay = Duration::from_secs(topology_propagation_delay_secs());
     tracing::info!("Waiting {propagation_delay:?} for Canton to propagate topology updates...");
     tokio::time::sleep(propagation_delay).await;
 

--- a/crates/decman/tests/common/db.rs
+++ b/crates/decman/tests/common/db.rs
@@ -378,6 +378,26 @@ pub async fn backdate_dec_party_cache(
     Ok(res.rows_affected())
 }
 
+/// Newest `updated_at` across the prefix's `dec_party` cache rows — the same
+/// value the handler's staleness check reads. Paired with
+/// [`backdate_dec_party_cache`] it proves a refresh actually ran and wrote,
+/// which observing the `refreshing` flag cannot: the spawned task can start
+/// and finish between two polls.
+pub async fn dec_party_cache_updated_at(
+    db_path: &Path,
+    prefix: &str,
+) -> anyhow::Result<Option<i64>> {
+    let pool = open(db_path).await?;
+    let v: Option<i64> =
+        sqlx::query_scalar("SELECT MAX(updated_at) FROM dec_party WHERE prefix = ?1")
+            .bind(prefix)
+            .fetch_one(&pool)
+            .await
+            .context("dec_party_cache_updated_at")?;
+    pool.close().await;
+    Ok(v)
+}
+
 pub async fn count_dec_party_identity(db_path: &Path, dec_party_id: &str) -> anyhow::Result<i64> {
     let pool = open(db_path).await?;
     let n: i64 =

--- a/crates/decman/tests/common/db.rs
+++ b/crates/decman/tests/common/db.rs
@@ -346,6 +346,38 @@ pub async fn dec_party_cache_has_participant(
     Ok(n > 0)
 }
 
+/// Test-only: age the `/decentralized-parties` cache for `prefix` so the next
+/// GET crosses the server's staleness threshold and spawns
+/// `refresh_and_cache_parties`.
+///
+/// The handler compares `now - max(dec_party.updated_at)` for the prefix
+/// against a 60s window. Backdating the rows is the same trigger as sleeping
+/// out that window, and it avoids lowering the threshold globally — a shorter
+/// window would make every parties GET in the suite spawn a peer fan-out
+/// refresh (see #415).
+///
+/// Returns the number of cache rows aged. Safe against a live node: it writes
+/// only `updated_at`, and a spurious refresh is what the caller wants anyway.
+pub async fn backdate_dec_party_cache(
+    db_path: &Path,
+    prefix: &str,
+    by: std::time::Duration,
+) -> anyhow::Result<u64> {
+    let pool = open_rw(db_path).await?;
+    let secs = i64::try_from(by.as_secs()).context("backdate offset overflows i64")?;
+    let res = sqlx::query(
+        "UPDATE dec_party SET updated_at = CAST(strftime('%s', 'now') AS INTEGER) - ?1 \
+         WHERE prefix = ?2",
+    )
+    .bind(secs)
+    .bind(prefix)
+    .execute(&pool)
+    .await
+    .context("backdate_dec_party_cache")?;
+    pool.close().await;
+    Ok(res.rows_affected())
+}
+
 pub async fn count_dec_party_identity(db_path: &Path, dec_party_id: &str) -> anyhow::Result<i64> {
     let pool = open(db_path).await?;
     let n: i64 =

--- a/crates/decman/tests/common/phases/owner_key_resilience.rs
+++ b/crates/decman/tests/common/phases/owner_key_resilience.rs
@@ -7,7 +7,8 @@
 //!   flag that is `true` while the background `refresh_and_cache_parties`
 //!   task is in progress;
 //! - the server's 60s staleness threshold (see
-//!   `src/server/handlers/parties.rs:79`).
+//!   `src/server/handlers/parties.rs:79`), which this phase crosses by
+//!   backdating `dec_party.updated_at` rather than by waiting it out.
 //!
 //! If the server later makes refreshes synchronous or removes the
 //! `refreshing` flag, this phase must be rewritten to trigger a refresh
@@ -20,7 +21,7 @@ use common::{api::DecentralizedPartiesResponse, canton_id::CantonId};
 use tokio::time::sleep;
 use tracing::info;
 
-use crate::common::{Fixture, scenario::Scenario};
+use crate::common::{Fixture, db, scenario::Scenario};
 
 pub async fn run(f: &mut Fixture) -> anyhow::Result<()> {
     info!("Phase: owner_key_resilience");
@@ -69,17 +70,27 @@ pub async fn run(f: &mut Fixture) -> anyhow::Result<()> {
             "P1's cache is force-refreshed and the refresh completes",
             |f, _| {
                 Box::pin(async move {
-                    // Wait out the server's 60s staleness window so the next GET
-                    // reliably triggers `refresh_and_cache_parties`. The previous
-                    // phase's `/decentralized-parties` GETs reset `updated_at`,
-                    // so without this wait the cache is too fresh and the
-                    // refresh never fires in test timing (suite total ~3min).
-                    sleep(Duration::from_secs(61)).await;
-
                     let prefix = f.party_prefix()?.to_string();
                     let path = format!("/decentralized-parties?prefix={prefix}");
 
-                    // The 61s sleep above guarantees the next stale-cache GET
+                    // Age the cache past the server's 60s staleness window so
+                    // the next GET triggers `refresh_and_cache_parties`. The
+                    // earlier phases' `/decentralized-parties` GETs keep
+                    // resetting `updated_at`, so the cache is otherwise too
+                    // fresh for the refresh to fire at all.
+                    let aged = db::backdate_dec_party_cache(
+                        &f.db_path(1),
+                        &prefix,
+                        Duration::from_secs(120),
+                    )
+                    .await?;
+                    anyhow::ensure!(
+                        aged > 0,
+                        "no dec_party cache rows for prefix {prefix} — nothing to make stale, \
+                         so the refresh under test would never fire"
+                    );
+
+                    // The backdate above guarantees the next stale-cache GET
                     // triggers `refresh_and_cache_parties`. We don't insist on
                     // observing `refreshing == true` because the spawned task
                     // can complete between polls on a fast localnet, leaving

--- a/crates/decman/tests/common/phases/owner_key_resilience.rs
+++ b/crates/decman/tests/common/phases/owner_key_resilience.rs
@@ -6,9 +6,10 @@
 //! - the `/decentralized-parties` response carrying a `refreshing: bool`
 //!   flag that is `true` while the background `refresh_and_cache_parties`
 //!   task is in progress;
-//! - the server's 60s staleness threshold (see
-//!   `src/server/handlers/parties.rs:79`), which this phase crosses by
-//!   backdating `dec_party.updated_at` rather than by waiting it out.
+//! - the server's 60s staleness threshold in
+//!   `get_decentralized_parties` (`src/server/handlers/parties.rs`), which
+//!   this phase crosses by backdating `dec_party.updated_at` rather than by
+//!   waiting it out.
 //!
 //! If the server later makes refreshes synchronous or removes the
 //! `refreshing` flag, this phase must be rewritten to trigger a refresh
@@ -72,32 +73,55 @@ pub async fn run(f: &mut Fixture) -> anyhow::Result<()> {
                 Box::pin(async move {
                     let prefix = f.party_prefix()?.to_string();
                     let path = format!("/decentralized-parties?prefix={prefix}");
+                    let db_path = f.db_path(1);
+
+                    // Quiesce before backdating. The preceding owner-key probe
+                    // polled this same endpoint, and any GET there may have
+                    // spawned a refresh. A task still in flight calls
+                    // `store_parties_to_db` afterwards, stamping `updated_at`
+                    // with the current time — clobbering the backdate below.
+                    // The cache would then read fresh, no new refresh would
+                    // fire, and this phase would pass without exercising the
+                    // UPSERT/COALESCE invariant it exists to guard.
+                    let mut quiesced = false;
+                    for _ in 0..150 {
+                        let r: DecentralizedPartiesResponse = f.get_json(f.p1.http, &path).await?;
+                        if !r.refreshing {
+                            quiesced = true;
+                            break;
+                        }
+                        sleep(Duration::from_millis(200)).await;
+                    }
+                    anyhow::ensure!(
+                        quiesced,
+                        "a refresh was still in flight after 30s; backdating now would race it"
+                    );
 
                     // Age the cache past the server's 60s staleness window so
                     // the next GET triggers `refresh_and_cache_parties`. The
                     // earlier phases' `/decentralized-parties` GETs keep
                     // resetting `updated_at`, so the cache is otherwise too
                     // fresh for the refresh to fire at all.
-                    let aged = db::backdate_dec_party_cache(
-                        &f.db_path(1),
-                        &prefix,
-                        Duration::from_secs(120),
-                    )
-                    .await?;
+                    let aged =
+                        db::backdate_dec_party_cache(&db_path, &prefix, Duration::from_secs(120))
+                            .await?;
                     anyhow::ensure!(
                         aged > 0,
                         "no dec_party cache rows for prefix {prefix} — nothing to make stale, \
                          so the refresh under test would never fire"
                     );
+                    let aged_at = db::dec_party_cache_updated_at(&db_path, &prefix)
+                        .await?
+                        .context("dec_party cache has no updated_at after backdating")?;
 
-                    // The backdate above guarantees the next stale-cache GET
-                    // triggers `refresh_and_cache_parties`. We don't insist on
-                    // observing `refreshing == true` because the spawned task
-                    // can complete between polls on a fast localnet, leaving
-                    // every observation as `false` even though a refresh did
-                    // run. Instead we poll until the response settles on
-                    // `refreshing == false` and let the final assertion
-                    // (owner_key intact) prove the invariant.
+                    // Trigger the stale-cache path.
+                    let _: DecentralizedPartiesResponse = f.get_json(f.p1.http, &path).await?;
+
+                    // Wait for the refresh to have actually completed, proven by
+                    // `updated_at` advancing past the aged value — a write only
+                    // `store_parties_to_db` performs. The `refreshing` flag can't
+                    // prove it: the spawned task can start and finish between two
+                    // polls, so every observation reads false either way.
                     //
                     // 30s budget (150 × 200ms). Localnet refreshes in
                     // milliseconds; devnet's `resolve_owner_keys_from_peers`
@@ -106,13 +130,19 @@ pub async fn run(f: &mut Fixture) -> anyhow::Result<()> {
                     // ≈3s/peer worst case on the kubectl tunnel). A run on
                     // 9fd91be exhausted the original 6s budget here.
                     for _ in 0..150 {
-                        let r: DecentralizedPartiesResponse = f.get_json(f.p1.http, &path).await?;
-                        if !r.refreshing {
+                        if db::dec_party_cache_updated_at(&db_path, &prefix)
+                            .await?
+                            .is_some_and(|t| t > aged_at)
+                        {
                             return Ok(());
                         }
+                        let _: DecentralizedPartiesResponse = f.get_json(f.p1.http, &path).await?;
                         sleep(Duration::from_millis(200)).await;
                     }
-                    anyhow::bail!("refresh did not complete within 30s")
+                    anyhow::bail!(
+                        "cache updated_at never advanced past the aged value within 30s — \
+                         refresh_and_cache_parties did not run, so this phase verified nothing"
+                    )
                 })
             },
         )

--- a/crates/decman/tests/common/processes.rs
+++ b/crates/decman/tests/common/processes.rs
@@ -144,9 +144,13 @@ pub async fn wait_for_exit(pid: u32, deadline: Duration) -> Result<()> {
 /// A bound TCP port only proves the listener exists. This proves actix has a
 /// worker actually serving requests, which is what the caller is about to do.
 /// The handler does no I/O, so a 200 is cheap and never blocks on Canton.
-async fn healthz_ok(http_port: u16) -> bool {
+///
+/// Takes the client rather than building one: the caller polls this every
+/// 200ms, and a fresh `Client` per attempt rebuilds a connection pool and TLS
+/// config each time.
+async fn healthz_ok(client: &reqwest::Client, http_port: u16) -> bool {
     let url = format!("http://127.0.0.1:{http_port}/healthz");
-    match reqwest::Client::new()
+    match client
         .get(&url)
         .timeout(Duration::from_secs(2))
         .send()
@@ -179,8 +183,10 @@ async fn healthz_ok(http_port: u16) -> bool {
 /// recovered from disk.
 pub async fn wait_for_server(http_port: u16, deadline: Duration) -> Result<()> {
     let start = Instant::now();
+    let client = reqwest::Client::new();
     loop {
-        if TcpStream::connect(("127.0.0.1", http_port)).await.is_ok() && healthz_ok(http_port).await
+        if TcpStream::connect(("127.0.0.1", http_port)).await.is_ok()
+            && healthz_ok(&client, http_port).await
         {
             // Short settle on top of the readiness probe. This was a blind 8s
             // standing in for two things: DecMan finishing bootstrap, which

--- a/crates/decman/tests/common/processes.rs
+++ b/crates/decman/tests/common/processes.rs
@@ -139,8 +139,26 @@ pub async fn wait_for_exit(pid: u32, deadline: Duration) -> Result<()> {
     }
 }
 
+/// Readiness signal after the port is bound: `/healthz` answering 200.
+///
+/// A bound TCP port only proves the listener exists. This proves actix has a
+/// worker actually serving requests, which is what the caller is about to do.
+/// The handler does no I/O, so a 200 is cheap and never blocks on Canton.
+async fn healthz_ok(http_port: u16) -> bool {
+    let url = format!("http://127.0.0.1:{http_port}/healthz");
+    match reqwest::Client::new()
+        .get(&url)
+        .timeout(Duration::from_secs(2))
+        .send()
+        .await
+    {
+        Ok(r) => r.status().is_success(),
+        Err(_) => false,
+    }
+}
+
 /// Block (with deadline) until the HTTP listener port is accepting TCP
-/// connections.
+/// connections AND `/healthz` answers 200.
 ///
 /// HTTP-only by design — the Noise *invite* listener's bound state is not
 /// a reliable signal that DecMan is healthy after a chaos restart. DecMan's
@@ -162,18 +180,20 @@ pub async fn wait_for_exit(pid: u32, deadline: Duration) -> Result<()> {
 pub async fn wait_for_server(http_port: u16, deadline: Duration) -> Result<()> {
     let start = Instant::now();
     loop {
-        if TcpStream::connect(("127.0.0.1", http_port)).await.is_ok() {
-            // Settle delay so a freshly-respawned DecMan has time to finish
-            // any in-flight workflow-resume work before the next test
-            // step starts pounding it. Bash harness used 5s here; chaos
-            // phases can restart multiple nodes back-to-back, so we use
-            // a longer settle to keep the next phase's peer-mesh
-            // pre-flight green.
-            sleep(Duration::from_secs(8)).await;
+        if TcpStream::connect(("127.0.0.1", http_port)).await.is_ok() && healthz_ok(http_port).await
+        {
+            // Short settle on top of the readiness probe. This was a blind 8s
+            // standing in for two things: DecMan finishing bootstrap, which
+            // `/healthz` now answers precisely, and the Noise mesh
+            // re-converging, which is not this function's job —
+            // `chaos::post_onboarding` retries a 422 peer-mesh pre-flight 12
+            // times and `ensure_nodes_healthy` repairs a node that never came
+            // back.
+            sleep(Duration::from_secs(1)).await;
             return Ok(());
         }
         if start.elapsed() >= deadline {
-            anyhow::bail!("http port {http_port} not bound after {deadline:?}");
+            anyhow::bail!("http port {http_port} not serving /healthz after {deadline:?}");
         }
         sleep(Duration::from_millis(200)).await;
     }

--- a/integration-tests/common.sh
+++ b/integration-tests/common.sh
@@ -189,7 +189,7 @@ start_nodes() {
         DECPM_METRICS_PORT="${metrics_ports[$idx]}" \
         DECPM_NOISE_PORT="${noise_ports[$idx]}" \
         DECPM_PORT="${http_ports[$idx]}" \
-        DECPM_REWARD_AUTOMATION_INTERVAL_SECS=15 \
+        DECPM_REWARD_AUTOMATION_INTERVAL_SECS="${DECPM_REWARD_AUTOMATION_INTERVAL_SECS:-15}" \
         "$BINARY" -d "$DEV_DIR/participant-$i" serve \
             >> "$log_file" 2>&1 &
         PIDS+=($!)

--- a/integration-tests/devnet.env.sh
+++ b/integration-tests/devnet.env.sh
@@ -141,6 +141,13 @@ export DEV_DIR
 # timeouts.
 export DECPM_TOPOLOGY_RETRY_MAX_ATTEMPTS=90
 
+# Same cadence common.sh already gave the initially-spawned nodes, but exported
+# so the chaos phases' respawned nodes (tests/common/processes.rs inherits this
+# environment) get it too instead of falling back to the 300s production
+# default. Kept at devnet's existing 15s — unlike localnet, this is a real
+# network and a 3s tick would hammer it.
+export DECPM_REWARD_AUTOMATION_INTERVAL_SECS=15
+
 # ---------------------------------------------------------------------------
 # Per-participant ports.
 # - HTTP: 8081/8082/8083 (DecMan's own HTTP API)

--- a/integration-tests/env.sh
+++ b/integration-tests/env.sh
@@ -15,6 +15,11 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/common.sh"
 # Resolve project root (parent of integration-tests/)
 SCRIPT_DIR="${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 
+# Localnet's Canton is a single container, so topology settles in under a
+# second and the 30s production default is pure sleep. devnet.env.sh
+# deliberately does NOT set this — devnet is a real network.
+export DECPM_TOPOLOGY_PROPAGATION_DELAY_SECS=3
+
 # Localnet
 LOCALNET_VERSION="0.6.12"
 LOCALNET_BUNDLE_URL="https://github.com/digital-asset/decentralized-canton-sync/releases/download/v${LOCALNET_VERSION}/${LOCALNET_VERSION}_splice-node.tar.gz"
@@ -97,6 +102,20 @@ cleanup() {
                 kill -9 "$pid" 2>/dev/null || true
             fi
         done < "$DEV_DIR/restarted-pids"
+    fi
+
+    # run.sh may still have `docker compose up --wait` in flight (it backgrounds
+    # the bring-up to overlap it with the build). Reap it first: stop_localnet's
+    # `down -v` racing a live `up` leaves half-created containers and volumes
+    # behind, which fails the next run's port checks.
+    if [ -n "${CANTON_BRINGUP_PID:-}" ] && kill -0 "$CANTON_BRINGUP_PID" 2>/dev/null; then
+        echo "Waiting for the background Canton bring-up to stop..."
+        kill "$CANTON_BRINGUP_PID" 2>/dev/null || true
+        wait "$CANTON_BRINGUP_PID" 2>/dev/null || true
+    fi
+    if [ -n "${CANTON_BRINGUP_LOG:-}" ] && [ -f "$CANTON_BRINGUP_LOG" ]; then
+        cat "$CANTON_BRINGUP_LOG"
+        rm -f "$CANTON_BRINGUP_LOG"
     fi
 
     # Stop localnet

--- a/integration-tests/env.sh
+++ b/integration-tests/env.sh
@@ -114,12 +114,32 @@ cleanup() {
     fi
 
     # run.sh may still have `docker compose up --wait` in flight (it backgrounds
-    # the bring-up to overlap it with the build). Reap it first: stop_localnet's
+    # the bring-up to overlap it with the build). Settle it first: stop_localnet's
     # `down -v` racing a live `up` leaves half-created containers and volumes
     # behind, which fails the next run's port checks.
+    #
+    # Deliberately NOT a plain `kill` on the pid: that pid is the subshell
+    # wrapper, and `docker compose` is its child. Killing the wrapper orphans
+    # compose and `down -v` still races a live `up` — the very thing this
+    # guards. Signalling a process group is not an option either: a background
+    # job in a non-interactive shell shares the script's own group (verified),
+    # so `kill -- -$pid` would target this script.
+    #
+    # So: let it finish, bounded, and only then take down the whole subtree.
     if [ -n "${CANTON_BRINGUP_PID:-}" ] && kill -0 "$CANTON_BRINGUP_PID" 2>/dev/null; then
-        echo "Waiting for the background Canton bring-up to stop..."
-        kill "$CANTON_BRINGUP_PID" 2>/dev/null || true
+        echo "Letting the background Canton bring-up settle before teardown..."
+        _bringup_waited=0
+        while kill -0 "$CANTON_BRINGUP_PID" 2>/dev/null && [ "$_bringup_waited" -lt 240 ]; do
+            sleep 1
+            _bringup_waited=$((_bringup_waited + 1))
+        done
+        if kill -0 "$CANTON_BRINGUP_PID" 2>/dev/null; then
+            echo "Bring-up overstayed ${_bringup_waited}s; terminating it and its compose child"
+            pkill -P "$CANTON_BRINGUP_PID" 2>/dev/null || true
+            sleep 2
+            pkill -9 -P "$CANTON_BRINGUP_PID" 2>/dev/null || true
+            kill -9 "$CANTON_BRINGUP_PID" 2>/dev/null || true
+        fi
         wait "$CANTON_BRINGUP_PID" 2>/dev/null || true
     fi
     if [ -n "${CANTON_BRINGUP_LOG:-}" ] && [ -f "$CANTON_BRINGUP_LOG" ]; then

--- a/integration-tests/env.sh
+++ b/integration-tests/env.sh
@@ -20,6 +20,15 @@ SCRIPT_DIR="${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 # deliberately does NOT set this — devnet is a real network.
 export DECPM_TOPOLOGY_PROPAGATION_DELAY_SECS=3
 
+# The reward-automation tick. Exported, not passed as a command prefix like
+# common.sh's other node env, because the chaos phases respawn nodes from the
+# Rust harness (tests/common/processes.rs), which inherits this process's
+# environment. A prefix-only value silently left every respawned node on the
+# 300s production default, so `coupon_reassignment` — which runs after the
+# chaos block — waited on whichever tick that node happened to be on. That is
+# the 48s/109s/219s spread this phase showed across runs.
+export DECPM_REWARD_AUTOMATION_INTERVAL_SECS=3
+
 # Localnet
 LOCALNET_VERSION="0.6.12"
 LOCALNET_BUNDLE_URL="https://github.com/digital-asset/decentralized-canton-sync/releases/download/v${LOCALNET_VERSION}/${LOCALNET_VERSION}_splice-node.tar.gz"

--- a/integration-tests/env.sh
+++ b/integration-tests/env.sh
@@ -29,6 +29,15 @@ export DECPM_TOPOLOGY_PROPAGATION_DELAY_SECS=3
 # the 48s/109s/219s spread this phase showed across runs.
 export DECPM_REWARD_AUTOMATION_INTERVAL_SECS=3
 
+# The peer's coordinator-poll cadence, which quantizes every multi-step
+# workflow: 100% of the suite's waits >=2s floored to an even second on the 2s
+# default, and "onboarding reaches completed" was exactly 22.0s (11 polls) in
+# five runs out of five. 500ms rather than something smaller because each poll
+# is a fresh Noise connection, and this runner is CPU-sensitive enough that
+# handshake pressure has stalled the mesh before. devnet keeps the 2s default —
+# there a coordinator step is a real Canton round trip.
+export DECPM_PEER_WAIT_POLL_DELAY_MS=500
+
 # Localnet
 LOCALNET_VERSION="0.6.12"
 LOCALNET_BUNDLE_URL="https://github.com/digital-asset/decentralized-canton-sync/releases/download/v${LOCALNET_VERSION}/${LOCALNET_VERSION}_splice-node.tar.gz"

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -165,7 +165,7 @@ CANTON_BRINGUP_PID=""
 CANTON_BRINGUP_LOG=""
 if [ "$TARGET" = "localnet" ]; then
     log_phase "Starting Canton ($TARGET) in the background"
-    CANTON_BRINGUP_LOG="$(mktemp)"
+    CANTON_BRINGUP_LOG="$(mktemp "${TMPDIR:-/tmp}/decman-it-canton-bringup-XXXXXX")"
     ( download_localnet && start_localnet ) >"$CANTON_BRINGUP_LOG" 2>&1 &
     CANTON_BRINGUP_PID=$!
 fi

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -131,7 +131,7 @@ if [ -z "${RUST_LOG:-}" ]; then
         # configure_peers restart window stale clients spam ~20 of these
         # over ~50s while the mesh converges. They're not actionable for
         # readers of a passing test; --verbose surfaces them.
-        export RUST_LOG="warn,hyper_noise::server=error,governance_workflows::common::scenario=info,governance_workflows::common::phases=info"
+        export RUST_LOG="warn,hyper_noise::server=error,governance_workflows::common::scenario=info,governance_workflows::common::phases=info,governance_workflows::common::chaos=info"
     fi
 fi
 
@@ -156,6 +156,20 @@ if [ "$TARGET" = "localnet" ]; then
     FEATURES_FLAG=(--features test-mode)
 fi
 
+# The localnet bring-up is minutes of pure waiting (most of it splice's readyz)
+# and needs nothing the compiler produces, so start it first and build
+# underneath it. Only localnet: on devnet `start_localnet` is
+# `start_canton_tunnels`, which records CANTON_TUNNEL_PIDS for cleanup, and a
+# subshell would lose them.
+CANTON_BRINGUP_PID=""
+CANTON_BRINGUP_LOG=""
+if [ "$TARGET" = "localnet" ]; then
+    log_phase "Starting Canton ($TARGET) in the background"
+    CANTON_BRINGUP_LOG="$(mktemp)"
+    ( download_localnet && start_localnet ) >"$CANTON_BRINGUP_LOG" 2>&1 &
+    CANTON_BRINGUP_PID=$!
+fi
+
 log_phase "Building release-ci binary (target=$TARGET)"
 # `-p decman` selects the server crate: the root is now a virtual workspace
 # (so a bare `--features` is rejected), and this skips compiling the decman-cli TUI.
@@ -166,11 +180,34 @@ if [ ! -f "$BINARY" ]; then
     exit 1
 fi
 
+# Link the e2e test binary now rather than after the stack is live, so the
+# nodes don't sit idle while their own test binary compiles. `cargo test` below
+# reuses this artifact — the flags must stay identical to the build above, per
+# the feature-unification note there.
+log_phase "Compiling e2e test binary"
+cargo test --no-run --profile release-ci -p decman ${FEATURES_FLAG[@]+"${FEATURES_FLAG[@]}"} \
+    --test governance_workflows
+
 # Canton bring-up. Both hooks are target-polymorphic: devnet.env.sh redefines
 # download_localnet as a no-op and start_localnet as start_canton_tunnels.
-log_phase "Starting Canton ($TARGET)"
-download_localnet
-start_localnet
+if [ -n "$CANTON_BRINGUP_PID" ]; then
+    log_phase "Waiting for Canton ($TARGET) bring-up"
+    bringup_rc=0
+    wait "$CANTON_BRINGUP_PID" || bringup_rc=$?
+    # Clear before the rc check so cleanup() doesn't try to kill a reaped pid.
+    CANTON_BRINGUP_PID=""
+    cat "$CANTON_BRINGUP_LOG"
+    rm -f "$CANTON_BRINGUP_LOG"
+    CANTON_BRINGUP_LOG=""
+    if [ "$bringup_rc" -ne 0 ]; then
+        echo "ERROR: Canton bring-up failed (exit $bringup_rc)" >&2
+        exit 1
+    fi
+else
+    log_phase "Starting Canton ($TARGET)"
+    download_localnet
+    start_localnet
+fi
 
 # dec-party-manager instances
 log_phase "Starting dec-party-manager instances"


### PR DESCRIPTION
Integration Tests is CI's only critical path. It runs ~31 min; every other job finishes in ≤7. About 13 of those minutes were fixed `sleep()` calls rather than work.

Measured off run [34234757752](https://github.com/DLC-link/decentralization-manager/actions/runs/34234757752) (a passing run on main-ish code):

| Segment | Before |
|---|---|
| Setup (checkout, apt, node, caches, toolchain) | 1:13 |
| `gen-types` | 0:36 |
| `cargo build --profile release-ci` | 1:22 |
| Canton bring-up (1:51 of it = splice healthcheck) | 2:24 |
| Start nodes + configure peers | 0:41 |
| Compile the e2e test binary | 1:20 |
| **e2e run** | **23:30** |

## What was actually slow

`TOPOLOGY_PROPAGATION_DELAY_SECS = 30` was a bare `const`, unlike the two functions right next to it in `consts.rs` which already read env vars. It sleeps unconditionally after every topology submission, in four workflow kinds (onboarding, kick, add-party, change-threshold). 20 workflows run per suite — 12 in visible scenarios, 8 more inside the chaos phases — so that one constant was ~10 minutes. It also explains why every party-creating phase landed on ~48-50s: 30s sleep plus ~18s of real work.

The rest: a 61s sleep in `owner_key_resilience`, ~16 node restarts × an 8s blind settle, and ~2:30 of pure serialization in `run.sh`.

## Changes

- **Propagation delay is now env-overridable** (`DECPM_TOPOLOGY_PROPAGATION_DELAY_SECS`), set to 3s for localnet, whose single-container Canton settles in well under a second. `devnet.env.sh` deliberately does not set it — devnet is a real network and keeps the 30s production default.
- **Bring-up overlaps the builds.** The localnet bring-up is backgrounded and the e2e test binary is linked before the stack goes live; both were serialized behind work they don't depend on. devnet stays synchronous, because there `start_localnet` is `start_canton_tunnels` and a subshell would lose `CANTON_TUNNEL_PIDS` that cleanup needs. `cleanup()` reaps the background bring-up before `stop_localnet`, so a `down -v` can't race a live `up`.
- **The 61s sleep is gone.** A new `db::backdate_dec_party_cache` helper ages `dec_party.updated_at` directly. Lowering the server's staleness threshold globally would have been the obvious alternative and is the wrong move — it would make every parties GET in the suite spawn a peer fan-out refresh, which is the #415 path.
- **The blind 8s post-restart settle is a `/healthz` probe + 1s.** The 8s stood in for two different things: DecMan finishing bootstrap, which `/healthz` answers precisely, and the Noise mesh re-converging, which isn't `wait_for_server`'s job — `chaos::post_onboarding` already retries a 422 peer-mesh pre-flight 12 times and `ensure_nodes_healthy` repairs a node that never came back.
- **A `concurrency` group** so a superseded PR commit stops holding a 30-min `ubuntu-very-big` runner. `cancel-in-progress` is gated on `github.event_name == 'pull_request'`, so a push to main and a release (which reaches this file via `workflow_call`) always finish.
- **Fixed a log blind spot.** The 8 chaos phases log at `::chaos`, which the quiet `RUST_LOG` preset filtered out — 419s of every run, 22% of the suite, produced no output at all. That's why the slowdown had gone unmeasured.

## Expected result

~31 min → **~17 min**, with no test removed and no assertion weakened. The numbers are projections from the measured segments; this PR's own CI run is the real check.

## Not in this PR

Sharding the e2e across parallel jobs is the remaining big win (~17 → ~10 min), but it isn't a config change. The driver in `governance_workflows.rs` documents hard ordering constraints — `canton_admin_tls` must run before any party includes P3, `dual_governance_onboarding` needs the ProviderService that `utility_onboarding` sets and must precede both `contracts_quorum_completes` and `kick` — and phases share one `Fixture` plus the same three nodes. Partitioning that needs the dependency graph untangled first, and guessing at the split would burn a lot of 30-min CI cycles to converge. Worth doing as its own change.

## Risk

The two changes that could flake rather than fail loudly are the 3s propagation delay and the shorter restart settle. Both are localnet-only, both are single numbers, and CI on this PR exercises every chaos phase. If a phase gets flaky, raising `DECPM_TOPOLOGY_PROPAGATION_DELAY_SECS` in `env.sh` is a one-line adjustment.
