### PR TITLE
Move the signing threshold and drop the kicked member's key

### DIFF
--- a/crates/decman/migrations/000017_participant_signing_key.down.sql
+++ b/crates/decman/migrations/000017_participant_signing_key.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE dec_party_participant DROP COLUMN signing_key;

--- a/crates/decman/migrations/000017_participant_signing_key.up.sql
+++ b/crates/decman/migrations/000017_participant_signing_key.up.sql
@@ -1,0 +1,7 @@
+-- Each member contributes one Daml (protocol) signing key to a decentralized
+-- party, but `PartyToParticipant.party_signing_keys` records no owner for any
+-- of them and the key is not delegated in topology, so nothing on-chain says
+-- whose key is whose. Kick needs that mapping to drop the removed member's
+-- key. Peers report their own fingerprint over the OwnerKeys exchange, the
+-- same way `owner_key` is resolved, and it is cached here.
+ALTER TABLE dec_party_participant ADD COLUMN signing_key TEXT;

--- a/crates/decman/src/db/rows.rs
+++ b/crates/decman/src/db/rows.rs
@@ -153,6 +153,10 @@ pub struct DecPartyParticipantRow {
     pub participant_uid: String,
     pub permission: String,
     pub owner_key: Option<String>,
+    /// Fingerprint of the Daml signing key this participant contributes to
+    /// the party's `party_signing_keys`. `None` until the participant
+    /// reports it over the OwnerKeys exchange.
+    pub signing_key: Option<String>,
 }
 
 #[derive(Debug, sqlx::FromRow)]

--- a/crates/decman/src/db/schema.rs
+++ b/crates/decman/src/db/schema.rs
@@ -224,6 +224,15 @@ pub trait Commitable {
         owner_key: &str,
     ) -> Result;
 
+    /// Update the Daml signing-key fingerprint for a specific participant in
+    /// a decentralized party
+    async fn update_participant_signing_key(
+        &mut self,
+        party_id: &CantonId,
+        participant_uid: &str,
+        signing_key: &str,
+    ) -> Result;
+
     /// Insert or replace a pending invitation
     async fn upsert_pending_invitation(&mut self, inv: &PendingInvitation) -> Result;
 

--- a/crates/decman/src/db/sqlite.rs
+++ b/crates/decman/src/db/sqlite.rs
@@ -701,9 +701,9 @@ impl Commitable for sqlx::Transaction<'static, sqlx::Sqlite> {
     ) -> Result {
         let party_id_str = party_id.to_string();
         // UPSERT each fresh row. permission may change (e.g., submission ->
-        // confirmation); owner_key only ever transitions NULL -> Some, never
-        // back to NULL. COALESCE keeps a previously-known fingerprint when
-        // the live Canton fetch carries None for it.
+        // confirmation); owner_key and signing_key only ever transition
+        // NULL -> Some, never back to NULL. COALESCE keeps a previously-known
+        // fingerprint when the live Canton fetch carries None for it.
         for p in participants {
             sqlx::query(
                 r"
@@ -711,17 +711,21 @@ impl Commitable for sqlx::Transaction<'static, sqlx::Sqlite> {
                     dec_party_id,
                     participant_uid,
                     permission,
-                    owner_key
-                ) VALUES (?, ?, ?, ?)
+                    owner_key,
+                    signing_key
+                ) VALUES (?, ?, ?, ?, ?)
                 ON CONFLICT(dec_party_id, participant_uid) DO UPDATE SET
                     permission = excluded.permission,
-                    owner_key = COALESCE(excluded.owner_key, dec_party_participant.owner_key)
+                    owner_key = COALESCE(excluded.owner_key, dec_party_participant.owner_key),
+                    signing_key =
+                        COALESCE(excluded.signing_key, dec_party_participant.signing_key)
                 ",
             )
             .bind(&party_id_str)
             .bind(&p.participant_uid)
             .bind(&p.permission)
             .bind(&p.owner_key)
+            .bind(&p.signing_key)
             .execute(&mut **self)
             .await?;
         }
@@ -868,6 +872,28 @@ impl Commitable for sqlx::Transaction<'static, sqlx::Sqlite> {
             ",
         )
         .bind(owner_key)
+        .bind(party_id.to_string())
+        .bind(participant_uid)
+        .execute(&mut **self)
+        .await?;
+
+        Ok(())
+    }
+
+    async fn update_participant_signing_key(
+        &mut self,
+        party_id: &CantonId,
+        participant_uid: &str,
+        signing_key: &str,
+    ) -> Result {
+        sqlx::query(
+            r"
+            UPDATE dec_party_participant
+            SET signing_key = ?
+            WHERE dec_party_id = ? AND participant_uid = ?
+            ",
+        )
+        .bind(signing_key)
         .bind(party_id.to_string())
         .bind(participant_uid)
         .execute(&mut **self)
@@ -1471,12 +1497,14 @@ mod tests {
                 participant_uid: "node1::1220aa".to_string(),
                 permission: "submission".to_string(),
                 owner_key: Some("fingerprint-1".to_string()),
+                signing_key: None,
             },
             DecPartyParticipantRow {
                 dec_party_id: party_id_str.clone(),
                 participant_uid: "node2::1220bb".to_string(),
                 permission: "confirmation".to_string(),
                 owner_key: None,
+                signing_key: None,
             },
         ];
         tx.replace_dec_party_participants(&party_id, &participants)
@@ -1518,6 +1546,7 @@ mod tests {
                 participant_uid: "node1::1220aa".to_string(),
                 permission: "submission".to_string(),
                 owner_key: Some("fingerprint-1".to_string()),
+                signing_key: None,
             }],
         )
         .await?;
@@ -1533,6 +1562,7 @@ mod tests {
                 participant_uid: "node1::1220aa".to_string(),
                 permission: "submission".to_string(),
                 owner_key: None,
+                signing_key: None,
             }],
         )
         .await?;
@@ -1544,6 +1574,66 @@ mod tests {
             result[0].owner_key,
             Some("fingerprint-1".to_string()),
             "owner_key should be preserved across a refresh that brings a NULL value"
+        );
+
+        Ok(())
+    }
+
+    /// The party's `party_signing_keys` record no owner per key, so the only
+    /// place the mapping from member to Daml key lives is what each member
+    /// reports about itself. A refresh that brings a NULL must not throw it
+    /// away, or a kick loses the record it needs to drop the right key (#428).
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn test_participant_signing_key_survives_a_refresh(pool: SqlitePool) -> Result {
+        let mut tx = pool.begin_transaction().await?;
+        tx.upsert_dec_party(&test_dec_party("net-a")).await?;
+        let party_id_str = format!("net-a::{TEST_NS}");
+        let party_id = CantonId::parse(&party_id_str)?;
+        tx.replace_dec_party_participants(
+            &party_id,
+            &[DecPartyParticipantRow {
+                dec_party_id: party_id_str.clone(),
+                participant_uid: "node1::1220aa".to_string(),
+                permission: "submission".to_string(),
+                owner_key: None,
+                signing_key: None,
+            }],
+        )
+        .await?;
+        // What `resolve_owner_keys_from_peers` writes once the peer answers.
+        tx.update_participant_signing_key(&party_id, "node1::1220aa", "daml-fingerprint-1")
+            .await?;
+        Commitable::commit(tx).await?;
+
+        let seeded = pool.get_dec_party_participants(&party_id).await?;
+        assert_eq!(
+            seeded.first().and_then(|p| p.signing_key.clone()),
+            Some("daml-fingerprint-1".to_string())
+        );
+
+        // A live Canton fetch never carries the fingerprint, so every refresh
+        // brings a NULL for it.
+        let mut tx = pool.begin_transaction().await?;
+        tx.replace_dec_party_participants(
+            &party_id,
+            &[DecPartyParticipantRow {
+                dec_party_id: party_id_str,
+                participant_uid: "node1::1220aa".to_string(),
+                permission: "confirmation".to_string(),
+                owner_key: None,
+                signing_key: None,
+            }],
+        )
+        .await?;
+        Commitable::commit(tx).await?;
+
+        let result = pool.get_dec_party_participants(&party_id).await?;
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].permission, "confirmation");
+        assert_eq!(
+            result[0].signing_key,
+            Some("daml-fingerprint-1".to_string()),
+            "signing_key should be preserved across a refresh that brings a NULL value"
         );
 
         Ok(())
