### PR TITLE
chore(decman): bump version to 1.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1810,7 +1810,7 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "decman"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "actix-cors",
  "actix-web",

--- a/crates/decman/Cargo.toml
+++ b/crates/decman/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "decman"
-version = "1.7.0"
+version = "1.8.0"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
Bumps `crates/decman/Cargo.toml` to 1.8.0 ahead of the v1.8.0 tag. The release workflow's `verify-tag` job compares the tag against this version, so the bump has to land on main before the tag is pushed.

Minor, not patch: the 18 commits since v1.7.0 add features — add hosts to an existing external party (#379), the add-party ACS export/import pipe (#408), and the signing-threshold move (#429).