### PR TITLE
Pin tokio-noise to the patched fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6007,8 +6007,7 @@ dependencies = [
 [[package]]
 name = "tokio-noise"
 version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d8a83b874e553ca5c1a0f9340ee67ccb131813d9fe9c074d9a28e6322cf7ff9"
+source = "git+https://github.com/DLC-link/tokio-noise?rev=79d706d648fccd5bb8457f15a31d49593430d657#79d706d648fccd5bb8457f15a31d49593430d657"
 dependencies = [
  "log",
  "snow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,9 @@ decman-lib = { path = "crates/decman-lib" }
 decman-wallet = { path = "crates/decman-wallet" }
 keycloak = { git = "https://github.com/DLC-link/canton-lib", rev = "651ea5221b4794f55bd152e9f3e762a92af69afd" }
 
+[patch.crates-io]
+tokio-noise = { git = "https://github.com/DLC-link/tokio-noise", rev = "79d706d648fccd5bb8457f15a31d49593430d657" }
+
 [profile.release]
 opt-level = 3
 strip = "debuginfo"


### PR DESCRIPTION
tokio-noise 0.0.5 replays bytes on the read path.

`poll_read` parks a decrypted packet in `read_overflow_buf` when it does not fit the caller's buffer, then serves it back on a later poll. That path returns as soon as the caller's buffer is full, which is before `drop_front_items` runs, so the bytes stay queued and go out again on the next poll.

Reading 8192 bytes in 100-byte chunks, bytes 200..299 come back as a copy of bytes 100..199.

## Why it hit the ACS pipe so hard

A Noise packet carries 2030 plaintext bytes, so a 1 MiB block is about 517 packets and a 4 MiB block about 2067. Every packet is a chance for the caller's buffer to end on the overflow boundary. Small messages almost never do, a multi-MB body does it constantly.

The duplicates desync HTTP framing, so hyper reports `end of file before message length reached`. That reads like a flaky peer, not corruption. Measured on devnet: about 16% of block fetches at 1 MiB and 30% at 4 MiB. A retry on a fresh connection re-rolls the buffer alignment, which is why most blocks recovered on the second attempt. One block exhausted all three and took the whole sync down with it.

This is not specific to party replication. Any Noise response large enough to overflow a read buffer can be corrupted.

`Connection: close` from #242 fixed a write-side strand and could not help here.

## What is in this PR

Only the pin. `[patch.crates-io]` covers the whole graph, so `hyper-noise` picks it up too:

```
tokio-noise v0.0.5 (https://github.com/DLC-link/tokio-noise?rev=79d706d6)
├── decman v1.7.0
└── hyper-noise v0.0.3
    └── decman v1.7.0
```

The fix itself is one reorder, in DLC-link/tokio-noise@79d706d6, with a regression test. Upstream PR is conduition/tokio-noise#4. The fork is pinned by rev and should be dropped once that lands and a release follows.

The existing `send_and_recv_large` could not catch this because its payload is uniformly 0xFF, so a replayed window compares equal. The new test uses position-dependent bytes and small reads, and fails on the old order with

```
stream corrupted at byte 200: expected [200, 201, 202, 203, ...], got [100, 101, 102, 103, ...]
```

Raising the ACS retry budget was the tempting fix and would have been wrong. It hides silent corruption, and a 1 TB ACS is on the order of a million packets.