@@ -1566,6 +1656,7 @@ mod tests {
                 participant_uid: "node1::1220aa".to_string(),
                 permission: "submission".to_string(),
                 owner_key: Some("fingerprint-1".to_string()),
+                signing_key: None,
             }],
         )
         .await?;
@@ -1603,6 +1694,7 @@ mod tests {
                 participant_uid: "node1::1220aa".to_string(),
                 permission: "submission".to_string(),
                 owner_key: None,
+                signing_key: None,
             }],
         )
         .await?;
@@ -1639,12 +1731,14 @@ mod tests {
                     participant_uid: p1.to_string(),
                     permission: "submission".to_string(),
                     owner_key: Some("fp-1".to_string()),
+                    signing_key: None,
                 },
                 DecPartyParticipantRow {
                     dec_party_id: party_id_str.clone(),
                     participant_uid: p2.to_string(),
                     permission: "submission".to_string(),
                     owner_key: Some("fp-2".to_string()),
+                    signing_key: None,
                 },
             ],
         )
@@ -1661,6 +1755,7 @@ mod tests {
                 participant_uid: p1.to_string(),
                 permission: "submission".to_string(),
                 owner_key: Some("fp-1".to_string()),
+                signing_key: None,
             }],
         )
         .await?;
@@ -1692,12 +1787,14 @@ mod tests {
                     participant_uid: "node1::1220aa".to_string(),
                     permission: "submission".to_string(),
                     owner_key: Some("fingerprint-1".to_string()),
+                    signing_key: None,
                 },
                 DecPartyParticipantRow {
                     dec_party_id: party_id_str.clone(),
                     participant_uid: "node2::1220bb".to_string(),
                     permission: "confirmation".to_string(),
                     owner_key: None,
+                    signing_key: None,
                 },
             ],
         )
@@ -1776,6 +1873,7 @@ mod tests {
                 participant_uid: "node1".to_string(),
                 permission: "submission".to_string(),
                 owner_key: None,
+                signing_key: None,
             }],
         )
         .await?;
@@ -2703,6 +2801,7 @@ mod tests {
                 participant_uid: "a-node1::1220aa".to_string(),
                 permission: "submission".to_string(),
                 owner_key: None,
+                signing_key: None,
             }],
         )
         .await?;
@@ -2714,12 +2813,14 @@ mod tests {
                     participant_uid: "b-node1::1220bb".to_string(),
                     permission: "submission".to_string(),
                     owner_key: None,
+                    signing_key: None,
                 },
                 DecPartyParticipantRow {
                     dec_party_id: party_b_str.clone(),
                     participant_uid: "b-node2::1220cc".to_string(),
                     permission: "confirmation".to_string(),
                     owner_key: None,
+                    signing_key: None,
                 },
             ],
         )

--- a/crates/decman/src/server/handlers/parties.rs
+++ b/crates/decman/src/server/handlers/parties.rs
@@ -442,6 +442,20 @@ pub async fn resolve_owner_keys_from_peers(
                 {
                     tracing::debug!("Failed to update owner key for {peer_uid}: {e}");
                 }
+
+                // Absent from peers that predate the field. Nothing else can
+                // supply it — the party's signing keys carry no owner — so a
+                // kick coordinated here falls back to elimination until this
+                // peer answers a later refresh.
+                let Some(signing_key) = entry["signing_key"].as_str() else {
+                    continue;
+                };
+                if let Err(e) = tx
+                    .update_participant_signing_key(&party_id_canton, &peer_uid, signing_key)
+                    .await
+                {
+                    tracing::debug!("Failed to update signing key for {peer_uid}: {e}");
+                }
             }
             if let Err(e) = Commitable::commit(tx).await {
                 tracing::debug!("Failed to commit owner key updates: {e}");
@@ -700,6 +714,10 @@ pub async fn store_parties_to_db(
                 }
                 .to_string(),
                 owner_key: p.owner_key.clone(),
+                // Reported by the participant itself over the OwnerKeys
+                // exchange, never carried on the live Canton fetch — the
+                // upsert COALESCEs a cached value rather than clearing it.
+                signing_key: None,
             })
             .collect();
         tx.replace_dec_party_participants(&party.party_id, &participants)

