### PR TITLE
Restore the SyncAcs payload on mismatch, not on absence

### DIFF
--- a/crates/decman/src/server/handlers/parties.rs
+++ b/crates/decman/src/server/handlers/parties.rs
@@ -1846,7 +1846,6 @@ async fn fetch_decentralized_parties(
     })
 }
 
-/// Get vetted packages for this participant
 /// Which participant is quarantined for which party.
 #[derive(Debug, serde::Deserialize, utoipa::IntoParams)]
 pub struct QuarantineQuery {
@@ -1913,6 +1912,7 @@ pub async fn clear_acs_import_quarantine(
         (status = 500, description = "Internal server error", body = ErrorResponse)
     )
 )]
+/// Get vetted packages for this participant
 #[get("/packages/vetted")]
 pub async fn get_vetted_packages(data: web::Data<AppState>) -> impl Responder {
     // Reads topology vetting state. Neither list contains the other: a DAR can

--- a/crates/decman/src/workflow/add_party/coordinator.rs
+++ b/crates/decman/src/workflow/add_party/coordinator.rs
@@ -109,14 +109,20 @@ async fn run_workflow(
                 // coordinator cannot rebuild live here: the command payload,
                 // which is restored from its artifact, and the Canton export
                 // stream, which has to be re-opened.
-                if workflow_state.get_command_payload().await.is_empty()
-                    && let Some(saved) = db
-                        .read_artifact(
-                            &instance_name,
-                            artifact_kinds::ADD_PARTY_SYNC_ACS_COMMAND,
-                            None,
-                        )
-                        .await?
+                // Restored on mismatch, NOT merely when empty: `run_workflow`
+                // seeds the payload with the bare config before this loop
+                // starts, so after a restart it is non-empty but wrong. The
+                // target decodes the SyncAcs command as two length-prefixed
+                // items and reads the config's leading `{"de` as a 2 GB length
+                // prefix, failing every attempt until it aborts.
+                if let Some(saved) = db
+                    .read_artifact(
+                        &instance_name,
+                        artifact_kinds::ADD_PARTY_SYNC_ACS_COMMAND,
+                        None,
+                    )
+                    .await?
+                    && workflow_state.get_command_payload().await != saved
                 {
                     tracing::info!(
                         "Restored the SyncAcs command payload after a restart ({len} bytes)",

--- a/crates/decman/src/workflow/add_party/mod.rs
+++ b/crates/decman/src/workflow/add_party/mod.rs
@@ -199,6 +199,44 @@ impl WorkflowStep for AddPartyStep {
 mod tests {
     use super::*;
 
+    /// A resumed coordinator seeds `command_payload` with the bare config
+    /// before its loop starts, so "is the payload missing?" is the wrong
+    /// question at `SyncAcs` — it is present and wrong. The target decodes
+    /// that command as two length-prefixed items, so the config's leading
+    /// bytes are read as a length: `{"de` is 0x7B226465, i.e. a 2 GB prefix on
+    /// a 365-byte payload, and every attempt fails until the peer aborts.
+    ///
+    /// This pins the shape that made the bug invisible: the bare config and a
+    /// real SyncAcs payload are both non-empty, so only comparing them tells
+    /// the two apart.
+    #[test]
+    fn a_bare_config_payload_is_not_a_valid_sync_acs_command() -> anyhow::Result<()> {
+        use crate::utils;
+
+        let config = serde_json::to_vec(&serde_json::json!({
+            "decentralized_party_id": "p::1220aa",
+            "new_participant_id": "q::1220bb",
+        }))?;
+        let package_ids = b"pkg-a\npkg-b".to_vec();
+        let sync_acs = utils::encode_length_prefixed(&[&config, &package_ids]);
+
+        // What a resumed coordinator serves without the restore.
+        assert!(!config.is_empty(), "an emptiness check cannot catch this");
+        assert!(
+            utils::decode_length_prefixed(&config, 2).is_err(),
+            "the bare config must not decode as a SyncAcs command"
+        );
+
+        // What it must serve instead.
+        let items = utils::decode_length_prefixed(&sync_acs, 2)?;
+        assert_eq!(items[0], config);
+        assert_eq!(items[1], package_ids);
+
+        // The two differ, which is what the restore now keys on.
+        assert_ne!(config, sync_acs);
+        Ok(())
+    }
+
     /// Every variant must round-trip through its persisted step name — a
     /// mismatch would break resume-after-restart for runs stopped on that
     /// step.

--- a/crates/decman/src/workflow/storage.rs
+++ b/crates/decman/src/workflow/storage.rs
@@ -115,9 +115,12 @@ pub mod artifact_kinds {
     /// target's preflight needs). The ACS itself is not in it: the target pulls
     /// the snapshot block by block straight into Canton's import.
     ///
-    /// Persisted because the coordinator only holds it in memory, and a restart
-    /// during the transfer would otherwise serve the target an empty payload it
-    /// cannot decode.
+    /// Persisted because the coordinator only holds it in memory. A resumed run
+    /// does not arrive with an *empty* payload — `run_workflow` seeds one with
+    /// the bare config before its loop starts — it arrives with the wrong one,
+    /// which the target decodes as a two-item command and rejects. So the
+    /// restore compares against what is currently served rather than testing
+    /// for absence.
     pub const ADD_PARTY_SYNC_ACS_COMMAND: &str = "add_party_sync_acs_command";
 
     /// Unsigned onboarding-flag clearing proposal (P2P update without the


### PR DESCRIPTION
The coordinator-restart restore added in #408 never fires. Found on devnet resuming a real ACS transfer.

## What happens

A resumed coordinator reaching `SyncAcs` serves the target the bare add-party config instead of the two-item SyncAcs command. The target decodes that command as two length-prefixed items, so it reads the config's leading `{"de` as a length prefix:

```
Failed to decode ImportAcs payload: Invalid payload: expected 2065851493 bytes
at offset 4, but only 361 remaining (item 0/2)
```

`2065851493` is `0x7B226465`, a 2 GB prefix on a 365-byte payload. Six attempts, then the peer aborts and the run is dead.

## Why the guard was wrong

`run_workflow` seeds `command_payload` with the bare config before its loop starts, so `GenerateAddPartyKeys` has something to carry. By the time a resumed run reaches `SyncAcs` the payload is therefore present and wrong, and the restore was gated on `is_empty()`.

Emptiness cannot be the discriminator here: the bare config and a real SyncAcs command are both non-empty. The restore now compares against what is currently served and replaces it on mismatch. Comparing also keeps the once-per-second step loop from re-setting the same bytes every tick.

## What this fixes in practice

The other two halves of the restart path already worked, verified on devnet at 13:37 UTC:

```
Recovering 1 in-progress workflow run(s) interrupted by last shutdown
Resuming AddParty coordinator run ... at step SyncAcs (2 of 3 peers completed)
No ACS export is open — re-opening it; the transfer restarts from the beginning
```

The run resumed and the Canton export stream was re-opened. Only the payload was wrong, so the target could never decode the command it was handed. With this, a coordinator restart mid-transfer is survivable end to end rather than two thirds of the way.

## Test

Pins the shape rather than the plumbing: a bare config is non-empty AND fails to decode as a two-item command, so no emptiness check can tell the two apart. Anyone reintroducing an `is_empty()` guard fails the test.

## Not covered

No integration phase restarts a coordinator mid-run, which is why #408 shipped with this. Worth adding, but it needs the harness to kill and revive a node inside a workflow, so it is its own change.