--- a/crates/decman/src/server/mod.rs
+++ b/crates/decman/src/server/mod.rs
@@ -2377,9 +2377,9 @@ async fn run_peer_listener(
 /// its entry in `PartyToParticipant.party_signing_keys`. That mapping exists
 /// nowhere else: the protobuf records no owner per key and the key is not
 /// delegated in topology, so only the node that generated it can say it is
-/// theirs. Kick needs it to drop the removed member's key. Omitted when this
-/// node has no such key for the party; a caller that predates the field
-/// ignores it.
+/// theirs. Kick needs it to drop the removed member's key. `null` when this
+/// node has no such key for the party, which the reader treats the same way
+/// as the absent field it gets from a caller's older peers.
 ///
 /// `requested_party_ids` is the list of parties the caller cares about, sent
 /// in the Noise `RequestOwnerKeys` payload by `resolve_owner_keys_from_peers`.

--- a/crates/decman/src/server/mod.rs
+++ b/crates/decman/src/server/mod.rs
@@ -41,7 +41,7 @@ use canton_proto_rs::com::digitalasset::canton::{
         admin::v30::{
             ListMyKeysRequest, private_key_metadata, vault_service_client::VaultServiceClient,
         },
-        v30::public_key,
+        v30::{SigningKeyUsage, public_key},
     },
     topology::admin::v30::{
         BaseQuery, ListDecentralizedNamespaceDefinitionRequest, StoreId, Synchronizer, base_query,
@@ -2370,7 +2370,16 @@ async fn run_peer_listener(
 
 /// Query Canton for this node's owner keys across a caller-supplied set of
 /// decentralized parties. Returns JSON:
-/// `[{"party_id": "prefix::namespace", "owner_key": "fingerprint"}, ...]`.
+/// `[{"party_id": "prefix::namespace", "owner_key": "fingerprint",
+/// "signing_key": "fingerprint"}, ...]`.
+///
+/// `signing_key` is this node's Daml (protocol) signing key for the party —
+/// its entry in `PartyToParticipant.party_signing_keys`. That mapping exists
+/// nowhere else: the protobuf records no owner per key and the key is not
+/// delegated in topology, so only the node that generated it can say it is
+/// theirs. Kick needs it to drop the removed member's key. Omitted when this
+/// node has no such key for the party; a caller that predates the field
+/// ignores it.
 ///
 /// `requested_party_ids` is the list of parties the caller cares about, sent
 /// in the Noise `RequestOwnerKeys` payload by `resolve_owner_keys_from_peers`.
@@ -2417,14 +2426,32 @@ async fn list_my_owner_keys(
         .into_inner();
 
     let mut my_fingerprints = Vec::new();
+    // Protocol-usage keys, indexed by the vault name onboarding / add-party
+    // gave them (`<party prefix>-daml-transactions`). The name is how
+    // `get_or_create_signing_key` finds the key again on a retry, so it is
+    // also the only local record of which party a protocol key belongs to.
+    let mut my_protocol_keys_by_name: HashMap<String, String> = HashMap::new();
     for key_meta in keys_response.private_keys_metadata {
         if let Some(private_key_metadata::PublicKeyWithName::V30(pub_key_with_name)) =
             &key_meta.public_key_with_name
             && let Some(pub_key) = &pub_key_with_name.public_key
             && let Some(public_key::Key::SigningPublicKey(signing_key)) = &pub_key.key
-            && signing_key.usage.contains(&1)
         {
-            my_fingerprints.push(compute_fingerprint(signing_key));
+            if signing_key
+                .usage
+                .contains(&(SigningKeyUsage::Namespace as i32))
+            {
+                my_fingerprints.push(compute_fingerprint(signing_key));
+            }
+            if signing_key
+                .usage
+                .contains(&(SigningKeyUsage::Protocol as i32))
+            {
+                my_protocol_keys_by_name.insert(
+                    pub_key_with_name.name.clone(),
+                    compute_fingerprint(signing_key),
+                );
+            }
         }
     }
 
@@ -2466,11 +2493,15 @@ async fn list_my_owner_keys(
         let Some(full_party_id) = namespace_to_party.get(&item.decentralized_namespace) else {
             continue;
         };
+        let signing_key = full_party_id.rsplit_once("::").and_then(|(prefix, _)| {
+            my_protocol_keys_by_name.get(&workflow::signing_keys::party_daml_key_name(prefix))
+        });
         for owner in &item.owners {
             if my_fingerprints.contains(owner) {
                 entries.push(serde_json::json!({
                     "party_id": full_party_id,
                     "owner_key": owner,
+                    "signing_key": signing_key,
                 }));
             }
         }

--- a/crates/decman/src/workflow/change_threshold/steps/proposals/create.rs
+++ b/crates/decman/src/workflow/change_threshold/steps/proposals/create.rs
@@ -1,4 +1,5 @@
 use canton_proto_rs::com::digitalasset::canton::{
+    crypto::v30::SigningKeysWithThreshold,
     protocol::v30::{
         DecentralizedNamespaceDefinition, PartyToParticipant, TopologyMapping, enums,
         topology_mapping,
@@ -27,8 +28,9 @@ use crate::{
 /// This step creates:
 /// - DNS proposal re-issuing the namespace with the new threshold (same
 ///   owners) — `CHANGE_THRESHOLD_DNS_PROPOSAL`
-/// - P2P proposal re-issuing the party mapping with the new threshold (same
-///   participants) — `CHANGE_THRESHOLD_P2P_PROPOSAL`
+/// - P2P proposal re-issuing the party mapping with the new threshold on both
+///   the hosting and the signing side (same participants, same keys) —
+///   `CHANGE_THRESHOLD_P2P_PROPOSAL`
 /// - New namespace definition — `CHANGE_THRESHOLD_NEW_NAMESPACE_DEF` (used by
 ///   submit to poll the topology)
 /// - Full party id — `CHANGE_THRESHOLD_PARTY_ID` (used by submit)
@@ -95,11 +97,26 @@ pub async fn create_proposals(
         threshold = current_p2p.threshold,
     );
 
+    // A `PartyToParticipant` carries two thresholds: how many hosting
+    // participants must confirm, and how many of the party's signing keys
+    // authorize a transaction for it. Both are the threshold this workflow
+    // exists to change, so re-issuing the signing keys verbatim changed only
+    // half of it (#428).
+    let signing_keys = current_p2p.party_signing_keys.ok_or_else(|| {
+        anyhow::anyhow!(
+            "Party {party_id} carries no party signing keys, so its signing threshold \
+             cannot be changed"
+        )
+    })?;
+
     let new_p2p = PartyToParticipant {
         party: party_id_str.clone(),
         threshold: new_threshold.try_into()?,
         participants: current_p2p.participants,
-        party_signing_keys: current_p2p.party_signing_keys,
+        party_signing_keys: Some(SigningKeysWithThreshold {
+            keys: signing_keys.keys,
+            threshold: new_threshold.try_into()?,
+        }),
     };
 
     // Create proposals using topology manager

--- a/crates/decman/src/workflow/kick/steps/cache.rs
+++ b/crates/decman/src/workflow/kick/steps/cache.rs
@@ -62,6 +62,7 @@ mod tests {
                 participant_uid: (*uid).to_string(),
                 permission: "submission".to_string(),
                 owner_key: None,
+                signing_key: None,
             })
             .collect();
 
@@ -127,6 +128,7 @@ mod tests {
                 participant_uid: NODE1.to_string(),
                 permission: "confirmation".to_string(),
                 owner_key: Some("fingerprint-1".to_string()),
+                signing_key: None,
             }],
         )
         .await?;

--- a/crates/decman/src/workflow/kick/steps/proposals/create.rs
+++ b/crates/decman/src/workflow/kick/steps/proposals/create.rs
@@ -1,4 +1,5 @@
 use canton_proto_rs::com::digitalasset::canton::{
+    crypto::v30::SigningKeysWithThreshold,
     protocol::v30::{
         DecentralizedNamespaceDefinition, PartyToParticipant, TopologyMapping, enums,
         topology_mapping,
@@ -17,6 +18,7 @@ use crate::{
     utils,
     workflow::{
         kick::KickConfig,
+        signing_keys::{known_signing_keys_by_member, signing_keys_without_member},
         storage::{WorkflowStorage, artifact_kinds},
         topology,
     },
@@ -26,7 +28,9 @@ use crate::{
 ///
 /// This step creates:
 /// - DNS proposal to update namespace (remove kicked owner) — `KICK_DNS_PROPOSAL`
-/// - P2P proposal to remove participant from mapping — `KICK_P2P_PROPOSAL`
+/// - P2P proposal to remove participant from mapping, with the kicked
+///   member's Daml key taken out of `party_signing_keys` and both thresholds
+///   moved to the new one — `KICK_P2P_PROPOSAL`
 /// - New namespace definition — `KICK_NEW_NAMESPACE_DEF` (used by submit)
 /// - Full party id — `KICK_PARTY_ID` (used by submit)
 pub async fn create_proposals(
@@ -133,11 +137,48 @@ pub async fn create_proposals(
         anyhow::bail!("Cannot remove all participants from party mapping");
     }
 
+    // Both thresholds move together, and the kicked member's Daml key comes
+    // out. Carrying `party_signing_keys` over verbatim left the removed
+    // member's key counting towards the party's signing threshold and left
+    // that threshold at its old value, which every peer refuses to sign (#428).
+    let current_signing_keys = current_p2p
+        .party_signing_keys
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Party {party_id} carries no party signing keys, so the kick cannot rebuild them"
+            )
+        })?
+        .keys;
+    let survivors: Vec<String> = new_participants
+        .iter()
+        .map(|p| p.participant_uid.clone())
+        .collect();
+    let claims = known_signing_keys_by_member(config, storage, &party_id).await?;
+    let new_signing_keys = signing_keys_without_member(
+        &current_signing_keys,
+        &kick_participant_str,
+        &survivors,
+        &claims,
+    )?;
+
+    if new_signing_keys.len() != new_participants.len() {
+        anyhow::bail!(
+            "Kick would leave the party with {keys} signing key(s) for {members} member(s). \
+             Every member contributes exactly one, so the party's key set does not match \
+             its membership and the peers would refuse the proposal",
+            keys = new_signing_keys.len(),
+            members = new_participants.len()
+        );
+    }
+
     let new_p2p = PartyToParticipant {
         party: party_id_str.clone(),
         threshold: new_threshold.try_into()?,
         participants: new_participants,
-        party_signing_keys: current_p2p.party_signing_keys,
+        party_signing_keys: Some(SigningKeysWithThreshold {
+            keys: new_signing_keys,
+            threshold: new_threshold.try_into()?,
+        }),
     };
 
     // Create proposals using topology manager

--- a/crates/decman/src/workflow/mod.rs
+++ b/crates/decman/src/workflow/mod.rs
@@ -6,6 +6,7 @@ pub mod external_party;
 pub mod kick;
 pub mod onboarding;
 pub mod party_replication;
+pub mod signing_keys;
 pub mod state;
 pub mod storage;
 pub mod topology;

--- a/crates/decman/src/workflow/signing_keys.rs
+++ b/crates/decman/src/workflow/signing_keys.rs
@@ -1,0 +1,340 @@
+//! The party's Daml signing keys, and which member contributed each one.
+//!
+//! `PartyToParticipant.party_signing_keys` is a flat list: the protobuf
+//! records no owner per key, and the Daml key — unlike the namespace key —
+//! gets no `NamespaceDelegation`, so nothing on-chain says whose key is
+//! whose. Only the node that generated a key can say it is theirs.
+//!
+//! Three sources are therefore combined to attribute the keys of a party:
+//!
+//! 1. `dec_party_identity` — every peer's key bundle on the node that
+//!    coordinated onboarding, the new member's on the node that ran
+//!    add-party, and its own on every node.
+//! 2. `dec_party_participant.signing_key` — each peer's own fingerprint as it
+//!    reported it over the `OwnerKeys` exchange, cached by the
+//!    `/decentralized-parties` refresh.
+//! 3. Elimination — a key claimed by no surviving member belongs to the one
+//!    being removed.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use canton_proto_rs::com::digitalasset::canton::crypto::{
+    admin::v30::{
+        ListKeysFilters, ListMyKeysRequest, private_key_metadata,
+        vault_service_client::VaultServiceClient,
+    },
+    v30::{SigningKeyUsage, SigningPublicKey, public_key},
+};
+use sqlx::SqlitePool;
+
+use crate::{
+    canton_id::CantonId,
+    config::NodeConfig,
+    db::schema::SchemaRead,
+    error::Result,
+    utils,
+    workflow::{
+        onboarding::steps::proposals::create::decode_keys_payload,
+        storage::{WorkflowStorage, identity_kinds},
+    },
+};
+
+/// Vault name of the Daml signing key a node holds for the party with this
+/// id prefix. Onboarding and add-party both mint the key under this name, and
+/// `get_or_create_signing_key` finds it again by it, so it is the local
+/// record of which party a protocol key belongs to.
+pub fn party_daml_key_name(party_id_prefix: &str) -> String {
+    format!("{party_id_prefix}-daml-transactions")
+}
+
+/// This node's own Daml signing-key fingerprint for a party: from its
+/// long-lived identity row, falling back to the vault key named after the
+/// party. Returns `None` when the node holds neither.
+async fn own_signing_key_fingerprint(
+    config: &NodeConfig,
+    db: &SqlitePool,
+    dec_party_id: &CantonId,
+) -> Result<Option<String>> {
+    let self_id = config.participant_id().to_string();
+    if let Some(payload) = db
+        .read_identity(dec_party_id, identity_kinds::PEER_PUBLIC_KEYS, &self_id)
+        .await?
+    {
+        let keys = decode_keys_payload(&payload)?;
+        if keys.len() == 2 {
+            return Ok(Some(utils::compute_fingerprint(&keys[1])));
+        }
+        tracing::warn!(
+            "PEER_PUBLIC_KEYS for {self_id} on {dec_party_id} holds {count} keys, not 2 — \
+             falling back to the vault",
+            count = keys.len()
+        );
+    }
+
+    let name = party_daml_key_name(&dec_party_id.prefix);
+    let mut vault_client = VaultServiceClient::new(config.admin_channel().await?);
+    let response = vault_client
+        .list_my_keys(tonic::Request::new(ListMyKeysRequest {
+            filters: Some(ListKeysFilters {
+                fingerprint: String::new(),
+                name: name.clone(),
+                purpose: vec![],
+                usage_v30: vec![SigningKeyUsage::Protocol as i32],
+            }),
+            base_request: None,
+        }))
+        .await?
+        .into_inner();
+
+    for meta in response.private_keys_metadata {
+        if let Some(private_key_metadata::PublicKeyWithName::V30(pkn)) = meta.public_key_with_name
+            && let Some(pk) = pkn.public_key
+            && let Some(public_key::Key::SigningPublicKey(spk)) = pk.key
+        {
+            return Ok(Some(utils::compute_fingerprint(&spk)));
+        }
+    }
+
+    tracing::warn!("No Daml signing key named '{name}' in this node's vault");
+    Ok(None)
+}
+
+/// Which Daml signing-key fingerprint each member of a party contributed, as
+/// far as this node can tell. Members whose key is unknown are absent from
+/// the map.
+///
+/// Reads the identity rows this node happens to hold, then the fingerprints
+/// participants reported for themselves, then — for this node — its own key.
+pub async fn known_signing_keys_by_member(
+    config: &NodeConfig,
+    db: &SqlitePool,
+    dec_party_id: &CantonId,
+) -> Result<BTreeMap<String, String>> {
+    let mut claims = BTreeMap::new();
+
+    for participant in db.get_dec_party_participants(dec_party_id).await? {
+        if let Some(fingerprint) = participant.signing_key {
+            claims.insert(participant.participant_uid, fingerprint);
+        }
+    }
+
+    // Identity rows outrank the cache: they are the key bundle this node was
+    // handed during the run that added the member, not a fingerprint relayed
+    // over the network afterwards.
+    for (peer_id, payload) in db
+        .list_identity(dec_party_id, identity_kinds::PEER_PUBLIC_KEYS)
+        .await?
+    {
+        match decode_keys_payload(&payload) {
+            Ok(keys) if keys.len() == 2 => {
+                claims.insert(peer_id, utils::compute_fingerprint(&keys[1]));
+            }
+            Ok(keys) => tracing::warn!(
+                "PEER_PUBLIC_KEYS for {peer_id} on {dec_party_id} holds {count} keys, not 2",
+                count = keys.len()
+            ),
+            Err(e) => {
+                tracing::warn!(
+                    "PEER_PUBLIC_KEYS for {peer_id} on {dec_party_id} will not decode: {e:#}"
+                )
+            }
+        }
+    }
+
+    let self_id = config.participant_id().to_string();
+    if !claims.contains_key(&self_id)
+        && let Some(own) = own_signing_key_fingerprint(config, db, dec_party_id).await?
+    {
+        claims.insert(self_id, own);
+    }
+
+    Ok(claims)
+}
+
+/// The key set a party should carry once `removed` is no longer a member.
+///
+/// `current` is the party's on-chain key list, `survivors` the members that
+/// stay, and `claims` the attribution [`known_signing_keys_by_member`]
+/// assembled. The removed member's key is identified directly when its
+/// fingerprint is known, and otherwise by elimination — a key no survivor
+/// claims can only be the departing member's.
+///
+/// # Errors
+///
+/// Errors when the key cannot be attributed either way. Signing a mapping
+/// that still carries the key would leave a removed participant counting
+/// towards the party's signing threshold, which is the whole point of taking
+/// it out.
+pub fn signing_keys_without_member(
+    current: &[SigningPublicKey],
+    removed: &str,
+    survivors: &[String],
+    claims: &BTreeMap<String, String>,
+) -> Result<Vec<SigningPublicKey>> {
+    let fingerprints: Vec<String> = current.iter().map(utils::compute_fingerprint).collect();
+
+    let claimed_by_removed = claims.get(removed).filter(|f| fingerprints.contains(f));
+    let target = match claimed_by_removed {
+        Some(fingerprint) => {
+            tracing::info!("Removing {removed}'s Daml signing key {fingerprint} from the party");
+            fingerprint.clone()
+        }
+        None => {
+            let survivor_claims: BTreeSet<&String> =
+                survivors.iter().filter_map(|uid| claims.get(uid)).collect();
+            let unclaimed: Vec<&String> = fingerprints
+                .iter()
+                .filter(|f| !survivor_claims.contains(f))
+                .collect();
+            match unclaimed.as_slice() {
+                [fingerprint] => {
+                    tracing::info!(
+                        "{removed}'s Daml signing key is not recorded locally; {fingerprint} is \
+                         the only party signing key no remaining member claims, so it is theirs"
+                    );
+                    (*fingerprint).clone()
+                }
+                [] => {
+                    tracing::info!(
+                        "Every party signing key is claimed by a remaining member, so \
+                         {removed} has none left to remove"
+                    );
+                    return Ok(current.to_vec());
+                }
+                _ => anyhow::bail!(
+                    "Cannot tell which of the party's {total} signing keys belongs to \
+                     {removed}: {count} of them are claimed by no remaining member. Refresh \
+                     /decentralized-parties so every member reports its signing key, then \
+                     retry — leaving the key in would keep {removed} counting towards the \
+                     party's signing threshold",
+                    total = fingerprints.len(),
+                    count = unclaimed.len()
+                ),
+            }
+        }
+    };
+
+    Ok(current
+        .iter()
+        .zip(&fingerprints)
+        .filter(|(_, fingerprint)| *fingerprint != &target)
+        .map(|(key, _)| key.clone())
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A `SigningPublicKey` whose fingerprint is stable and distinct per
+    /// `seed` — the tests only ever compare fingerprints.
+    fn key(seed: u8) -> SigningPublicKey {
+        SigningPublicKey {
+            public_key: vec![seed; 32],
+            usage: vec![SigningKeyUsage::Protocol as i32],
+            ..Default::default()
+        }
+    }
+
+    fn fingerprint(seed: u8) -> String {
+        utils::compute_fingerprint(&key(seed))
+    }
+
+    fn claims(entries: &[(&str, u8)]) -> BTreeMap<String, String> {
+        entries
+            .iter()
+            .map(|(uid, seed)| ((*uid).to_string(), fingerprint(*seed)))
+            .collect()
+    }
+
+    fn uids(names: &[&str]) -> Vec<String> {
+        names.iter().map(|n| (*n).to_string()).collect()
+    }
+
+    #[test]
+    fn drops_the_key_the_removed_member_claims() -> Result {
+        let current = vec![key(1), key(2), key(3)];
+        let claims = claims(&[("p1", 1), ("p2", 2), ("p3", 3)]);
+
+        let remaining = signing_keys_without_member(&current, "p3", &uids(&["p1", "p2"]), &claims)?;
+
+        assert_eq!(
+            remaining
+                .iter()
+                .map(utils::compute_fingerprint)
+                .collect::<Vec<_>>(),
+            vec![fingerprint(1), fingerprint(2)]
+        );
+        Ok(())
+    }
+
+    /// The devnet case: a fourth member joined via add-party, and the node
+    /// coordinating the kick never recorded its key. The three survivors do
+    /// claim theirs, so the fourth key is the one to drop.
+    #[test]
+    fn drops_the_unclaimed_key_when_the_removed_member_is_unknown() -> Result {
+        let current = vec![key(1), key(2), key(3), key(4)];
+        let claims = claims(&[("p1", 1), ("p2", 2), ("p3", 3)]);
+
+        let remaining =
+            signing_keys_without_member(&current, "p4", &uids(&["p1", "p2", "p3"]), &claims)?;
+
+        assert_eq!(
+            remaining
+                .iter()
+                .map(utils::compute_fingerprint)
+                .collect::<Vec<_>>(),
+            vec![fingerprint(1), fingerprint(2), fingerprint(3)]
+        );
+        Ok(())
+    }
+
+    /// A stale cached fingerprint that is not in the party's key set must not
+    /// be taken at its word — elimination still finds the right key.
+    #[test]
+    fn ignores_a_claim_that_is_not_in_the_key_set() -> Result {
+        let current = vec![key(1), key(2), key(3)];
+        let claims = claims(&[("p1", 1), ("p2", 2), ("p3", 9)]);
+
+        let remaining = signing_keys_without_member(&current, "p3", &uids(&["p1", "p2"]), &claims)?;
+
+        assert_eq!(
+            remaining
+                .iter()
+                .map(utils::compute_fingerprint)
+                .collect::<Vec<_>>(),
+            vec![fingerprint(1), fingerprint(2)]
+        );
+        Ok(())
+    }
+
+    /// Retrying a kick that already landed: the key is gone and there is
+    /// nothing left to take out.
+    #[test]
+    fn leaves_the_set_alone_when_the_removed_key_is_already_gone() -> Result {
+        let current = vec![key(1), key(2)];
+        let claims = claims(&[("p1", 1), ("p2", 2)]);
+
+        let remaining = signing_keys_without_member(&current, "p3", &uids(&["p1", "p2"]), &claims)?;
+
+        assert_eq!(remaining.len(), 2);
+        Ok(())
+    }
+
+    /// Two unattributed keys and no record of the removed member's: guessing
+    /// would either strand a survivor's key or leave the departing member's
+    /// in, so the kick has to stop.
+    #[test]
+    fn refuses_when_two_keys_are_unclaimed() {
+        let current = vec![key(1), key(2), key(3)];
+        let claims = claims(&[("p1", 1)]);
+
+        match signing_keys_without_member(&current, "p3", &uids(&["p1", "p2"]), &claims) {
+            Ok(_) => panic!("ambiguous attribution must not produce a key set"),
+            Err(error) => assert!(
+                error.to_string().contains("Cannot tell which"),
+                "unexpected error: {error}"
+            ),
+        }
+    }
+}

--- a/crates/decman/src/workflow/validation.rs
+++ b/crates/decman/src/workflow/validation.rs
@@ -43,6 +43,18 @@ use crate::{
     },
 };
 
+/// What an unrecorded local key bundle means for a check that needs it.
+///
+/// Onboarding generates the bundle on the run itself, so its absence there is
+/// a broken run. Every later proposal falls back to the long-lived identity
+/// row, which a party onboarded before that table existed does not have — the
+/// same legacy gap the DNS owner-set check tolerates.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum WhenUnrecorded {
+    Fail,
+    Skip,
+}
+
 /// What the operator agreed to when they accepted the invitation.
 ///
 /// Built from the peer's own `workflow_runs` row, which
@@ -216,7 +228,7 @@ impl PeerExpectations {
             );
         }
 
-        self.check_threshold(namespace_def.threshold, owners.len())?;
+        self.check_threshold("namespace", namespace_def.threshold, owners.len())?;
 
         let owner_set: std::collections::HashSet<String> = owners.iter().cloned().collect();
         let computed = compute_decentralized_namespace(&owner_set);
@@ -294,7 +306,7 @@ impl PeerExpectations {
         self.check_p2p_membership(&mapping)?;
         self.check_onboarding_markers(&mapping)?;
         self.check_p2p_thresholds(&mapping)?;
-        self.check_own_daml_key(storage, instance_name, &mapping)
+        self.check_own_daml_key(storage, instance_name, &mapping, WhenUnrecorded::Fail)
             .await
     }
 
@@ -348,7 +360,7 @@ impl PeerExpectations {
                 expected = self.members.len()
             );
         }
-        self.check_threshold(namespace_def.threshold, owners.len())?;
+        self.check_threshold("namespace", namespace_def.threshold, owners.len())?;
 
         // Losing our namespace from the owner set would leave this node hosting
         // a party it can no longer authorize changes to. The lookup itself is
@@ -381,6 +393,12 @@ impl PeerExpectations {
         self.check_p2p_membership(&mapping)?;
         self.check_onboarding_markers(&mapping)?;
         self.check_p2p_thresholds(&mapping)?;
+        // Kick rebuilds the key set to take the departing member's key out
+        // (#428), and it has to work out which key that is from local records.
+        // Get it wrong and a remaining member's key goes instead: the counts
+        // still match, so only the member whose key vanished can catch it.
+        self.check_own_daml_key(storage, instance_name, &mapping, WhenUnrecorded::Skip)
+            .await?;
 
         tracing::info!(
             "{kind:?} proposals match the accepted invitation for {dec_party_id}",
@@ -644,36 +662,72 @@ impl PeerExpectations {
     /// authorize a transaction for it. Both are pinned — leaving the signing
     /// threshold unchecked would let a coordinator raise a hosting threshold
     /// the operator agreed to while quietly dropping the signing one to 1.
+    ///
+    /// The size of the key set is pinned with them, because a threshold only
+    /// means what the operator agreed to if the set it counts over does. Two
+    /// of three member keys is the accepted 2; two of a set that still holds
+    /// a kicked member's key is not (#428).
     fn check_p2p_thresholds(&self, mapping: &PartyToParticipant) -> Result {
-        self.check_threshold(i32::try_from(mapping.threshold)?, self.members.len())?;
-        match &mapping.party_signing_keys {
-            Some(signing_keys) => {
-                self.check_threshold(i32::try_from(signing_keys.threshold)?, self.members.len())
-            }
-            // Signing a mapping with no party signing keys does not merely
-            // leave a threshold unchecked — it submits a party that can no
-            // longer authorize anything. Every mapping this tool produces
-            // carries them (onboarding sets them, and the kick / add-party /
-            // change-threshold / clearing proposals all derive from the current
-            // on-chain mapping), so an absent set is a stripped proposal.
-            None => anyhow::bail!(
+        self.check_threshold(
+            "hosting",
+            i32::try_from(mapping.threshold)?,
+            self.members.len(),
+        )?;
+
+        // Signing a mapping with no party signing keys does not merely leave a
+        // threshold unchecked — it submits a party that can no longer
+        // authorize anything. Every mapping this tool produces carries them
+        // (onboarding sets them, and the kick / add-party / change-threshold /
+        // clearing proposals all derive from the current on-chain mapping), so
+        // an absent set is a stripped proposal.
+        let Some(signing_keys) = &mapping.party_signing_keys else {
+            anyhow::bail!(
                 "P2P proposal carries no party signing keys, which would leave the party \
                  unable to authorize anything"
-            ),
+            );
+        };
+
+        self.check_threshold(
+            "signing",
+            i32::try_from(signing_keys.threshold)?,
+            self.members.len(),
+        )?;
+
+        // Every member contributes exactly one Daml key, so the counts match.
+        // A peer cannot tell whose key is whose — the mapping records no owner
+        // per key — but it can tell that one too many is present, which is
+        // what a kick that forgot to drop the departing member's key looks
+        // like from here.
+        if signing_keys.keys.len() != self.members.len() {
+            anyhow::bail!(
+                "P2P proposal carries {keys} party signing key(s) for {members} member(s); \
+                 each member contributes exactly one, so a surplus key would let a \
+                 non-member keep authorizing for the party",
+                keys = signing_keys.keys.len(),
+                members = self.members.len()
+            );
         }
+        Ok(())
     }
 
     /// The threshold must be the one the invitation advertised, and in any
     /// case a sane value for the owner count — a threshold of 0 or one above
     /// the owner count would either need no signatures or deadlock the party.
-    fn check_threshold(&self, threshold: i32, owner_count: usize) -> Result {
+    ///
+    /// `kind` names which threshold is being checked. A mapping carries a
+    /// hosting and a signing threshold and both come through here, so a
+    /// message that named neither read as though the coordinator had ignored
+    /// the operator's input when in fact the other one was wrong.
+    fn check_threshold(&self, kind: &str, threshold: i32, owner_count: usize) -> Result {
         let owner_count = i32::try_from(owner_count)?;
         if !(1..=owner_count).contains(&threshold) {
-            anyhow::bail!("proposed threshold {threshold} is outside 1..={owner_count}");
+            anyhow::bail!("proposed {kind} threshold {threshold} is outside 1..={owner_count}");
         }
         match self.threshold {
             Some(expected) if expected != threshold => {
-                anyhow::bail!("proposed threshold {threshold} differs from the accepted {expected}")
+                anyhow::bail!(
+                    "proposed {kind} threshold {threshold} differs from the accepted {expected}"
+                )
             }
             Some(_) => Ok(()),
             // Only the onboarding invite's threshold is optional on the wire
@@ -683,14 +737,14 @@ impl PeerExpectations {
             None if self.kind == WorkflowKind::Onboarding => {
                 tracing::warn!(
                     "accepted onboarding invitation carried no threshold; only the range \
-                     check was applied to the proposed {threshold}"
+                     check was applied to the proposed {kind} threshold {threshold}"
                 );
                 Ok(())
             }
             None => anyhow::bail!(
-                "accepted {kind:?} invitation carries no threshold, so the proposed \
-                 {threshold} cannot be checked against it",
-                kind = self.kind
+                "accepted {workflow:?} invitation carries no threshold, so the proposed \
+                 {kind} threshold {threshold} cannot be checked against it",
+                workflow = self.kind
             ),
         }
     }
@@ -702,16 +756,22 @@ impl PeerExpectations {
         storage: &SqlitePool,
         instance_name: &str,
         mapping: &PartyToParticipant,
+        when_unrecorded: WhenUnrecorded,
     ) -> Result {
-        let keys = self
-            .own_keys(storage, instance_name)
-            .await?
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "this node's public keys are not on the {instance_name} run, so the P2P \
-                     proposal cannot be checked against them"
-                )
-            })?;
+        let keys = match self.own_keys(storage, instance_name).await? {
+            Some(keys) => keys,
+            None if when_unrecorded == WhenUnrecorded::Fail => anyhow::bail!(
+                "this node's public keys are not on the {instance_name} run, so the P2P \
+                 proposal cannot be checked against them"
+            ),
+            None => {
+                tracing::warn!(
+                    "this node's keys are unrecorded for this party (onboarded before the \
+                     identity table existed); skipping the party-signing-key check"
+                );
+                return Ok(());
+            }
+        };
         let own_daml_fingerprint = utils::compute_fingerprint(&keys[1]);
         let signing_keys = mapping
             .party_signing_keys
@@ -1044,7 +1104,7 @@ mod tests {
     fn rejects_a_threshold_the_invitation_did_not_advertise() -> Result {
         let a = canton_id("p1", 1)?;
         let expectations = expectations(vec![a.clone()], a);
-        assert!(expectations.check_threshold(1, 3).is_err());
+        assert!(expectations.check_threshold("namespace", 1, 3).is_err());
         Ok(())
     }
 
@@ -1054,9 +1114,9 @@ mod tests {
         let a = canton_id("p1", 1)?;
         let mut expectations = expectations(vec![a.clone()], a);
         expectations.threshold = Some(0);
-        assert!(expectations.check_threshold(0, 3).is_err());
+        assert!(expectations.check_threshold("namespace", 0, 3).is_err());
         expectations.threshold = Some(4);
-        assert!(expectations.check_threshold(4, 3).is_err());
+        assert!(expectations.check_threshold("namespace", 4, 3).is_err());
         Ok(())
     }
 
@@ -1064,7 +1124,7 @@ mod tests {
     fn accepts_the_advertised_threshold() -> Result {
         let a = canton_id("p1", 1)?;
         let expectations = expectations(vec![a.clone()], a);
-        expectations.check_threshold(2, 3)
+        expectations.check_threshold("namespace", 2, 3)
     }
 
     #[tokio::test]
@@ -1201,12 +1261,12 @@ mod tests {
         expectations.threshold = None;
 
         expectations.kind = WorkflowKind::Kick;
-        assert!(expectations.check_threshold(2, 3).is_err());
+        assert!(expectations.check_threshold("namespace", 2, 3).is_err());
         expectations.kind = WorkflowKind::AddParty;
-        assert!(expectations.check_threshold(2, 3).is_err());
+        assert!(expectations.check_threshold("namespace", 2, 3).is_err());
 
         expectations.kind = WorkflowKind::Onboarding;
-        expectations.check_threshold(2, 3)
+        expectations.check_threshold("namespace", 2, 3)
     }
 
     /// `generate_keys` derives the vault key names from the prefix, so an

--- a/crates/decman/src/workflow/validation.rs
+++ b/crates/decman/src/workflow/validation.rs
@@ -917,6 +917,20 @@ mod tests {
         }
     }
 
+    /// One distinct Daml signing key per member — the shape every mapping
+    /// this tool builds carries, and what the checks expect to see.
+    fn signing_keys(count: u8, threshold: u32) -> SigningKeysWithThreshold {
+        SigningKeysWithThreshold {
+            keys: (1..=count)
+                .map(|seed| SigningPublicKey {
+                    public_key: vec![seed; 32],
+                    ..Default::default()
+                })
+                .collect(),
+            threshold,
+        }
+    }
+
     /// Wrap a mapping the way the coordinator ships it, so the decode path is
     /// exercised end to end rather than around.
     fn encode_proposal(mapping: topology_mapping::Mapping) -> Vec<u8> {
@@ -1117,10 +1131,8 @@ mod tests {
         let (a, b) = (canton_id("p1", 1)?, canton_id("p2", 2)?);
         let expectations = expectations(vec![a.clone(), b.clone()], a.clone());
         let mut mapping = p2p("dec::x", &[a, b], 2);
-        mapping.party_signing_keys = Some(SigningKeysWithThreshold {
-            keys: Vec::new(),
-            threshold: 1,
-        });
+        // A full key set, so the failure is the threshold and not the count.
+        mapping.party_signing_keys = Some(signing_keys(2, 1));
         assert!(expectations.check_p2p_thresholds(&mapping).is_err());
         Ok(())
     }
@@ -1316,11 +1328,62 @@ mod tests {
         let (a, b) = (canton_id("p1", 1)?, canton_id("p2", 2)?);
         let expectations = expectations(vec![a.clone(), b.clone()], a.clone());
         let mut mapping = p2p("dec::x", &[a, b], 2);
-        mapping.party_signing_keys = Some(SigningKeysWithThreshold {
-            keys: Vec::new(),
-            threshold: 2,
-        });
+        mapping.party_signing_keys = Some(signing_keys(2, 2));
         expectations.check_p2p_thresholds(&mapping)
+    }
+
+    /// The bug in #428: kick dropped the departing member from
+    /// `participants` but carried `party_signing_keys` over verbatim, leaving
+    /// its Daml key still counting towards the party's signing threshold. A
+    /// peer cannot tell whose key is whose — the mapping records no owner per
+    /// key — but one key too many for the member set is exactly what that
+    /// mistake looks like from here.
+    #[test]
+    fn rejects_a_surplus_party_signing_key() -> Result {
+        let (a, b) = (canton_id("p1", 1)?, canton_id("p2", 2)?);
+        let expectations = expectations(vec![a.clone(), b.clone()], a.clone());
+        let mut mapping = p2p("dec::x", &[a, b], 2);
+        // Two remaining members, three keys — the kicked member's is still in.
+        mapping.party_signing_keys = Some(signing_keys(3, 2));
+
+        let error = expectations
+            .check_p2p_thresholds(&mapping)
+            .err()
+            .map(|e| e.to_string())
+            .unwrap_or_default();
+        assert!(
+            error.contains("3 party signing key(s) for 2 member(s)"),
+            "unexpected error: {error}"
+        );
+        Ok(())
+    }
+
+    /// The other half of #428: the operator asked for 2, the coordinator moved
+    /// the hosting threshold and left the signing one at 3, and the refusal
+    /// said only "proposed threshold 3 differs from the accepted 2" — which
+    /// reads as though the coordinator had ignored the operator's input. The
+    /// message has to say which of the two thresholds is wrong.
+    #[test]
+    fn names_the_signing_threshold_when_only_it_is_stale() -> Result {
+        let (a, b, c) = (
+            canton_id("p1", 1)?,
+            canton_id("p2", 2)?,
+            canton_id("p3", 3)?,
+        );
+        let expectations = expectations(vec![a.clone(), b.clone(), c.clone()], a.clone());
+        let mut mapping = p2p("dec::x", &[a, b, c], 2);
+        mapping.party_signing_keys = Some(signing_keys(3, 3));
+
+        let error = expectations
+            .check_p2p_thresholds(&mapping)
+            .err()
+            .map(|e| e.to_string())
+            .unwrap_or_default();
+        assert!(
+            error.contains("signing threshold 3 differs from the accepted 2"),
+            "unexpected error: {error}"
+        );
+        Ok(())
     }
 
     #[test]
@@ -1333,10 +1396,7 @@ mod tests {
         let mut mapping = p2p(&party.to_string(), &[a, b], 2);
         // Keep the mapping otherwise valid so the assertion below is about the
         // onboarding flag, not about an earlier check tripping first.
-        mapping.party_signing_keys = Some(SigningKeysWithThreshold {
-            keys: Vec::new(),
-            threshold: 2,
-        });
+        mapping.party_signing_keys = Some(signing_keys(2, 2));
         mapping.participants[1].onboarding = Some(hosting_participant::Onboarding::default());
         let payload = encode_proposal(topology_mapping::Mapping::PartyToParticipant(mapping));
 

--- a/crates/decman/tests/common/phases/change_threshold.rs
+++ b/crates/decman/tests/common/phases/change_threshold.rs
@@ -1,0 +1,176 @@
+use std::time::Duration;
+
+use anyhow::Context;
+use common::{
+    api::DecentralizedPartiesResponse,
+    types::{InvitationType, WorkflowKind, WorkflowProgress, WorkflowRole},
+};
+use serde_json::{Value, json};
+use tracing::info;
+
+use crate::common::{
+    Fixture,
+    http::{probe_workflow_run_visible, probe_workflow_status},
+    invitations::{InvitationIds, post_accept_invitation, probe_pending_invitation},
+    scenario::Scenario,
+};
+
+/// Change the party's threshold, then put it back.
+///
+/// Runs directly after `add_party`, so the party is known to hold P1 + P2 +
+/// P3 at threshold 2. It goes down to 1 and back to 2, which leaves the
+/// party exactly as the later phases expect to find it. Lowering first is
+/// deliberate: the round that restores 2 then only needs the single
+/// signature the lowered threshold asks for, so neither round depends on
+/// full-threshold authorization.
+///
+/// `PartyToParticipant` carries two thresholds — how many hosting
+/// participants must confirm, and how many of the party's signing keys
+/// authorize a transaction for it — and this workflow exists to move the
+/// threshold, so it has to move both. A run that moves only the hosting one
+/// leaves the signing threshold at its old value, and every peer refuses to
+/// sign a proposal whose threshold is not the one its operator accepted. The
+/// workflow then never completes, which is what #428 hit on devnet.
+pub async fn run(f: &mut Fixture) -> anyhow::Result<()> {
+    info!("Phase: change_threshold");
+
+    round("lower the threshold to 1", 2, 1).run(f).await?;
+    round("restore the threshold to 2", 1, 2).run(f).await?;
+    Ok(())
+}
+
+/// One threshold change, start to landed: post it, have both other members
+/// accept, and assert the party ends up on `to`.
+fn round(name: &'static str, from: i64, to: i64) -> Scenario<InvitationIds> {
+    Scenario::with_ctx(name, InvitationIds::default())
+        .given("party present with all three members", |f, _| {
+            Box::pin(async move {
+                f.party_id()?;
+                f.party_prefix()?;
+                Ok(())
+            })
+        })
+        .when("P1 posts /change-threshold", move |f, _| {
+            Box::pin(async move {
+                let req = json!({
+                    "decentralized_party_id": f.party_id()?.to_string(),
+                    "new_threshold": to,
+                    "previous_threshold": from,
+                });
+                let _: Value = f
+                    .post_json(f.p1.http, "/change-threshold", &req)
+                    .await
+                    .context("POST /change-threshold")?;
+                Ok(())
+            })
+        })
+        .then(
+            "ChangeThreshold invitation visible on P2",
+            Duration::from_secs(60),
+            |f, ctx| {
+                Box::pin(async move {
+                    let id =
+                        probe_pending_invitation(f, f.p2.http, InvitationType::ChangeThreshold)
+                            .await?;
+                    ctx.p2 = Some(id);
+                    Some(Ok(()))
+                })
+            },
+        )
+        .when("P2 accepts ChangeThreshold invitation", |f, ctx| {
+            Box::pin(async move {
+                let id = ctx
+                    .p2
+                    .as_deref()
+                    .context("P2 invitation id not set")?
+                    .to_string();
+                post_accept_invitation(f, f.p2.http, &id)
+                    .await
+                    .context("accept ChangeThreshold on P2")
+            })
+        })
+        .then(
+            "ChangeThreshold invitation visible on P3",
+            Duration::from_secs(60),
+            |f, ctx| {
+                Box::pin(async move {
+                    let id =
+                        probe_pending_invitation(f, f.p3.http, InvitationType::ChangeThreshold)
+                            .await?;
+                    ctx.p3 = Some(id);
+                    Some(Ok(()))
+                })
+            },
+        )
+        .when("P3 accepts ChangeThreshold invitation", |f, ctx| {
+            Box::pin(async move {
+                let id = ctx
+                    .p3
+                    .as_deref()
+                    .context("P3 invitation id not set")?
+                    .to_string();
+                post_accept_invitation(f, f.p3.http, &id)
+                    .await
+                    .context("accept ChangeThreshold on P3")
+            })
+        })
+        .then(
+            "change-threshold workflow reaches completed",
+            Duration::from_secs(240),
+            |f, _| {
+                Box::pin(async move {
+                    probe_workflow_status(
+                        &*f,
+                        f.p1.http,
+                        "/change-threshold/status",
+                        "change-threshold",
+                    )
+                    .await
+                })
+            },
+        )
+        .then(
+            "ChangeThreshold completed run visible in /workflows on P2 (Peer)",
+            Duration::from_secs(30),
+            |f, _| {
+                Box::pin(async move {
+                    probe_workflow_run_visible(
+                        f,
+                        f.p2.http,
+                        WorkflowKind::ChangeThreshold,
+                        WorkflowRole::Peer,
+                        WorkflowProgress::Completed,
+                    )
+                    .await
+                })
+            },
+        )
+        .then(
+            "the party's threshold is the new one",
+            Duration::from_secs(60),
+            move |f, _| {
+                Box::pin(async move {
+                    let prefix = match f.party_prefix() {
+                        Ok(v) => v.to_string(),
+                        Err(e) => return Some(Err(e)),
+                    };
+                    // `refresh=true` forces a fresh Canton fetch, so this
+                    // asserts the real topology rather than the up-to-60s
+                    // stale cache that would still carry the old threshold.
+                    let path = format!("/decentralized-parties?prefix={prefix}&refresh=true");
+                    let r: DecentralizedPartiesResponse =
+                        f.probe_get_json(f.p1.http, &path).await?;
+                    let party = r
+                        .parties
+                        .into_iter()
+                        .find(|p| p.party_id.prefix == prefix)?;
+                    // Retry until the topology change has propagated; a
+                    // threshold stuck on the old value surfaces as a timeout.
+                    if i64::from(party.threshold) != to {
+                        return None;
+                    }
+                    Some(Ok(()))
+                })
+            },
+        )
+}

--- a/crates/decman/tests/common/phases/mod.rs
+++ b/crates/decman/tests/common/phases/mod.rs
@@ -6,6 +6,7 @@ pub mod add_party_missing_dar;
 pub mod cancel_cascades;
 pub mod cancel_stuck_contracts;
 pub mod canton_admin_tls;
+pub mod change_threshold;
 pub mod check_peer_dars;
 pub mod concurrent_cross_workflows;
 pub mod concurrent_sibling_cancel;

--- a/crates/decman/tests/governance_workflows.rs
+++ b/crates/decman/tests/governance_workflows.rs
@@ -151,6 +151,9 @@ async fn governance_workflows_e2e() -> anyhow::Result<()> {
     // threshold signatures, topology growth, ACS sync, onboarding-flag
     // clearing) + the already-member and same-party 409 guards.
     phases::add_party::run(&mut f).await?;
+    // Threshold change on the restored 3-member party: down to 1 and back to
+    // 2, so later phases still find the party at threshold 2.
+    phases::change_threshold::run(&mut f).await?;
 
     // ----------------------------------------------------------------------
     // Negative-path / chaos tests. They mutate workflow_runs (cancel/dismiss)


### PR DESCRIPTION
Fixes #428.

Kick and change-threshold both re-issued `PartyToParticipant` with `party_signing_keys` carried over verbatim. Only the hosting threshold moved, and a kicked member kept its Daml key in the set, still counting towards the party's signing threshold.

Two commits, so the defects are visible in CI before the fix lands.

### 944b00df, tests only: CI red

```
Format, Clippy & Unit Tests   FAIL   538 passed; 2 failed   (fmt and clippy clean)
Integration Tests             FAIL   change_threshold timed out after 240s
```

`names_the_signing_threshold_when_only_it_is_stale` reported `proposed threshold 3 differs from the accepted 2`, the devnet message that reads as though the coordinator ignored the operator's input. `rejects_a_surplus_party_signing_key` reported nothing at all, because a kick that keeps the removed member's key raises no error today.

The new `change_threshold` integration phase is the devnet failure end to end. Every earlier phase passed, including kick and add-party, then the peers refused:

```
Refusing the coordinator's change-threshold proposals:
  proposed threshold 2 differs from the accepted 1
ChangeThreshold peer workflow ... failed: Aborting peer
```

There was no change-threshold phase in the suite before this, which is why nothing caught the defect.

### fead41d3, the fix: CI green

```
Format, Clippy & Unit Tests   PASS   546 passed; 0 failed
Integration Tests             PASS   change_threshold 16.1s + 18.1s
```

### How the key is attributed

Nothing on-chain says which member contributed which signing key. The protobuf records no owner, and the Daml key gets no `NamespaceDelegation`, so only the node that generated a key can say it is theirs.

Peers now report their own fingerprint over the existing OwnerKeys exchange, as a new JSON field so older peers stay compatible, cached in `dec_party_participant.signing_key` next to `owner_key`. Kick resolves the departing member's key from that cache, from the identity rows it holds, or by elimination: the key no remaining member claims. When it still cannot tell, the kick stops rather than leave the key in.

Two peer-side guards make a wrong attribution fail loudly instead of silently:

- a mapping carrying more signing keys than the party has members is refused
- `check_party_proposals` now also runs `check_own_daml_key`, so dropping the wrong key is caught by the member whose key went missing

The threshold refusal now names which of the two thresholds is stale.

### Note on scope

The confirmation and signing thresholds stay coupled, which is what `add_party` and `check_p2p_thresholds` already assume. Decoupling them is #234.
